### PR TITLE
Prepend log entries with DRAFT

### DIFF
--- a/config/initializers/prepend_draft_to_logs_in_development.rb
+++ b/config/initializers/prepend_draft_to_logs_in_development.rb
@@ -1,0 +1,3 @@
+if Rails.env.development? && ENV['DRAFT'] == 'true'
+  ContentStore::Application.config.log_tags = ["DRAFT"]
+end


### PR DESCRIPTION
https://trello.com/c/9IjHVbeJ

this will help distinguish between request for draft content and live content in development environment when content-store is running with DRAFT=true.

the initial thought was to write to a separate log file like: log/draft_development.log. i was able to get rails to start writing to that log in draft mode, but couldn't prevent it from writing to log/development.log. hence, resorted to this approach.