### PR TITLE
Reset rabbitmq channel on errors.

### DIFF
--- a/lib/queue_publisher.rb
+++ b/lib/queue_publisher.rb
@@ -37,6 +37,9 @@ class QueuePublisher
         }
       )
     end
+  rescue Timeout::Error, Bunny::Exception
+    reset_channel
+    raise
   end
 
   private
@@ -49,6 +52,12 @@ class QueuePublisher
 
     # passive parameter ensures we don't create the exchange.
     @channel.topic(@exchange_name, passive: true)
+  end
+
+  def reset_channel
+    @exchange = nil
+    @channel.close if @channel and @channel.open?
+    @channel = nil
   end
 
   def presented_item(item)


### PR DESCRIPTION
The publisher confirm feature we're using allow sending one or more
messages to rabbitmq, and then requesting confirms for all of them.
This requires Bunny to keep track of how many confirms are outstanding.
If an error occurs when sending a message, this count can get out of
sync with the server, resulting in Bunny attempting to wait for more
confirms than will ever be sent, which in turn leads to timeout errors.

The outstanding message count is a per-channel thing, so by closing the
channel, and creating a new one, this problem is avoided, and subsequent
message sending works.
