### PR TITLE
Fix setting of updated_at field.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ group :development, :test do
   gem 'database_cleaner', '1.2.0'
   gem 'factory_girl', '4.4.0'
   gem 'webmock', '~> 1.18.0', :require => false
+  gem 'timecop', '0.7.1'
 
   gem 'simplecov', '0.8.2', :require => false
   gem 'simplecov-rcov', '0.2.3', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,7 @@ GEM
       tilt (~> 1.1, != 1.3.0)
     thor (0.19.1)
     tilt (1.4.1)
+    timecop (0.7.1)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
@@ -164,5 +165,6 @@ DEPENDENCIES
   rspec-rails (= 2.14.2)
   simplecov (= 0.8.2)
   simplecov-rcov (= 0.2.3)
+  timecop (= 0.7.1)
   unicorn (= 4.8.2)
   webmock (~> 1.18.0)

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -23,6 +23,9 @@ class ContentItem
   before_save :register_routes
   before_upsert :register_routes
 
+  # The updated_at field isn't set on upsert - https://github.com/mongoid/mongoid/issues/3716
+  before_upsert :set_updated_at
+
   def as_json(options = nil)
     super(options).slice(*PUBLIC_ATTRIBUTES).tap do |hash|
       hash["base_path"] = self.base_path

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -59,6 +59,16 @@ describe ContentItem do
     end
   end
 
+  it "should set updated_at on upsert" do
+    item = build(:content_item)
+    Timecop.freeze do
+      item.upsert
+      item.reload
+
+      expect(item.updated_at.to_s).to eq(Time.zone.now.to_s)
+    end
+  end
+
   describe "registering routes" do
     before do
       routes = [

--- a/spec/requests/submiting_content_item_spec.rb
+++ b/spec/requests/submiting_content_item_spec.rb
@@ -36,6 +36,7 @@ describe "content item write API" do
       expect(item.format).to eq("answer")
       expect(item.need_ids).to eq(["100123", "100124"])
       expect(item.public_updated_at).to eq(Time.zone.parse("2014-05-14T13:00:06Z"))
+      expect(item.updated_at).to be_within(10.seconds).of(Time.zone.now)
       expect(item.details).to eq({"body" => "<p>Some body text</p>\n"})
     end
 
@@ -53,12 +54,14 @@ describe "content item write API" do
 
   context 'updating an existing content item' do
     before(:each) do
-      @item = create(:content_item,
+      Timecop.travel(30.minutes.ago) do
+        @item = create(:content_item,
                      :base_path => "/vat-rates",
                      :need_ids => ["100321"],
                      :public_updated_at => Time.zone.parse("2014-03-12T14:53:54Z"),
                      :details => {"foo" => "bar"}
                     )
+      end
       WebMock::RequestRegistry.instance.reset! # Clear out any requests made by factory creation.
       put_json "/content/vat-rates", @data
     end
@@ -72,6 +75,7 @@ describe "content item write API" do
       expect(@item.title).to eq("VAT rates")
       expect(@item.need_ids).to eq(["100123", "100124"])
       expect(@item.public_updated_at).to eq(Time.zone.parse("2014-05-14T13:00:06Z"))
+      expect(@item.updated_at).to be_within(10.seconds).of(Time.zone.now)
       expect(@item.details).to eq({"body" => "<p>Some body text</p>\n"})
     end
 

--- a/spec/support/timecop.rb
+++ b/spec/support/timecop.rb
@@ -1,0 +1,4 @@
+
+RSpec.configuration.after :each do
+  Timecop.return
+end


### PR DESCRIPTION
This wasn't being set because the `Mongoid::Timestamps` module doesn't
create the necessary `before_upsert` hooks.  Manually adding this
callback fixes this issue.  I've also added an integration level test to
ensure this doesn't fail again in future.

See https://github.com/mongoid/mongoid/issues/3716 for the bug report
against mongoid
