### PR TITLE
Handle non-ASCII paths.

### DIFF
--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -62,4 +62,19 @@ describe "Fetching a content item", :type => :request do
     expect(response.status).to eq(404)
   end
 
+  it "returns an item with a non-ASCII path" do
+    path = URI.encode('/news/בוט לאינד')
+    create(:content_item,
+     :base_path => path,
+     :content_id => SecureRandom.uuid,
+     :title => "VAT rates",
+     :description => "Current VAT rates",
+     :format => "answer",
+     :need_ids => ["100136"],
+     :public_updated_at => 30.minutes.ago,
+     :details => {"body" => "<div class=\"highlight-answer\">\n<p>The standard <abbr title=\"Value Added Tax\">VAT</abbr> rate is <em>20%</em></p>\n</div>\n"})
+    get "/content/#{path}"
+    data = JSON.parse(response.body)
+    expect(data['title']).to eq("VAT rates")
+  end
 end


### PR DESCRIPTION
Rails automatically decodes percent-escaped parameters, but these are no longer valid paths and fail both our absolute_path validation and the parsing involved in calling out to other HTTP services. We now explicitly re-encode the base_path and use that encoded version in the database and when calling URL arbiter etc.
