### PR TITLE
Change the documentation around link types

### DIFF
--- a/doc/content_item_fields.md
+++ b/doc/content_item_fields.md
@@ -114,9 +114,10 @@ For example:
       "topics": ['TOPIC-CONTENT-ID'],
     }
 
-The keys identify the type of related content, which may or may not match a
-format type. The value is a list of associated items, the order of which may be
-significant; the content store preserves the order.
+The keys identify the relationship between the current item and the linked
+items: this may or may not match a format type. Each value is a list of
+associated items, the order of which may be significant; the content store
+preserves the order.
 
 The link types currently in use are:
  - `related`: for non-specific related items


### PR DESCRIPTION
The previous documentation said that the keys represented the type of the linked item (`organisations` or `topics`, for example); it's more accurate to say that it's the type of the relationship itself.

For example, the `related` link type doesn't care about the type of the thing it's linking to. As anotehr example, we could feasibly add `next` or `previous` links for a series of items (multi-part guides, say), or `up` links to a parent section.
