### PR TITLE
Fix translation lookup for item with no content_id

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -133,6 +133,7 @@ private
   end
 
   def load_available_translations
+    return [self] if self.content_id.blank?
     ContentItem
       .excluding_redirects
       .where(:content_id => content_id)

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -411,8 +411,8 @@ describe ContentItem, :type => :model do
         @item = build(:content_item)
       end
 
-      it 'should return an empty hash' do
-        expect(@item.linked_items).to eq({})
+      it 'should not return any linked items' do
+        expect(@item.linked_items.except("available_translations")).to eq({})
       end
     end
 
@@ -588,6 +588,20 @@ describe ContentItem, :type => :model do
 
         it 'should prefer the newest item' do
           expect(item_en.linked_items["available_translations"]).to eq([item_en, item_fr_new])
+        end
+      end
+
+      context 'for an item without a content_id' do
+        let!(:item_en) { create(:content_item, locale: 'en', content_id: nil) }
+        let!(:other_item_fr) { create(:content_item, locale: 'fr', content_id: nil) }
+        let!(:item_en_new) {
+          Timecop.travel(10.seconds.from_now) do
+            create(:content_item, locale: 'en', content_id: nil)
+          end
+        }
+
+        it 'should return only itself' do
+          expect(item_en.linked_items["available_translations"]).to eq([item_en])
         end
       end
     end

--- a/spec/presenters/public_content_item_presenter_spec.rb
+++ b/spec/presenters/public_content_item_presenter_spec.rb
@@ -30,7 +30,7 @@ describe PublicContentItemPresenter do
 
     it "includes the link type" do
       expect(presenter.as_json).to have_key("links")
-      expect(presenter.as_json["links"].keys).to eq(["related"])
+      expect(presenter.as_json["links"].keys).to match_array(["available_translations", "related"])
     end
 
     it "includes each linked item" do


### PR DESCRIPTION
This was previously looking up available_translations using a nil content_id.  This resulted in an apparently random item being linked as the available translation (eg at the moment, "Civil Service Apprenticeship Schemes" is being returned as a translation of "VAT rates").