### PR TITLE
Explain intent of update_types

### DIFF
--- a/doc/input_examples/generic.json
+++ b/doc/input_examples/generic.json
@@ -9,7 +9,14 @@
   "redirects": [
     {"path": "/base-path/obsolete-path", "type": "exact"}
   ],
-  // one of 'major', 'minor', 'republish'.
+  // One of:
+  //  'major' - major changes to a piece of content.
+  //  'minor' - changes which don't affect the meaning of the content, eg typo
+  //            correction.
+  //  'republish' - useful in situations such as when the data structure has
+  //                changed. Might also be used for content being migrated to
+  //                GOV.UK.
+  //
   // Others can be added in future, content-store will just pass them through to the fanout.
   "update_type": "republish"
 }


### PR DESCRIPTION
We think we will allow HMRC to set the update type when they publish a new manual/manual section. If we are going to do that, we need to be able to document what the values are for, so it makes sense to clarify what the values are intended for within content-store.
