### PR TITLE
Slience output when creating mongoid test indexes.

### DIFF
--- a/spec/support/mongoid_indexes.rb
+++ b/spec/support/mongoid_indexes.rb
@@ -1,5 +1,7 @@
 RSpec.configure do |config|
   config.before(:suite) do
-    ::Mongoid::Tasks::Database.create_indexes
+    silence_stream(STDOUT) do
+      ::Mongoid::Tasks::Database.create_indexes
+    end
   end
 end


### PR DESCRIPTION
Reduces noise in the output.
