### PR TITLE
Add cache-control and expires header in reponse

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,4 +7,13 @@ class ApplicationController < ActionController::API
   def error_404
     head :not_found
   end
+
+  def expires_at(expiration_time)
+    response.headers['Cache-Control'] = config.cache_control_directive
+    response.headers['Expires'] = expiration_time.httpdate
+  end
+
+  def config
+    @config ||= ContentStore::Application.config
+  end
 end

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -3,6 +3,7 @@ class ContentItemsController < ApplicationController
 
   def show
     item = ContentItem.find_by(:base_path => params[:base_path])
+    expires_at config.default_ttl.from_now
     render :json => item
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -66,6 +66,10 @@ module ContentStore
     # Disable Rack::Cache
     config.action_dispatch.rack_cache = nil
 
+    # Caching
+    config.cache_control_directive = 'public'
+    config.default_ttl = 30.minutes
+
     def router_api
       @router_api ||= GdsApi::Router.new(Plek.current.find('router-api'))
     end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -22,5 +22,7 @@ ContentStore::Application.configure do
   # Only use best-standards-support built into browsers
   config.action_dispatch.best_standards_support = :builtin
 
+  # Caching
+  config.cache_control_directive = 'no-cache'
 
 end

--- a/spec/requests/fetching_content_item_spec.rb
+++ b/spec/requests/fetching_content_item_spec.rb
@@ -2,39 +2,55 @@ require 'spec_helper'
 
 describe "Fetching a content item" do
 
-  it "should return details for the requested item" do
-    item = create(:content_item,
-                 :base_path => "/vat-rates",
-                 :title => "VAT rates",
-                 :description => "Current VAT rates",
-                 :format => "answer",
-                 :need_ids => ["100136"],
-                 :public_updated_at => 30.minutes.ago,
-                 :details => {"body" => "<div class=\"highlight-answer\">\n<p>The standard <abbr title=\"Value Added Tax\">VAT</abbr> rate is <em>20%</em></p>\n</div>\n"}
-                 )
+  context "valid request" do
+    let!(:item) {
+      create(:content_item,
+       :base_path => "/vat-rates",
+       :title => "VAT rates",
+       :description => "Current VAT rates",
+       :format => "answer",
+       :need_ids => ["100136"],
+       :public_updated_at => 30.minutes.ago,
+       :details => {"body" => "<div class=\"highlight-answer\">\n<p>The standard <abbr title=\"Value Added Tax\">VAT</abbr> rate is <em>20%</em></p>\n</div>\n"})
+    }
 
-    get "/content/vat-rates"
+    it "should return details for the requested item" do
+      get "/content/vat-rates"
 
-    expect(response.status).to eq(200)
-    expect(response.content_type).to eq("application/json")
+      expect(response.status).to eq(200)
+      expect(response.content_type).to eq("application/json")
 
-    data = JSON.parse(response.body)
+      data = JSON.parse(response.body)
 
-    expect(data['base_path']).to eq('/vat-rates')
-    expect(data['title']).to eq("VAT rates")
-    expect(data['description']).to eq("Current VAT rates")
-    expect(data['format']).to eq("answer")
-    expect(data['need_ids']).to eq(["100136"])
-    expect(data['updated_at']).to eq(item.updated_at.iso8601)
-    expect(data['public_updated_at']).to eq(item.public_updated_at.iso8601)
-    expect(data['details']).to eq({"body" => "<div class=\"highlight-answer\">\n<p>The standard <abbr title=\"Value Added Tax\">VAT</abbr> rate is <em>20%</em></p>\n</div>\n"})
+      expect(data['base_path']).to eq('/vat-rates')
+      expect(data['title']).to eq("VAT rates")
+      expect(data['description']).to eq("Current VAT rates")
+      expect(data['format']).to eq("answer")
+      expect(data['need_ids']).to eq(["100136"])
+      expect(data['updated_at']).to eq(item.updated_at.iso8601)
+      expect(data['public_updated_at']).to eq(item.public_updated_at.iso8601)
+      expect(data['details']).to eq({"body" => "<div class=\"highlight-answer\">\n<p>The standard <abbr title=\"Value Added Tax\">VAT</abbr> rate is <em>20%</em></p>\n</div>\n"})
 
-    expected_keys = ContentItem::PUBLIC_ATTRIBUTES
-    expect(data.keys - expected_keys).to eq([])
+      expected_keys = ContentItem::PUBLIC_ATTRIBUTES
+      expect(data.keys - expected_keys).to eq([])
+    end
+
+    it "should set a 30 minutes Expires header in response" do
+      Timecop.freeze do
+        get "/content/vat-rates"
+        expect(response.headers["Expires"]).to eq(30.minutes.from_now.httpdate)
+      end
+    end
+
+    it "should set a cache-control header with value public" do
+      get "/content/vat-rates"
+      expect(response.headers["Cache-Control"]).to eq('public')
+    end
   end
 
   it "should 404 for a non-existent item" do
     get "/content/non-existent"
     expect(response.status).to eq(404)
   end
+
 end


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/4800

Cache-Control public allow intermediaries to cache
content. Expires is preferred over max-age or else
we would have to reduce the max-age as we approach
scheduled publishing time of an upcoming edition.

related links:

www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.1
www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.21
