### PR TITLE
Add uniqueness validation on route/redirect paths.

### DIFF
--- a/app/models/registerable_route_set.rb
+++ b/app/models/registerable_route_set.rb
@@ -10,6 +10,7 @@ class RegisterableRouteSet < OpenStruct
 
   validate :registerable_routes_and_redirects_are_valid,
            :all_routes_and_redirects_are_beneath_base_path,
+           :all_routes_and_redirects_have_unique_paths,
            :redirect_cannot_have_routes
   validate :registerable_routes_include_base_path, :if => :base_path_route_required?
   validate :registerable_redirects_include_base_path, :if => :is_redirect
@@ -121,6 +122,18 @@ private
     end
     unless registerable_redirects.all? {|redirect| base_path_with_extension?(redirect) || beneath_base_path?(redirect) }
       errors[:registerable_redirects] << 'must be below the base path'
+    end
+  end
+
+  def all_routes_and_redirects_have_unique_paths
+    paths = registerable_routes.map(&:path)
+    unless paths == paths.uniq
+      errors[:registerable_routes] << 'must have unique paths'
+    end
+
+    paths = registerable_redirects.map(&:path)
+    unless paths == paths.uniq
+      errors[:registerable_redirects] << 'must have unique paths'
     end
   end
 

--- a/spec/models/registerable_route_set_spec.rb
+++ b/spec/models/registerable_route_set_spec.rb
@@ -155,6 +155,13 @@ describe RegisterableRouteSet, :type => :model do
         expect(@route_set.errors[:registerable_routes].size).to eq(1)
       end
 
+      it "requires all routes to have a unique path" do
+        @route_set.registerable_routes << build(:registerable_route, :path => @route_set.base_path)
+
+        expect(@route_set).not_to be_valid
+        expect(@route_set.errors[:registerable_routes].size).to eq(1)
+      end
+
       it "requires all routes to be beneath the base path" do
         @route_set.registerable_routes << build(:registerable_route, :path => "/another-path")
         expect(@route_set).not_to be_valid
@@ -202,6 +209,13 @@ describe RegisterableRouteSet, :type => :model do
 
       it "requires all redirects to be valid" do
         @route_set.registerable_redirects.first.type = "not_a_valid_type"
+        expect(@route_set).not_to be_valid
+        expect(@route_set.errors[:registerable_redirects].size).to eq(1)
+      end
+
+      it "requires all redirects to have a unique path" do
+        @route_set.registerable_redirects << build(:registerable_redirect, :path => @route_set.base_path)
+
         expect(@route_set).not_to be_valid
         expect(@route_set.errors[:registerable_redirects].size).to eq(1)
       end


### PR DESCRIPTION
To prevent confusion caused if a path is included more than once.