### PR TITLE
[DISCUSS] Validate that base_path in body matches the request URL

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,7 @@ class ApplicationController < ActionController::API
   end
 
   def parse_json_request
-    @request_data = JSON.parse(request.body.read).except('base_path')
+    @request_data = JSON.parse(request.body.read)
   rescue JSON::ParserError
     head :bad_request
   end

--- a/app/models/publish_intent.rb
+++ b/app/models/publish_intent.rb
@@ -6,10 +6,12 @@ class PublishIntent
     intent = PublishIntent.find_or_initialize_by(:base_path => base_path)
     result = intent.new_record? ? :created : :replaced
 
-    intent.update_attributes(attributes) or result = false
+    assignable_attributes = attributes.except('base_path')
+    intent.update_attributes(assignable_attributes) or result = false
+
     return result, intent
   rescue Mongoid::Errors::UnknownAttribute => e
-    extra_fields = attributes.keys - self.fields.keys
+    extra_fields = assignable_attributes.keys - self.fields.keys
     intent.errors.add(:base, "unrecognised field(s) #{extra_fields.join(', ')} in input")
     return false, intent
   rescue Mongoid::Errors::InvalidValue => e

--- a/spec/integration/submitting_content_item_spec.rb
+++ b/spec/integration/submitting_content_item_spec.rb
@@ -275,6 +275,23 @@ describe "content item write API", :type => :request do
     end
   end
 
+  context "create with a mismatched slug" do
+    before :each do
+      @data["base_path"] = "/not-about-vat-rates"
+      put_json "/content/vat-rates", @data
+    end
+
+    it "rejects the update" do
+      expect(response.status).to eq(422)
+    end
+
+    it "includes an error message" do
+      data = JSON.parse(response.body)
+      expected_error_message = "mismatch with path supplied in request URL"
+      expect(data["errors"]).to eq({"base_path" => [expected_error_message]})
+    end
+  end
+
   context "url-arbiter returns validation error" do
     before :each do
       url_arbiter_returns_validation_error_for("/vat-rates", "publishing_app" => ["can't be blank"])

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -318,7 +318,7 @@ describe ContentItem, :type => :model do
           result = item = nil
 
           expect {
-            result, item = ContentItem.create_or_replace(@item.base_path, { foo: 'foo', bar: 'bar' })
+            result, item = ContentItem.create_or_replace(@item.base_path, 'base_path' => @item.base_path, 'foo' => 'foo', 'bar' => 'bar' )
           }.to_not raise_error
 
           expect(result).to be false
@@ -332,7 +332,7 @@ describe ContentItem, :type => :model do
 
           expect {
             # routes should be of type Array
-            result, item = ContentItem.create_or_replace(@item.base_path, { routes: 12 })
+            result, item = ContentItem.create_or_replace(@item.base_path, 'base_path' => @item.base_path, 'routes' => 12 )
           }.to_not raise_error
 
           expect(result).to be false


### PR DESCRIPTION
We currently document base_path in the body as being required, but we don't
actually validate its presence or that it matches the one in the request URL.

This means we could end up with a situation where some publishing apps are
sending the wrong value some or all of the time but we don't realise it until
we (hypothetically) change content-store to start using the value in the body.

We still need to discard the base_path for the purposes of update_attributes,
as described here:
d70d92d98125e5dc44476ca9bd5051e677db59a2

The alternative to this change would be to drop `base_path` from the bodies for write requests.