### PR TITLE
Pedantic documentation fixes

### DIFF
--- a/doc/output_examples/frontend/basic_formats.md
+++ b/doc/output_examples/frontend/basic_formats.md
@@ -1,13 +1,13 @@
 
-## Needed things:
+## Needed things
 
-### Controller:
+### Controller
 
 * Format
 
 ### View
 
-* API url
+* API URL
 * Breadcrumb section links
 * Title
 * Body (HTML)
@@ -18,10 +18,10 @@
 
 ## Deprecated fields to be removed
 
-* business_proposition - If this is still needed it should be implemented as a tag
-* need_extended_font - was for a feature that was never fully implemented.
-* alternative_title - The only place this is used is in submitting content to rummager - it's added to indexable_content.
-  This will be the concern of the publishing tools in future - they'll construct indexable_content themselves.
+* `business_proposition` - If this is still needed it should be implemented as a tag.
+* `need_extended_font` - This was for a feature that was never fully implemented.
+* `alternative_title` - The only place this is used is in submitting content to rummager - it's added to `indexable_content`.
+  This will be the concern of the publishing tools in future - they'll construct `indexable_content` themselves.
 
 ## Things to be provided
 

--- a/doc/output_examples/frontend/find_my_nearest.md
+++ b/doc/output_examples/frontend/find_my_nearest.md
@@ -1,15 +1,15 @@
 
-## Needed things:
+## Needed things
 
-### Controller:
+### Controller
 
 * Format
 
 ### View
 
-Everything from basic_formats plus:
+Everything from basic formats plus:
 
-* place_type - slug of data set in Imminence
+* `place_type` - slug of data set in Imminence
 
 ## Notes
 

--- a/doc/output_examples/frontend/licence.md
+++ b/doc/output_examples/frontend/licence.md
@@ -1,15 +1,15 @@
 
-## Needed things:
+## Needed things
 
-### Controller:
+### Controller
 
 * Format
 
 ### View
 
-Everything from basic_formats plus:
+Everything from basic formats plus:
 
-* licence_identifier
+* `licence_identifier`
 
 ## Notes
 

--- a/doc/output_examples/frontend/local_transaction.md
+++ b/doc/output_examples/frontend/local_transaction.md
@@ -1,16 +1,16 @@
 
-## Needed things:
+## Needed things
 
-### Controller:
+### Controller
 
 * Format
 
 ### View
 
-Everything from basic_formats plus:
+Everything from basic formats plus:
 
-* lgsl_code
-* lgil_override - (optional)
+* `lgsl_code`
+* `lgil_override` - (optional)
 
 ## Details
 

--- a/doc/output_examples/frontend/travel-advice-country.md
+++ b/doc/output_examples/frontend/travel-advice-country.md
@@ -6,8 +6,8 @@
 * Breadcrumb
 * Country name
 * Parts
-* updated_at
-* reviewed_at
-* change_description
+* `updated_at`
+* `reviewed_at`
+* `change_description`
 * image details
 * document details

--- a/doc/output_examples/frontend/travel-advice-index.md
+++ b/doc/output_examples/frontend/travel-advice-index.md
@@ -1,8 +1,8 @@
 
-## Needed things:
+## Needed things
 
 ### View
 
 * countries
-** updated_at
-** synonyms
+* `updated_at`
+* synonyms

--- a/doc/output_examples/routing.md
+++ b/doc/output_examples/routing.md
@@ -1,5 +1,5 @@
 
-## Routes for content:
+## Routes for content
 
 Within the app, the details for an item of content will live at:
 
@@ -10,9 +10,9 @@ eg
     https://content-store.production.alphagov.co.uk/content/vat-rates
     https://content-store.production.alphagov.co.uk/content/government/organisations/cabinet-office
 
-We could have an optional .json suffix.
+We could have an optional `.json` suffix.
 
-## Public API endpoint.
+## Public API endpoint
 
 This would end up being surfaced to the public at:
 


### PR DESCRIPTION
- Remove trailing punctuation from headings
- Quote field names as code
- Fix capitalisation on 'URL'
- Make capitalisation and punctuation consistent within lists
