### PR TITLE
Make public_updated_at required for renderable content

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -49,6 +49,7 @@ class ContentItem
   validates :format, :update_type, format: { with: /\A[a-z0-9_]+\z/i, allow_blank: true }
   validates :title, presence: true, if: :renderable_content?
   validates :rendering_app, presence: true, format: /\A[a-z0-9-]*\z/,if: :renderable_content?
+  validates :public_updated_at, presence: true, if: :renderable_content?
   validate :route_set_is_valid
   validate :no_extra_route_keys
   validate :links_are_valid

--- a/spec/factories/content_item.rb
+++ b/spec/factories/content_item.rb
@@ -8,6 +8,7 @@ FactoryGirl.define do
     rendering_app 'frontend'
     update_type 'minor'
     routes { [{ 'path' => base_path, 'type' => 'exact' }] }
+    public_updated_at Time.now
 
     trait :with_content_id do
       content_id { SecureRandom.uuid }

--- a/spec/integration/end_to_end_spec.rb
+++ b/spec/integration/end_to_end_spec.rb
@@ -14,6 +14,7 @@ describe "End-to-end behaviour", :type => :request do
     "routes" => [
       { "path" => "/vat-rates", "type" => 'exact' }
     ],
+    "public_updated_at" => Time.now
   }}
 
   def create_item(data_hash)


### PR DESCRIPTION
This change only adds it for "renderable content" (anything but 'gone' and
'redirect' items) because there making Whitehall produce redirect items with a
(meaningful) public_updated_at is non-trivial.