### PR TITLE
Add a feature-flag for route registration.

### DIFF
--- a/app/models/registerable_route_set.rb
+++ b/app/models/registerable_route_set.rb
@@ -24,9 +24,11 @@ class RegisterableRouteSet < Struct.new(:registerable_routes, :base_path, :rende
   end
 
   def register!
-    register_backend
-    registerable_routes.each { |route| register_route(route) }
-    commit_routes
+    if ENABLE_ROUTE_REGISTRATION
+      register_backend
+      registerable_routes.each { |route| register_route(route) }
+      commit_routes
+    end
   end
 
 private

--- a/config/initializers/enable_route_registration.rb
+++ b/config/initializers/enable_route_registration.rb
@@ -1,0 +1,2 @@
+# This file potentially overwritten on deploy
+ENABLE_ROUTE_REGISTRATION = Rails.env.development? || Rails.env.test?


### PR DESCRIPTION
This will enable us to deploy content-store all the way to production
without having to switch the routes until we're ready.
