### PR TITLE
Don't allow dashes in format or update_type

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -46,7 +46,7 @@ class ContentItem
   validates :format, :publishing_app, presence: true
   # This isn't persisted, but needs to be set when making changes because it's used in the message queue.
   validates :update_type, presence: { if: :changed? }
-  validates :format, :update_type, format: { with: /\A[a-z0-9_-]+\z/i, allow_blank: true }
+  validates :format, :update_type, format: { with: /\A[a-z0-9_]+\z/i, allow_blank: true }
   validates :title, :rendering_app, presence: true, if: :renderable_content?
   validate :route_set_is_valid
   validate :links_are_valid

--- a/db/migrate/20141203161550_fixup_manual_section_format.rb
+++ b/db/migrate/20141203161550_fixup_manual_section_format.rb
@@ -1,0 +1,13 @@
+class FixupManualSectionFormat < Mongoid::Migration
+  def self.up
+    ContentItem.where(:format => "manual-section").each do |item|
+      item.set(:format => "manual_section")
+    end
+  end
+
+  def self.down
+    ContentItem.where(:format => "manual_section").each do |item|
+      item.set(:format => "manual-section")
+    end
+  end
+end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -186,7 +186,6 @@ describe ContentItem, :type => :model do
             word
             alpha12numeric
             under_score
-            dashed-item
             mixedCASE
           ).each do |value|
             @item.public_send("#{field}=", value)
@@ -195,6 +194,7 @@ describe ContentItem, :type => :model do
 
           [
             'no spaces',
+            'dashed-item',
             'puncutation!',
           ].each do |value|
             @item.public_send("#{field}=", value)


### PR DESCRIPTION
In order to reduce confusion require underscores to separate words in
these fields (similarly to keys in the links hash).

There's only one format that was using dashes (manual-section), and the
publishing tool [has now been updated to use underscores](https://github.com/alphagov/specialist-publisher/pull/342). A migration updates existing items.

All the update_types in use are currently single words.

**Note:** This should not be merged until https://github.com/alphagov/specialist-publisher/pull/342 has been deployed to prod.
