### PR TITLE
Revert "Add a feature-flag for route registration."

### DIFF
--- a/app/models/registerable_route_set.rb
+++ b/app/models/registerable_route_set.rb
@@ -24,11 +24,9 @@ class RegisterableRouteSet < Struct.new(:registerable_routes, :base_path, :rende
   end
 
   def register!
-    if ENABLE_ROUTE_REGISTRATION
-      register_backend
-      registerable_routes.each { |route| register_route(route) }
-      commit_routes
-    end
+    register_backend
+    registerable_routes.each { |route| register_route(route) }
+    commit_routes
   end
 
 private

--- a/config/initializers/enable_route_registration.rb
+++ b/config/initializers/enable_route_registration.rb
@@ -1,2 +1,0 @@
-# This file potentially overwritten on deploy
-ENABLE_ROUTE_REGISTRATION = Rails.env.development? || Rails.env.test?


### PR DESCRIPTION
This reverts commit b760e76d9ecd398d42c13032f4e5bcbb1c655a6c.

This is now being enabled everywhere, so the feature flag is no longer
needed.
