### PR TITLE
Clarify use of public_updated_at field

### DIFF
--- a/doc/content_item_fields.md
+++ b/doc/content_item_fields.md
@@ -114,9 +114,9 @@ for the Latin America and Caribbean region").
 
 ISO 8601 formatted timestamp. Present in all contexts.
 
-This is the time at which the content was last publicly visibly updated. This
-can be used for sorting by update date, but will not be changed for minor
-updates.
+This is the update date that should be surfaced to the user. This is used for
+sorting documents by update date. It should change when there is a major
+update and should not change for a minor update.
 
 ## `details`
 


### PR DESCRIPTION
The previous wording made it sound like the ContentStore used this field in some way. This new wording makes it clear that the publishing App should send the correct timestamp.