### PR TITLE
Recover from closed Bunny connection

### DIFF
--- a/config/rabbitmq.yml
+++ b/config/rabbitmq.yml
@@ -4,6 +4,7 @@ defaults: &defaults
   vhost: /
   user: content_store
   pass: content_store
+  recover_from_connection_close: true
 
 development:
   <<: *defaults


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/5649

We initialise Bunny in a rails initialiser. If RabbitMQ
is restarted, the Bunny connection breaks, and the app
throws errors while communicating with RabbitMQ.

Bunny can be instructed to recover from a server-sent
connection.close using `recover_from_connection_close`
option passed to Bunny.new.

This makes it impossible to force client to disconnect,
but it seems unlikely that we'd want to do that.

Bunny docs on Automatic recovery:
http://rubybunny.info/articles/error_handling.html#automatic_recovery
