### PR TITLE
Allow the app to boot when rabbitmq is unavailable.

### DIFF
--- a/lib/queue_publisher.rb
+++ b/lib/queue_publisher.rb
@@ -5,9 +5,11 @@ class QueuePublisher
 
     @exchange_name = options.fetch(:exchange)
     @options = options.except(:exchange)
+  end
 
-    @connection = Bunny.new(@options)
-    @connection.start
+  def connection
+    establish_connection if @connection.nil?
+    @connection
   end
 
   def exchange
@@ -55,8 +57,13 @@ class QueuePublisher
     raise
   end
 
+  def establish_connection
+    @connection = Bunny.new(@options)
+    @connection.start
+  end
+
   def connect_to_exchange
-    @channel = @connection.create_channel
+    @channel = connection.create_channel
 
     # Enable publisher confirms, so we get acks back after publishes.
     @channel.confirm_select

--- a/spec/lib/queue_publisher_spec.rb
+++ b/spec/lib/queue_publisher_spec.rb
@@ -25,7 +25,16 @@ describe QueuePublisher do
         expect(Bunny).to receive(:new).with(options.except(:exchange)).and_return(mock_session)
         expect(mock_session).to receive(:start)
 
-        queue_publisher
+        queue_publisher.connection
+      end
+
+      it "does not raise an exception from the constructor if connecting to rabbitmq fails" do
+        # This is to ensure the application can still boot when rabbitmq is unavailable.
+        allow(Bunny).to receive(:new).and_raise(Bunny::TCPConnectionFailedForAllHosts)
+
+        expect {
+          queue_publisher
+        }.not_to raise_error
       end
 
       it "creates the channel and exchange" do


### PR DESCRIPTION
Change QueuePublisher to connect to rabbitmq on demand as opposed to in
the constructor. This means that the constructor won't raise an error
if rabbitmq is unavailable/unresponsive. Because this is called from an
initializer, if it raises an exception it will cause the application to
fail to boot.