### PR TITLE
Placeholder format allows including real format.

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -125,7 +125,7 @@ private
   end
 
   def register_routes
-    registerable_route_set.register! unless self.format == "placeholder"
+    registerable_route_set.register! unless self.format.start_with?("placeholder")
   end
 
   def send_message

--- a/doc/content_item_fields.md
+++ b/doc/content_item_fields.md
@@ -35,7 +35,7 @@ set of fields than those listed below.
 
  - `gone`: A content item which has [gone away](gone_item.md)
  - `redirect`: A content item which has [been redirected](redirect_item.md)
- - `placeholder`: A temporary [placeholder](placeholder_item.md) for a content item.
+ - `placeholder*`: A temporary [placeholder](placeholder_item.md) for a content item.
 
 ## `content_id`
 

--- a/doc/placeholder_item.md
+++ b/doc/placeholder_item.md
@@ -3,10 +3,11 @@
 Items not yet being served from the content store, but that need to be linked to and
 referenced from other content items in the content store.
 
-During the transition to using the content store as the source of published content
-on GOV.UK, there may be a need to link to content that isn't yet being served
-directly from the content store. In such cases, the content that needs to be
-linked to can be added to the content store with a format of "placeholder".
-"placeholder" content will be expanded out when linked to in the `links` field
-of a content item, and can also be retrieved from the content store, but will not
-have its routes registered or updated.
+During the transition to using the content store as the source of published
+content on GOV.UK, there may be a need to link to content that isn't yet being
+served directly from the content store. In such cases, the content that needs
+to be linked to can be added to the content store with either a format of
+"placeholder" or a format prefixed with "placeholder_".  Placeholder content
+will be expanded out when linked to in the `links` field of a content item, and
+can also be retrieved from the content store, but will not have its routes
+registered or updated.

--- a/doc/route_registration.md
+++ b/doc/route_registration.md
@@ -27,8 +27,8 @@ The following routes would be created:
 
 ### Placeholder items
 
-Items with a format of "placeholder" will not have the routes registered with
-the router.  The routes will still be validated though.
+Items with a format starting with "placeholder" will not have the routes
+registered with the router.  The routes will still be validated though.
 
 ### Redirects for subpaths
 

--- a/spec/integration/submitting_placeholder_item_spec.rb
+++ b/spec/integration/submitting_placeholder_item_spec.rb
@@ -61,6 +61,27 @@ describe "submitting placeholder items to the content store", :type => :request 
     end
   end
 
+  context "an item with a format prefixed with 'placeholder_'" do
+    before :each do
+      @data["format"] = "placeholder_answer"
+    end
+
+    it "creates the content item" do
+      put_json "/content/vat-rates", @data
+      item = ContentItem.where(:base_path => "/vat-rates").first
+      expect(item).to be
+      expect(item.title).to eq("VAT rates")
+      expect(item.description).to eq("Current VAT rates")
+      expect(item.format).to eq("placeholder_answer")
+    end
+
+    it "does not register routes for the content item" do
+      put_json "/content/vat-rates", @data
+      refute_routes_registered("frontend", [['/vat-rates', 'exact']])
+    end
+
+  end
+
   context "create with an invalid routes" do
     before(:each) do
       @data["routes"] << {"path" => "/not-vat-rates", "type" => "exact"}


### PR DESCRIPTION
This changes the placeholder logic to skip route registration for any items with a format that starts with "placeholder".  This will allow content-register (among others) to extract the real format from items sent with a format of eg  "placeholder_foo".

See alphagov/content-register#13 for the corresponding change to content-register to support this.
