### PR TITLE
Add a rake task to validate content items in the database

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,8 @@ else
   gem 'gds-api-adapters', '~> 16.3.1'
 end
 
+gem 'govuk-content-schema-test-helpers', '1.2.0'
+
 group :development, :test do
   gem 'rspec-rails', '~> 3.0.2'
   gem 'database_cleaner', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
-    addressable (2.3.6)
+    addressable (2.3.8)
     airbrake (4.0.0)
       builder
       multi_json
@@ -60,9 +60,13 @@ GEM
       plek
       rack-cache
       rest-client (~> 1.6.3)
+    govuk-content-schema-test-helpers (1.2.0)
+      json-schema (~> 2.5.1)
     hike (1.2.3)
     i18n (0.6.11)
     json (1.8.1)
+    json-schema (2.5.1)
+      addressable (~> 2.3.7)
     kgio (2.9.2)
     link_header (0.0.8)
     logstash-event (1.1.5)
@@ -184,6 +188,7 @@ DEPENDENCIES
   database_cleaner (~> 1.2)
   factory_girl (~> 4.4.0)
   gds-api-adapters (~> 16.3.1)
+  govuk-content-schema-test-helpers (= 1.2.0)
   logstasher (= 0.5.0)
   mongoid (= 4.0.0)
   mongoid_rails_migrations (= 1.0.1)

--- a/lib/tasks/check_content_items_against_schema.rake
+++ b/lib/tasks/check_content_items_against_schema.rake
@@ -1,0 +1,52 @@
+desc """
+  Validate content items against their frontend schemas. Ignores formats without schemas.
+
+  Optionally supply a comma separated list of format names to check.
+
+  This assumes that govuk-content-schemas is in a sibling directory. Set
+  GOVUK_CONTENT_SCHEMAS_PATH to override with a custom path.
+"""
+task :check_content_items_against_schema, [:format_names] => :environment do |_task, args|
+  GovukContentSchemaTestHelpers.configure do |config|
+    config.schema_type = 'frontend'
+    config.project_root = Rails.root
+  end
+
+  formats_to_use = if args[:format_names].present?
+    args[:format_names].split(",")
+  else
+    # placeholder items can have a format of 'placeholder' or 'placeholder_my_format_name'.
+    # redirect doesn't have a frontend schema.
+    (GovukContentSchemaTestHelpers::Util.formats + [/\Aplaceholder_.+/]) - ['redirect']
+  end
+
+  validatable_content_items = ContentItem.where(:format.in => formats_to_use)
+  api_url_callable = lambda { |base_path| "http://api.example.com/content#{base_path}" }
+
+  invalid_content_items = []
+
+  puts "Validating #{validatable_content_items.count} content items"
+  validatable_content_items.order_by([:format, :asc], [:_id, :asc]).each do |content_item|
+    presenter = PublicContentItemPresenter.new(content_item, api_url_callable)
+    validator = GovukContentSchemaTestHelpers::Validator.new(content_item.format, presenter.to_json)
+    if validator.valid?
+      print "."
+    else
+      invalid_content_items << [content_item, validator.errors]
+      print "F"
+    end
+  end
+
+  puts ""
+
+  puts "Found #{invalid_content_items.size} invalid items"
+
+  puts ""
+
+  invalid_content_items.each do |content_item, errors|
+    puts "#{content_item.base_path} format: #{content_item.format} has errors:"
+    puts errors
+    puts ""
+    puts ""
+  end
+end


### PR DESCRIPTION
Example output:
```
$ bundle exec rake check_content_items_against_schema[case_study]
Validating 887 content items
....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................F.....F.F...........F..............................................................................................................................................................................................................................................................................................................................................................................................................
Found 4 invalid items

/government/case-studies/intellectual-property-bundlebean format: case_study has errors:
The property '#/details/image/caption' of type FalseClass did not match one or more of the required schemas. The schema specific errors were:

- anyOf #0:
    - The property '#/details/image/caption' of type FalseClass did not match the following type: string
- anyOf #1:
    - The property '#/details/image/caption' of type FalseClass did not match the following type: null


/government/case-studies/intellectual-property-kids-bee-happy format: case_study has errors:
The property '#/details/image/caption' of type FalseClass did not match one or more of the required schemas. The schema specific errors were:

- anyOf #0:
    - The property '#/details/image/caption' of type FalseClass did not match the following type: string
- anyOf #1:
    - The property '#/details/image/caption' of type FalseClass did not match the following type: null
```