### PR TITLE
Refer to this app consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
-# Content Store
+# The content store
 
 The central storage of *published* content on GOV.UK.
 
-Content Store maps public-facing URLs to published items of content, represented
+The content store maps public-facing URLs to published items of content, represented
 as JSON data. It will replace [content API](https://github.com/alphagov/govuk_content_api)
 in time.
 
-Publishing applications add content to Content Store; public-facing
-applications read content from Content Store and render them on GOV.UK.
+Publishing applications add content to the content store; public-facing
+applications read content from the content store and render them on GOV.UK.
 
 ## Content items
 
-`ContentItem` is the base unit of content in Content Store. They have both a
+`ContentItem` is the base unit of content in the content store. They have both a
 private and public-facing JSON representation. More details on these
 representations and the meanings of the individual fields can be found in
 [doc/content_item_fields.md](doc/content_item_fields.md).
 
-## Writing content items to Content Store
+## Writing content items to the content store
 
 Publishing applications will "publish" content on GOV.UK by sending them to
-Content Store. To add or update a piece of content in Content Store, make a PUT
+the content store. To add or update a piece of content in the content store, make a PUT
 request:
 
 ``` sh
@@ -37,9 +37,9 @@ in [gds-api-adapters](https://github.com/alphagov/gds-api-adapters) for writing
 content to content-store, although it is likely that this will soon be extracted
 to a separate gem.
 
-## Reading content from Content Store
+## Reading content from the content store
 
-To retrieve content from Content Store, make a GET request:
+To retrieve content from the content store, make a GET request:
 
 ``` sh
   curl https://content-store.production.alphagov.co.uk/content<base_path>

--- a/doc/content_item_fields.md
+++ b/doc/content_item_fields.md
@@ -116,7 +116,7 @@ For example:
 
 The keys identify the type of related content, which may or may not match a
 format type. The value is a list of associated items, the order of which may be
-significant; content store preserves the order.
+significant; the content store preserves the order.
 
 In the `storing` context, the items are UUID strings.
 
@@ -191,5 +191,5 @@ It must be one of:
  - 'republish' - useful in situations such as when the data
    structure has changed.
 
-Other types may be added in future, content-store will just pass them through
+Other types may be added in future, the content store will just pass them through
 to the fanout.

--- a/doc/gone_item.md
+++ b/doc/gone_item.md
@@ -1,6 +1,6 @@
 ## Gone items
 
-To represent content that is no longer available, the content-store will support items with a format
+To represent content that is no longer available, the content store will support items with a format
 of "gone".  These will cause a gone route to be setup in the router so that the item returns a 410
 HTTP status.
 

--- a/doc/placeholder_item.md
+++ b/doc/placeholder_item.md
@@ -1,12 +1,12 @@
 ## Placeholder items
 
-Items not yet being served from content-store, but that need to be linked to and
-referenced from other content items in content-store.
+Items not yet being served from the content store, but that need to be linked to and
+referenced from other content items in the content store.
 
-During the transition to using content-store as the source of published content
+During the transition to using the content store as the source of published content
 on GOV.UK, there may be a need to link to content that isn't yet being served
-directly from the content-store. In such cases, the content that needs to be
-linked to can be added to content-store with a format of "placeholder".
+directly from the content store. In such cases, the content that needs to be
+linked to can be added to the content store with a format of "placeholder".
 "placeholder" content will be expanded out when linked to in the `links` field
-of a content item, and can also be retrieved from content-store, but will not
+of a content item, and can also be retrieved from the content store, but will not
 have its routes registered or updated.

--- a/doc/redirect_item.md
+++ b/doc/redirect_item.md
@@ -1,6 +1,6 @@
 ## Redirect items
 
-To represent content that can be found under a different `base_path`, the content-store will support
+To represent content that can be found under a different `base_path`, the content store will support
 items with a format of "redirect".  These items have slightly different validation rules:
 
 * They must include a redirect for the `base_path` in their redirects array.

--- a/doc/route_registration.md
+++ b/doc/route_registration.md
@@ -1,6 +1,6 @@
 ## Registering routes with the router.
 
-After saving an item, the content-store will register routes with the router.  All items listed in the
+After saving an item, the content store will register routes with the router.  All items listed in the
 routes array will be created as routes pointing at the rendering_app. The routes for a content item must contain a route for the base_path.
 
 All entries in the routes array must be under the base_path (ie either a subpath of the base_path, or the base_path with an extension)
@@ -32,7 +32,7 @@ the router.  The routes will still be validated though.
 
 ### Redirects for subpaths
 
-The content-store can also create redirects for paths under the base_path.  This is intended to support
+The content store can also create redirects for paths under the base_path.  This is intended to support
 cases where the structure within a piece of content has changed (eg a part of a guide no longer exists.)
 
 **Note:** it is invalid for the redirects array to include the base_path.  The only exception is redirect items,


### PR DESCRIPTION
We haven't had a consistent naming convention so far, so several versions have cropped up:
- Content Store
- the content store
- content-store
- the content-store

I've rejected the two hyphenated versions in the name of plain English. The choice of "the content store" over "Content Store" is semi-arbitrary: I think it reflects how we tend to refer to this app, but that may well reflect confirmation bias on my part.
