### PR TITLE
Remove url-arbiter feature flag.

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -29,8 +29,6 @@ class ContentItemsController < ApplicationController
   end
 
   def register_with_url_arbiter
-    return unless ENABLE_URL_ARBITER
-
     Rails.application.url_arbiter_api.reserve_path(params["base_path"], "publishing_app" => @request_data["publishing_app"])
   rescue GOVUK::Client::Errors::Conflict => e
     return_arbiter_error(:conflict, e)

--- a/config/initializers/url_arbiter_feature_flag.rb
+++ b/config/initializers/url_arbiter_feature_flag.rb
@@ -1,3 +1,0 @@
-# This file potentially overwritten on deploy
-
-ENABLE_URL_ARBITER = Rails.env.development? || Rails.env.test?


### PR DESCRIPTION
This is now to be enabled everywhere, so the flag is unnecessary.
