### PR TITLE
Allow exact redirects to include query and fragments

### DIFF
--- a/app/models/registerable_redirect.rb
+++ b/app/models/registerable_redirect.rb
@@ -1,8 +1,34 @@
 class RegisterableRedirect < RegisterableRoute
 
-  validates :destination, presence: true, absolute_path: true
+  validates :destination, presence: true
+  validates :destination, absolute_path: true, unless: :exact?
+  validate :validate_exact_redirect_destination, if: :exact?
 
   def register!
     Rails.application.router_api.add_redirect_route(path, type, destination)
+  end
+
+  private
+
+  def validate_exact_redirect_destination
+    unless valid_exact_redirect_target?(destination)
+      errors[:destination] << "is not a valid redirect destination"
+    end
+  end
+
+  # Valid 'exact' redirect targets differ from standard targets in that we
+  # allow:
+  # 1. Query strings
+  # 2. Fragments
+  def valid_exact_redirect_target?(target)
+    return false unless target.present? and target.starts_with?("/")
+
+    uri = URI.parse(target)
+    expected = uri.path
+    expected << "?#{uri.query}" if uri.query.present?
+    expected << "##{uri.fragment}" if uri.fragment.present?
+    expected == target
+  rescue URI::InvalidURIError
+    false
   end
 end

--- a/app/models/registerable_route.rb
+++ b/app/models/registerable_route.rb
@@ -8,4 +8,8 @@ class RegisterableRoute < OpenStruct
   def register!(rendering_app)
     Rails.application.router_api.add_route(path, type, rendering_app)
   end
+
+  def exact?
+    type == "exact"
+  end
 end

--- a/spec/integration/submitting_redirect_item_spec.rb
+++ b/spec/integration/submitting_redirect_item_spec.rb
@@ -77,6 +77,27 @@ describe "submitting redirect items to the content store", :type => :request do
     it "updates routes for the content item" do
       assert_redirect_routes_registered([['/crb-checks', 'prefix', '/dbs-checks'], ['/crb-checks.json', 'exact', '/api/content/dbs-checks']])
     end
+  end
 
+  describe "exact redirect destination variants" do
+    it "allows exact redirect destinations that include a query string and fragment" do
+      @data["redirects"] = [{"path" => "/crb-checks", "type" => "exact", "destination" => "/dbs-checks?foo=bar#overview"}]
+
+      put_json "/content/crb-checks", @data
+
+      expect(response.status).to eq(201)
+
+      assert_redirect_routes_registered([['/crb-checks', 'exact', '/dbs-checks?foo=bar#overview']])
+    end
+
+    it "disallows prefix redirect destinations that include a query string and fragment" do
+      @data["redirects"] = [{"path" => "/crb-checks", "type" => "prefix", "destination" => "/dbs-checks?foo=bar#overview"}]
+
+      put_json "/content/crb-checks", @data
+
+      expect(response.status).to eq(422)
+
+      assert_no_routes_registered_for_path('/crb-checks')
+    end
   end
 end

--- a/spec/models/registerable_redirect_spec.rb
+++ b/spec/models/registerable_redirect_spec.rb
@@ -5,10 +5,51 @@ describe RegisterableRedirect, :type => :model do
   let(:factory_name) { :registerable_redirect }
   it_behaves_like 'a valid registerable route'
 
-  it 'validates destination is an absolute path' do
-    route = build(:registerable_redirect, :destination => 'not-absolute-path')
+  context "for a prefix redirect" do
 
-    expect(route).to_not be_valid
-    expect(route.errors[:destination].size).to eq(1)
+    it 'validates destination is an absolute path' do
+      route = build(:registerable_redirect, :type => "prefix", :destination => 'not-absolute-path')
+
+      expect(route).to_not be_valid
+      expect(route.errors[:destination].size).to eq(1)
+    end
+  end
+
+  context "for an exact redirect" do
+    let(:redirect) { build(:registerable_redirect, :type => "exact") }
+
+    it "is valid with an absolute path with optional query string and fragment" do
+      [
+        '/foo/bar',
+        '/foo?bar=baz',
+        '/foo/bar#baz',
+      ].each do |dest|
+        redirect.destination = dest
+        expect(redirect).to be_valid, "expected redirect to be valid with destination: '#{dest}'"
+      end
+    end
+
+    it "is invalid with an invalid or non-absolute URL" do
+      [
+        'foo/bar',
+        '/url with spaces',
+        'fdjkdfjkljsdaf',
+      ].each do |dest|
+        redirect.destination = dest
+        expect(redirect).not_to be_valid, "expected redirect not to be valid with destination: '#{dest}'"
+        expect(redirect.errors[:destination].size).to eq(1)
+      end
+    end
+
+    it "is invalid with an external URL" do
+      [
+        'https://www.example.com/foo/bar',
+        'https://www.gov.uk/foo/bar',
+      ].each do |dest|
+        redirect.destination = dest
+        expect(redirect).not_to be_valid, "expected redirect not to be valid with destination: '#{dest}'"
+        expect(redirect.errors[:destination].size).to eq(1)
+      end
+    end
   end
 end

--- a/spec/support/router_helpers.rb
+++ b/spec/support/router_helpers.rb
@@ -49,7 +49,7 @@ module RouterHelpers
 
   def assert_no_routes_registered_for_path(path)
     route_stub = stub_http_request(:put, "#{GdsApi::TestHelpers::Router::ROUTER_API_ENDPOINT}/routes").
-      with(:body => {"route" => hash_including("incoming_path" => "/vat-rates")})
+      with(:body => {"route" => hash_including("incoming_path" => path)})
     assert_not_requested(route_stub)
   end
 end


### PR DESCRIPTION
The router now supports exact redirect targets that include a query
string or fragment, so we can now allow them here.
