### PR TITLE
Add publishing_app field to ContentItem.

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -9,6 +9,7 @@ class ContentItem
   field :need_ids, :type => Array, :default => []
   field :public_updated_at, :type => DateTime
   field :details, :type => Hash, :default => {}
+  field :publishing_app, :type => String
   field :rendering_app, :type => String
   field :routes, :type => Array, :default => []
   field :redirects, :type => Array, :default => []


### PR DESCRIPTION
Without this, it's not possible to submit JSON including this field,
even though it's included in the documentation.  Validations around this
can be added later when it's actually used.
