### PR TITLE
Fix queue:watcher task to ack messages.

### DIFF
--- a/lib/tasks/queue.rake
+++ b/lib/tasks/queue.rake
@@ -22,7 +22,7 @@ namespace :queue do
     end
 
     puts "Listening for messages"
-    q.subscribe(:block => true, :ack => true) do |delivery_info, properties, payload|
+    q.subscribe(:block => true) do |delivery_info, properties, payload|
       puts <<-EOT
 ----- New Message -----
 Routing_key: #{delivery_info.routing_key}


### PR DESCRIPTION
Setting `:ack => true` indicates that messages will be manually acked
(which is a little non-obvious.  This option has been renamed to
`:manual_ack` in newer versions of bunny.)

The default is to auto ack messages, which is what we want in this
instance.
