### PR TITLE
Set routing key for heartbeat messages

### DIFF
--- a/lib/govuk_exchange.rb
+++ b/lib/govuk_exchange.rb
@@ -4,9 +4,9 @@ class GovukExchange
     @config = config
   end
 
-  def publish(message, headers: {})
+  def publish(message, options = {})
     start_connection
-    exchange.publish message, headers
+    exchange.publish message, options
     wait_for_confirmation
     close_channel_and_connection
   end

--- a/lib/heartbeat_generator.rb
+++ b/lib/heartbeat_generator.rb
@@ -7,7 +7,7 @@ class HeartbeatGenerator
   end
 
   def generate
-    @exchange.publish(heartbeat_message, headers: message_headers)
+    @exchange.publish(heartbeat_message, message_options)
   end
 
 private
@@ -15,16 +15,17 @@ private
   ROUTING_KEY = "heartbeat.major"
 
   def heartbeat_message
-    JSON.generate(
-      {
-        timestamp: Time.now.utc.iso8601,
-        hostname: Socket.gethostname,
-        routing_key: ROUTING_KEY
-      }
-    )
+    {
+      timestamp: Time.now.utc.iso8601,
+      hostname: Socket.gethostname,
+    }.to_json
   end
 
-  def message_headers
-    { content_type: "application/x-heartbeat" }
+  def message_options
+    {
+      routing_key: ROUTING_KEY,
+      content_type: "application/x-heartbeat",
+      persistent: false,
+    }
   end
 end

--- a/spec/integration/heartbeat_message_publishing_spec.rb
+++ b/spec/integration/heartbeat_message_publishing_spec.rb
@@ -12,7 +12,7 @@ describe "sending a heartbeat message on the queue", :type => :request do
     read_channel = conn.create_channel
     ex = read_channel.topic(@config.fetch(:exchange), passive: true)
     @queue = read_channel.queue("", :exclusive => true)
-    @queue.bind(ex, routing_key: '#')
+    @queue.bind(ex, routing_key: 'heartbeat.major')
     example.run
 
     read_channel.close
@@ -23,11 +23,11 @@ describe "sending a heartbeat message on the queue", :type => :request do
     heartbeat_exchange = GovukExchange.new(exchange_name, config: @config)
     HeartbeatGenerator.new(heartbeat_exchange).generate
 
-    _, properties, payload = wait_for_message_on(@queue)
+    delivery_info, properties, payload = wait_for_message_on(@queue)
     message = JSON.parse(payload)
 
     expect(properties.content_type).to eq("application/x-heartbeat")
+    expect(delivery_info.routing_key).to eq("heartbeat.major")
     expect(message.fetch("hostname")).to eq(Socket.gethostname)
-    expect(message.fetch("routing_key")).to eq("heartbeat.major")
   end
 end

--- a/spec/lib/heartbeat_generator_spec.rb
+++ b/spec/lib/heartbeat_generator_spec.rb
@@ -14,14 +14,17 @@ describe HeartbeatGenerator do
         {
           timestamp: Time.now.utc.iso8601,
           hostname: "example-hostname",
-          routing_key: "heartbeat.major",
         }
       )
 
       HeartbeatGenerator.new(mock_exchange).generate
 
       expect(mock_exchange).to have_received(:publish).
-        with(expected_data, headers: { :content_type => "application/x-heartbeat" })
+        with(expected_data, {
+          routing_key: "heartbeat.major",
+          content_type: "application/x-heartbeat",
+          persistent: false,
+        })
     end
   end
 end


### PR DESCRIPTION
The routing key needs to be part of the options passed to Bunny's
exchange.publish method, not part of the message body.  See
http://www.rubydoc.info/github/ruby-amqp/bunny/Bunny/Exchange#publish-instance_method

The publish options aren't all headers, so call them `message_options`
instead of `message_headers`.  Change signature of the
GovukExchange.publish method to match that of Bunny's Exchange.publish
method (by making it have a second parameter of options with a default
of {}, rather than a named parameter called headers which requires a
hash), for a less surprising API.

Also, add "persistent: false", to indicate that we don't require the
heartbeat to be persisted on failure (this is the default, but
specifying it explicitly informs future readers that this is a
deliberate choice, since we choose to have persistent: true for
non-heartbeat messages).
