### PR TITLE
Make it clear that the "gone item" behaviour isn't implemented

### DIFF
--- a/doc/gone_item.md
+++ b/doc/gone_item.md
@@ -1,4 +1,6 @@
-## Gone items
+## Gone items (not implemented)
+
+**Note:** this is not implemented and is an intended feature for this application.
 
 To represent content that is no longer available, the content store will support items with a format
 of "gone".  These will cause a gone route to be setup in the router so that the item returns a 410


### PR DESCRIPTION
People (read: me) might read this documentation as being part of
functionality that already exists in the content-store.

Remove that assumption by making it clear that it's the intended
behaviour.
