### PR TITLE
Disable action_mailer and active_resource

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -3,8 +3,8 @@ require File.expand_path('../boot', __FILE__)
 # Pick the frameworks you want:
 # require "active_record/railtie"
 require "action_controller/railtie"
-require "action_mailer/railtie"
-require "active_resource/railtie"
+# require "action_mailer/railtie"
+# require "active_resource/railtie"
 # require "sprockets/railtie"
 # require "rails/test_unit/railtie"
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,7 +14,7 @@ ContentStore::Application.configure do
   config.action_controller.perform_caching = false
 
   # Don't care if the mailer can't send
-  config.action_mailer.raise_delivery_errors = false
+  #config.action_mailer.raise_delivery_errors = false
 
   # Print deprecation notices to the Rails logger
   config.active_support.deprecation = :log

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -27,7 +27,7 @@ ContentStore::Application.configure do
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
-  config.action_mailer.delivery_method = :test
+  #config.action_mailer.delivery_method = :test
 
 
   # Print deprecation notices to the stderr


### PR DESCRIPTION
They're not used, so there's no need to load them.
