### PR TITLE
Dont return entity in PUT responses

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -59,6 +59,8 @@ class ContentItemsController < ApplicationController
     return_arbiter_error(:conflict, e)
   rescue GOVUK::Client::Errors::UnprocessableEntity => e
     return_arbiter_error(:unprocessable_entity, e)
+  rescue GOVUK::Client::Errors::BaseError => e
+    return_arbiter_error(:server_error, e)
   end
 
   def return_arbiter_error(status, exception)

--- a/app/controllers/publish_intents_controller.rb
+++ b/app/controllers/publish_intents_controller.rb
@@ -15,13 +15,15 @@ class PublishIntentsController < ApplicationController
     else
       status = :unprocessable_entity
     end
-    render :json => intent, :status => status
+    response_body = {}
+    response_body[:errors] = intent.errors.as_json if intent.errors.any?
+    render :json => response_body, :status => status
   end
 
   def destroy
     intent = PublishIntent.find_by(:base_path => encoded_base_path)
     intent.destroy
 
-    render :json => intent
+    render :json => {}
   end
 end

--- a/app/presenters/private_content_item_presenter.rb
+++ b/app/presenters/private_content_item_presenter.rb
@@ -9,7 +9,6 @@ class PrivateContentItemPresenter
   def as_json(options = nil)
     @item.as_json(options).tap do |hash|
       hash["update_type"] = @item.update_type if @item.update_type
-      hash["errors"] = @item.errors.as_json.stringify_keys if @item.errors.any?
     end
   end
 end

--- a/spec/integration/publish_intent_crud_spec.rb
+++ b/spec/integration/publish_intent_crud_spec.rb
@@ -23,14 +23,11 @@ describe "CRUD of publish intents", :type => :request do
         expect(intent.publish_time).to match_datetime(publish_time)
       end
 
-      it "responds with a created status, and the intent as json" do
+      it "responds with a created status and an empty JSON document" do
         put_json "/publish-intent/vat-rates", data
 
         expect(response.status).to eq(201)
-
-        data = JSON.parse(response.body)
-        expect(data['base_path']).to eq('/vat-rates')
-        expect(data['publish_time']).to match_datetime(publish_time)
+        expect(response.body).to eq('{}')
       end
     end
 
@@ -44,14 +41,10 @@ describe "CRUD of publish intents", :type => :request do
         expect(intent.publish_time).to match_datetime(publish_time)
       end
 
-      it "responds with an ok status, and the intent as json" do
+      it "responds with an ok status" do
         put_json "/publish-intent/vat-rates", data
 
         expect(response.status).to eq(200)
-
-        data = JSON.parse(response.body)
-        expect(data['base_path']).to eq('/vat-rates')
-        expect(data['publish_time']).to match_datetime(publish_time)
       end
     end
 
@@ -100,9 +93,6 @@ describe "CRUD of publish intents", :type => :request do
       put_json "/publish-intent#{path}", data.merge("base_path" => path, "routes" => [{"path" => path, "type" => "exact"}])
 
       expect(response.status).to eq(201)
-
-      data = JSON.parse(response.body)
-      expect(data['base_path']).to eq(path)
 
       expect(PublishIntent.where(:base_path => path).first).to be
     end
@@ -179,14 +169,10 @@ describe "CRUD of publish intents", :type => :request do
       expect(PublishIntent.where(:base_path => "/vat-rates").first).not_to be
     end
 
-    it "returns 200 with details of the deleted intent" do
+    it "returns 200" do
       delete "/publish-intent/vat-rates"
 
       expect(response.status).to eq(200)
-
-      data = JSON.parse(response.body)
-      expect(data['base_path']).to eq('/vat-rates')
-      expect(data['publish_time']).to match_datetime(intent.publish_time)
     end
 
     it "returns 404 for non-existent intent" do

--- a/spec/integration/submitting_content_item_spec.rb
+++ b/spec/integration/submitting_content_item_spec.rb
@@ -43,20 +43,9 @@ describe "content item write API", :type => :request do
       expect(item.details).to eq({"body" => "<p>Some body text</p>\n"})
     end
 
-    it "responds with the content item as JSON in the body" do
+    it "responds with an empty JSON document in the body" do
       put_json "/content/vat-rates", @data
-      item = ContentItem.where(:base_path => "/vat-rates").first
-      response_data = JSON.parse(response.body)
-
-      expect(response_data["title"]).to eq(item.title)
-    end
-
-    it "responds with all the fields in the content item" do
-      # Because this is still publishing-side, we include everything
-      put_json "/content/vat-rates", @data
-      response_data = JSON.parse(response.body)
-
-      expect(response_data.keys).to include(*@data.keys - ["update_type"])
+      expect(response.body).to eq('{}')
     end
 
     it "registers routes for the content item" do
@@ -156,13 +145,6 @@ describe "content item write API", :type => :request do
         expect(@item.details).to eq({"body" => "<p>Some body text</p>\n"})
       end
 
-      it "responds with the content item as JSON in the body" do
-        put_json "/content/vat-rates", @data
-        @item.reload
-        response_data = JSON.parse(response.body)
-        expect(response_data["title"]).to eq(@item.title)
-      end
-
       it "updates routes for the content item" do
         put_json "/content/vat-rates", @data
         assert_routes_registered("frontend", [['/vat-rates', 'exact']])
@@ -236,7 +218,6 @@ describe "content item write API", :type => :request do
 
     it "includes validation error messages in the response" do
       data = JSON.parse(response.body)
-      expect(data["title"]).to eq("")
       expect(data["errors"]).to eq({"title" => ["can't be blank"]})
     end
   end

--- a/spec/integration/submitting_content_item_spec.rb
+++ b/spec/integration/submitting_content_item_spec.rb
@@ -270,6 +270,25 @@ describe "content item write API", :type => :request do
     end
   end
 
+  context "url-arbiter returns an unexpected response code (or another unexpected exception is raised)" do
+    before :each do
+      stub_request(:put, "#{GOVUK::Client::TestHelpers::URLArbiter::URL_ARBITER_ENDPOINT}/paths/vat-rates").to_return do |request|
+        {
+          status: 502, body: "<html>Welcome to nginx</html>", :headers => { content_type: "application/html" }
+        }
+      end
+
+      put_json "/content/vat-rates", @data
+    end
+
+    it "should return 500 with error messages" do
+      expect(response.status).to eq(500)
+
+      data = JSON.parse(response.body)
+      expect(data["errors"]).to eq({"url_arbiter_registration" => ["502: <html>Welcome to nginx</html>"]})
+    end
+  end
+
   context "copes with non-ASCII paths" do
     let(:path) { URI.encode('/news/בוט לאינד') }
     before :each do

--- a/spec/integration/submitting_gone_item_spec.rb
+++ b/spec/integration/submitting_gone_item_spec.rb
@@ -28,14 +28,8 @@ describe "submitting gone items to the content store", :type => :request do
       expect(item.format).to eq("gone")
     end
 
-    it "responds with the item as JSON in the body" do
-      response_data = JSON.parse(response.body)
-      expect(response_data["format"]).to eq("gone")
-    end
-
     it "registers gone routes for the item" do
       assert_gone_routes_registered([['/dodo-sanctuary', 'prefix'], ['/dodo-sanctuary.json', 'exact']])
     end
   end
-
 end

--- a/spec/integration/submitting_redirect_item_spec.rb
+++ b/spec/integration/submitting_redirect_item_spec.rb
@@ -33,11 +33,6 @@ describe "submitting redirect items to the content store", :type => :request do
       expect(item.updated_at).to be_within(10.seconds).of(Time.zone.now)
     end
 
-    it "responds with the item as JSON in the body" do
-      response_data = JSON.parse(response.body)
-      expect(response_data["format"]).to eq("redirect")
-    end
-
     it "registers redirect routes for the item" do
       assert_redirect_routes_registered([['/crb-checks', 'prefix', '/dbs-checks'], ['/crb-checks.json', 'exact', '/api/content/dbs-checks']])
     end
@@ -67,11 +62,6 @@ describe "submitting redirect items to the content store", :type => :request do
       expect(@item.public_updated_at).to eq(Time.zone.parse("2014-05-14T13:00:06Z"))
       expect(@item.updated_at).to be_within(10.seconds).of(Time.zone.now)
       expect(@item.details).to eq({})
-    end
-
-    it "responds with the content item as JSON in the body" do
-      response_data = JSON.parse(response.body)
-      expect(response_data["format"]).to eq("redirect")
     end
 
     it "updates routes for the content item" do

--- a/spec/presenters/private_content_item_presenter_spec.rb
+++ b/spec/presenters/private_content_item_presenter_spec.rb
@@ -23,14 +23,4 @@ describe PrivateContentItemPresenter do
   it "includes an update type" do
     expect(presenter.as_json["update_type"]).to eq("minor")
   end
-
-  context "with validation errors" do
-    let(:item) { build(:content_item, :with_blank_title).tap(&:valid?) }
-
-    it "includes details of any errors" do
-      json_hash = presenter.as_json
-      expect(json_hash).to have_key("errors")
-      expect(json_hash["errors"]).to eq({"title" => ["can't be blank"]})
-    end
-  end
 end


### PR DESCRIPTION
content-store returns the entity (the thing you sent it) as part of the response document, with an `errors` key mixed in. We don't have a use-case for this and we can't think of one, other than a stateless client (but we don't think this is a strong use case). If we need it, we can add it back in.

Aside:
This change makes some other work much simpler - https://github.com/alphagov/gds-api-adapters/pull/276