### PR TITLE
Bump bunny gem to 1.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'unicorn', '4.8.2'
 
 gem 'plek', '~> 1.9'
 
-gem 'bunny', '~> 1.3.1'
+gem 'bunny', '~> 1.5.0'
 
 if ENV['GDS_API_ADAPTERS_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
     arel (5.0.1.20140414130214)
     bson (2.3.0)
     builder (3.2.2)
-    bunny (1.3.1)
+    bunny (1.5.0)
       amq-protocol (>= 1.9.2)
     ci_reporter (1.9.2)
       builder (>= 2.1.2)
@@ -169,7 +169,7 @@ PLATFORMS
 
 DEPENDENCIES
   airbrake (= 4.0.0)
-  bunny (~> 1.3.1)
+  bunny (~> 1.5.0)
   ci_reporter (= 1.9.2)
   database_cleaner (~> 1.2)
   factory_girl (~> 4.4.0)


### PR DESCRIPTION
This allows us to specify mutliple rabbitmq hosts which will help with
robustness if one goes down.
