### PR TITLE
Return helpful message if value is of wrong type

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -13,7 +13,10 @@ class ContentItem
     return result, item
   rescue Mongoid::Errors::UnknownAttribute => e
     extra_fields = details.keys - self.fields.keys - %w(update_type)
-    item.errors.add(:base, "unrecognised field(s) #{extra_fields.join(',')} in input")
+    item.errors.add(:base, "unrecognised field(s) #{extra_fields.join(', ')} in input")
+    return false, item
+  rescue Mongoid::Errors::InvalidValue => e
+    item.errors.add(:base, e.message)
     return false, item
   end
 

--- a/spec/integration/submitting_content_item_spec.rb
+++ b/spec/integration/submitting_content_item_spec.rb
@@ -235,7 +235,24 @@ describe "content item write API", :type => :request do
 
     it "includes an error message" do
       data = JSON.parse(response.body)
-      expect(data["errors"]).to eq({"base" => ["unrecognised field(s) foo,bar in input"]})
+      expect(data["errors"]).to eq({"base" => ["unrecognised field(s) foo, bar in input"]})
+    end
+  end
+
+  context "create with value of incorrect type" do
+    before :each do
+      @data["routes"] = 12
+      put_json "/content/vat-rates", @data
+    end
+
+    it "rejects the update" do
+      expect(response.status).to eq(422)
+    end
+
+    it "includes an error message" do
+      data = JSON.parse(response.body)
+      expected_error_message = Mongoid::Errors::InvalidValue.new(Array, @data['routes'].class).message
+      expect(data["errors"]).to eq({"base" => [expected_error_message]})
     end
   end
 


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/6128

instead of returning a 500 because of exceptions `Mongoid::Errors::InvalidValue`, return an error message when a value is of incorrect type.
