### PR TITLE
Set explicit path for cron in schedule.rb

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,5 +1,7 @@
 require 'whenever'
 
+env :PATH, '/usr/local/bin:/usr/bin:/bin'
+
 # Use this file to easily define all of your cron jobs.
 #
 # It's helpful, but not entirely necessary to understand cron before proceeding.


### PR DESCRIPTION
We were relying on `govuk_env` to set the correct path for the cron env.
Since the default cron env is "/usr/bin:/bin", that is not sufficient as `govuk_env` is in /usr/local/bin

See https://github.com/alphagov/whitehall/blob/master/config/schedule.rb#L1-L2
