### PR TITLE
Use MONGODB_URI from ENV var to connect to mongodb

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -1,19 +1,18 @@
 development:
   sessions:
     default:
-      database: <%= ENV['MONGO_DB_NAME'] || 'content_store_development' %>
-      hosts:
-        - localhost:27017
+      # MONGODB_URI includes draft_content_store_development or content_store_development
+      # depending on whether we're running content store in draft mode or not.
+      uri: <%= ENV['MONGODB_URI'] || 'mongodb://localhost/content_store_development' %>
       options:
         write:
           w: 1
         read: primary
+
 test:
   sessions:
     default:
-      database: content_store_test
-      hosts:
-        - localhost:27017
+      uri: mongodb://localhost/content_store_test
       options:
         write:
           w: 1
@@ -22,3 +21,12 @@ test:
         # low amounts for fast failures.
         max_retries: 1
         retry_interval: 0
+
+production:
+  sessions:
+    default:
+      uri: <%= ENV['MONGODB_URI'] %>
+      options:
+        write:
+          w: majority
+        read: primary_preferred


### PR DESCRIPTION
### Pre-requisites

- [ ] make deployment repo changes mentioned on the Trello card
- [ ] [puppet changes](https://github.gds/gds/puppet/pull/2748)
- [ ] [stop uploading mongoid.yml from alphagov-deployment](https://github.gds/gds/alphagov-deployment/pull/888)

### Description

https://trello.com/c/2ZsPnGKo

moving towards the design of configuring stuff using only
ENV vars over file uploads through capistrano, as:

https://github.com/alphagov/router-api/pull/65

content-store already uses ENV vars for setting the db name
for draft-content-store, so this change does the same for
other db configs like content-store mongodb name and uri.

this will enable us to stop uploading mongoid.yml during deploy.