### PR TITLE
Really remove non-case-study whitehall unpublishings

### DIFF
--- a/db/migrate/20150220114658_really_remove_non_case_study_whitehall_unpublishings.rb
+++ b/db/migrate/20150220114658_really_remove_non_case_study_whitehall_unpublishings.rb
@@ -1,0 +1,42 @@
+class ReallyRemoveNonCaseStudyWhitehallUnpublishings < Mongoid::Migration
+  def self.up
+    puts "Removing redirects for #{content_items.count} items"
+    content_items.each do |content_item|
+      puts "Content item #{content_item.id}"
+      if content_item.format == 'redirect'
+        remove_redirect(content_item)
+      end
+      content_item.destroy
+      puts "  -> destroyed content item"
+    end
+    router_api.commit_routes
+  end
+
+  def self.down
+    raise "non-reversible migration"
+  end
+
+  def self.remove_redirect(content_item)
+    content_item.redirects.each do |redirect|
+      begin
+        router_api.delete_route(redirect['path'], redirect['type'])
+        puts "  -> removed redirect '#{redirect["path"]}'"
+      rescue GdsApi::HTTPNotFound => e
+        puts "  -> redirect #{redirect["path"]} not found. Nothing done."
+      end
+    end
+  end
+
+  def self.content_items
+    ContentItem.where(
+      publishing_app: "whitehall",
+      format: {"$in" => ["unpublishing", "redirect"]}
+    ).reject do |content_item|
+      content_item.base_path =~ %r{/case-studies/}
+    end
+  end
+
+  def self.router_api
+    Rails.application.router_api
+  end
+end


### PR DESCRIPTION
In https://github.com/alphagov/content-store/pull/96 we attempted to
remove these.

However, we ran this migration before deploying the change to whitehall
which stopped sending unpublishings for non-case-studies to the content
store (deployed 22nd dec).

Therefore, some slipped through the net.

In addition we missed out unpublishings of translated content items.

This migration cleans up the remaining unpublishings.