### PR TITLE
Enable message queue by default in development.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,6 @@ yourself. Once RabbitMQ is installed, visit http://localhost:15672 and 1) add a
 A more detailed specification of how to configure RabbitMQ can be found in the
 [puppet manifest](https://github.gds/gds/puppet/blob/master/modules/govuk/manifests/apps/content_store/rabbitmq.pp)
 for content store.
+
+Publishing to the message queue can be disabled by setting the
+`DISABLE_QUEUE_PUBLISHER` environment variable.

--- a/config/initializers/message_queue.rb
+++ b/config/initializers/message_queue.rb
@@ -1,8 +1,8 @@
 require 'queue_publisher'
 
-if Rails.env.production? || ENV['USE_QUEUE_PUBLISHER']
-  config = YAML.load_file(Rails.root.join("config", "rabbitmq.yml"))[Rails.env].symbolize_keys
-else
+if Rails.env.test? || ENV['DISABLE_QUEUE_PUBLISHER']
   config = {noop: true}
+else
+  config = YAML.load_file(Rails.root.join("config", "rabbitmq.yml"))[Rails.env].symbolize_keys
 end
 Rails.application.queue_publisher = QueuePublisher.new(config)


### PR DESCRIPTION
The current setting whereby it's disabled by default has led to
confusion.  Given rabbitmq is available and configured on the dev VM it
makes sense for this to be enabled by default.

It remains disabled by default for the tests because the test suite
enables it explicitly for the tests that need it.
