### PR TITLE
Require a base_path in the routes.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,12 +2,12 @@ Rails.application.routes.draw do
 
   with_options :format => false do |r|
     r.with_options :constraints => {:base_path => %r[/.*]} do |path_routes|
-      path_routes.get "/content(*base_path)" => "content_items#show", :as => :content_item
-      path_routes.put "/content(*base_path)" => "content_items#update"
+      path_routes.get "/content*base_path" => "content_items#show", :as => :content_item
+      path_routes.put "/content*base_path" => "content_items#update"
 
-      path_routes.get "/publish-intent(*base_path)" => "publish_intents#show"
-      path_routes.put "/publish-intent(*base_path)" => "publish_intents#update"
-      path_routes.delete "/publish-intent(*base_path)" => "publish_intents#destroy"
+      path_routes.get "/publish-intent*base_path" => "publish_intents#show"
+      path_routes.put "/publish-intent*base_path" => "publish_intents#update"
+      path_routes.delete "/publish-intent*base_path" => "publish_intents#destroy"
     end
 
     r.get "/healthcheck", :to => proc { [200, {}, ["OK"]] }

--- a/spec/routing/content_item_routing_spec.rb
+++ b/spec/routing/content_item_routing_spec.rb
@@ -13,6 +13,10 @@ describe "routing of content_item requests", :type => :routing do
     it "should not match a base_path without a leading /" do
       expect(:get => "/contentfoo").not_to be_routable
     end
+
+    it "should require a base_path" do
+      expect(:get => "/content").not_to be_routable
+    end
   end
 
   context "PUT route" do
@@ -26,6 +30,10 @@ describe "routing of content_item requests", :type => :routing do
 
     it "should not match a base_path without a leading /" do
       expect(:put => "/contentfoo").not_to be_routable
+    end
+
+    it "should require a base_path" do
+      expect(:put => "/content").not_to be_routable
     end
   end
 end

--- a/spec/routing/publish_intent_routing_spec.rb
+++ b/spec/routing/publish_intent_routing_spec.rb
@@ -13,6 +13,10 @@ describe "routing of publish_intent requests", :type => :routing do
     it "should not match a base_path without a leading /" do
       expect(:get => "/publish-intentfoo").not_to be_routable
     end
+
+    it "should require a base_path" do
+      expect(:get => "/publish-intent").not_to be_routable
+    end
   end
 
   context "PUT route" do
@@ -27,6 +31,10 @@ describe "routing of publish_intent requests", :type => :routing do
     it "should not match a base_path without a leading /" do
       expect(:put => "/publish-intentfoo").not_to be_routable
     end
+
+    it "should require a base_path" do
+      expect(:put => "/publish-intent").not_to be_routable
+    end
   end
 
   context "DELETE route" do
@@ -40,6 +48,10 @@ describe "routing of publish_intent requests", :type => :routing do
 
     it "should not match a base_path without a leading /" do
       expect(:delete => "/publish-intentfoo").not_to be_routable
+    end
+
+    it "should require a base_path" do
+      expect(:delete => "/publish-intent").not_to be_routable
     end
   end
 end


### PR DESCRIPTION
Using parens around a route parameter makes that param optional.  This
meant that requests for eg `/content` were being routed through to
`content_items#show`, which then errored because it expected `base_path` to be
populated.