### PR TITLE
Update moped (Mongoid's mongo driver) to 2.0.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
       moped (~> 2.0.0)
       origin (~> 2.1)
       tzinfo (>= 0.3.37)
-    moped (2.0.0)
+    moped (2.0.1)
       bson (~> 2.2)
       connection_pool (~> 2.0)
       optionable (~> 0.2.0)


### PR DESCRIPTION
This includes some fixes around the cluster reconnect behaviour, which
we hope will mean that it copes better with intermittent network issues,
and mongo re-elections.
