### PR TITLE
Add separate GET route for the public API to use

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,9 @@ Rails.application.routes.draw do
 
   with_options :format => false do |r|
     r.with_options :constraints => {:base_path => %r[/.*]} do |path_routes|
+      # The /api/content route is used for requests via the public API
+      path_routes.get "/api/content*base_path" => "content_items#show", :as => :content_item_api
+
       path_routes.get "/content*base_path" => "content_items#show", :as => :content_item
       path_routes.put "/content*base_path" => "content_items#update"
 

--- a/spec/routing/content_item_routing_spec.rb
+++ b/spec/routing/content_item_routing_spec.rb
@@ -19,6 +19,24 @@ describe "routing of content_item requests", :type => :routing do
     end
   end
 
+  context "GET API route" do
+    it "should route to the controller passing on the base_path" do
+      expect(:get => "/api/content/foo/bar").to route_to({
+        :controller => "content_items",
+        :action => "show",
+        :base_path => "/foo/bar",
+      })
+    end
+
+    it "should not match a base_path without a leading /" do
+      expect(:get => "/api/contentfoo").not_to be_routable
+    end
+
+    it "should require a base_path" do
+      expect(:get => "/api/content").not_to be_routable
+    end
+  end
+
   context "PUT route" do
     it "should route to the controller passing on the base_path" do
       expect(:put => "/content/foo/bar").to route_to({
@@ -34,6 +52,20 @@ describe "routing of content_item requests", :type => :routing do
 
     it "should require a base_path" do
       expect(:put => "/content").not_to be_routable
+    end
+  end
+
+  context "PUT API route" do
+    it "should not route with a base_path" do
+      expect(:put => "/api/content/foo/bar").not_to be_routable
+    end
+
+    it "should not route a base_path without a leading /" do
+      expect(:put => "/api/contentfoo").not_to be_routable
+    end
+
+    it "should not route without a base_path" do
+      expect(:put => "/api/content").not_to be_routable
     end
   end
 end


### PR DESCRIPTION
I'm shortly planning to make the content-store "GET content" API public.  As
part of that, we'd like to be very sure that only GET requests will be routed
from the public API.

To help with this, this commit adds a route to handle GET requests to
`/api/content/foo`.  This route serves exactly the same content as
`/content/foo`, but only handles GET requests.

By pointing publicapi at this route, we get some defence-in-depth that only the
read-only part of the API is available.  We also make it easier to distinguish
requests which have come via the public API from those which come from other
internal apps in log files and in systems such as Kibana.