### PR TITLE
Warn against using order to determine primacy

### DIFF
--- a/doc/content_item_fields.md
+++ b/doc/content_item_fields.md
@@ -117,11 +117,12 @@ For example:
 The keys identify the relationship between the current item and the linked
 items: this may or may not match a format type. Each value is a list of
 associated items (even if the relationship type implies that only a single such
-item can exist). The content store preserves the order, although if the order
-implies something more significant (such as a primary organisation or section),
-this relationship should be expressed in its own link type, because linked
-content items will be left out of the `retrieving` context if they are not yet
-published.
+item can exist).
+
+The content store preserves the order, although if the order implies something
+more significant (such as a primary organisation or section), this relationship
+should be expressed in its own link type, because linked content items will be
+left out of the `retrieving` context if they are not yet published.
 
 The link types currently in use are:
  - `related`: for non-specific related items


### PR DESCRIPTION
We haven't been explicit that, while the content store preserves ordering, we shouldn't be using that to express different kinds of relationships, such as primary sections.
