### PR TITLE
Deprecate base_path in body in the publishing context

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,6 +18,8 @@ class ApplicationController < ActionController::API
   end
 
   def parse_json_request
+    # FIXME base_path in the request body is deprecated and will be considered
+    # an error once all clients have been updated.
     @request_data = JSON.parse(request.body.read).except('base_path')
   rescue JSON::ParserError
     head :bad_request

--- a/doc/content_item_fields.md
+++ b/doc/content_item_fields.md
@@ -16,7 +16,8 @@ from the content store API can be found in
 
 ## `base_path`
 
-A string. Present in all contexts.
+A string. Present in the request URL in the storing context and included in the
+document in all other contexts.
 
 The absolute path of the content on GOV.UK. This uniquely identifies the
 content within the content store and allows the content store to answer the

--- a/doc/gone_item.md
+++ b/doc/gone_item.md
@@ -8,10 +8,10 @@ Items with a format of gone will have all routes setup in the same way as other 
 route_registration.md), with the exception that instead of routing to the rendering_app, routes will be
 created as gone routes.
 
-For example, given an item including the following fields:
+For example, given the following request:
 
+    PUT /content/gone-foo
     {
-      "base_path": "/gone-foo",
       "format": "gone",
       "publishing_app": "publisher",
       "update_type": "major",

--- a/doc/publish_intents.md
+++ b/doc/publish_intents.md
@@ -17,7 +17,8 @@ propagated out.
 
 A publish intent has the following fields:
 
-* `base_path` - The path of the item that will be published.
+* `base_path` - The path of the item that will be published. Found in the
+request URL of write requests and the response body for read requests.
 * `publish_time` - ISO 8601 formatted timestamp. The time the corresponding
   content item will be published.
 * `publishing_app` - The publishing app that owns this content (see
@@ -31,8 +32,8 @@ A publish intent has the following fields:
 For example:
 
 ``` js
+PUT /publish-intent/vat-rates
 {
-  "base_path": "/vat-rates",
   "publish_time": "2015-01-05T09:00:00+00:00",
   "publishing_app": "publisher",
   "rendering_app": "frontend",

--- a/doc/redirect_item.md
+++ b/doc/redirect_item.md
@@ -8,10 +8,10 @@ items with a format of "redirect".  These items have slightly different validati
 * The `routes` array and `rendering_app` will be ignored, and should be left empty.
 * A title is not required.
 
-For example, given the following item:
+For example, given the following request:
 
+    PUT /content/moved-foo
     {
-      "base_path": "/moved-foo",
       "format": "redirect",
       "publishing_app": "publisher",
       "update_type": "major",

--- a/doc/route_registration.md
+++ b/doc/route_registration.md
@@ -8,10 +8,10 @@ All items listed in the routes array will be created as routes pointing at the
 All entries in the routes array must be under the `base_path` (ie either a
 subpath of the `base_path`, or the `base_path` with an extension)
 
-Given an item including the following fields:
+Given the following request:
 
+    PUT /content/foo
     {
-      "base_path": "/foo",
       "rendering_app": "frontend",
       "routes": [
         {"path": "/foo", "type": "exact"},
@@ -44,10 +44,10 @@ which are described in redirect_item.md.
 Redirects are specified in the redirects array.  These optionally specify a destination path, which if
 ommitted defaults to the base_path.
 
-e.g. given an item including the following fields:
+e.g. given the following request:
 
+    PUT /content/foo
     {
-      "base_path": "/foo",
       "redirects": [
         {"path": "/foo.json", "type": "exact", "destination": "/api/foo.json"},
         {"path": "/foo/obsolete-part", "type": "exact"}


### PR DESCRIPTION
The documentation implies that the base_path must be included in the request
body for write requests as well as in the URL. This is not true and in fact if
supplied in the body it is discarded, otherwise it is ignored - the base_path
in the URL is used instead.

Leading developers to believe that it is required but not performing any
validation on it seems likely to be a source of errors, so let's get rid of it.

Once all clients have been updated to omit it from the request body, we can
stop treating it as a special case and start rejecting it as we would any other
unexpected field.