### PR TITLE
Allow mongo db name to be set from ENV

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -1,7 +1,7 @@
 development:
   sessions:
     default:
-      database: content_store_development
+      database: <%= ENV['MONGO_DB_NAME'] || 'content_store_development' %>
       hosts:
         - localhost:27017
       options:


### PR DESCRIPTION
https://trello.com/c/9IjHVbeJ

to be able to run two instances of content-store in development, one as live and other as draft, we need to be able to switch to the respective database.

intention is to set MONGO_DB_NAME envvar with value as draft_content_store_development through govuk_setenv when running the draft-content-store instance.