### PR TITLE
Assert on numeric status code values in tests.

### DIFF
--- a/spec/requests/fetching_content_item_spec.rb
+++ b/spec/requests/fetching_content_item_spec.rb
@@ -15,7 +15,7 @@ describe "Fetching a content item" do
 
     get "/content/vat-rates"
 
-    expect(response).to be_success
+    expect(response.status).to eq(200)
     expect(response.content_type).to eq("application/json")
 
     data = JSON.parse(response.body)
@@ -34,6 +34,6 @@ describe "Fetching a content item" do
 
   it "should 404 for a non-existent item" do
     get "/content/non-existent"
-    expect(response).to be_missing
+    expect(response.status).to eq(404)
   end
 end

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -5,7 +5,7 @@ describe "healthcheck path" do
   it "should respond with 'OK'" do
     get "/healthcheck"
 
-    expect(response).to be_success
+    expect(response.status).to eq(200)
     expect(response.body).to eq("OK")
   end
 end


### PR DESCRIPTION
This makes it clearer, as we all know that the HTTP status codes mean.
