### PR TITLE
Return public API URLs when from the public endpoint

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -10,7 +10,11 @@ class ContentItemsController < ApplicationController
     # The presenter needs context about routes and host names from controller
     # to know how to generate API URLs, so we can take the Rails helper and
     # pass that in as a callable
-    api_url_method = method(:content_item_url)
+    if params[:public_api_request]
+      api_url_method = method(:content_item_api_url)
+    else
+      api_url_method = method(:content_item_url)
+    end
     presenter = PublicContentItemPresenter.new(item, api_url_method)
 
     render :json => presenter

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   with_options :format => false do |r|
     r.with_options :constraints => {:base_path => %r[/.*]} do |path_routes|
       # The /api/content route is used for requests via the public API
-      path_routes.get "/api/content*base_path" => "content_items#show", :as => :content_item_api
+      path_routes.get "/api/content*base_path" => "content_items#show", :as => :content_item_api, :public_api_request => true
 
       path_routes.get "/content*base_path" => "content_items#show", :as => :content_item
       path_routes.put "/content*base_path" => "content_items#update"

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -94,6 +94,32 @@ describe "Fetching a content item", :type => :request do
     describe "expanding linked items" do
       # functional behaviour of link expansion covered in end_to_end_spec
 
+      describe "generating the API URL" do
+        let!(:linked_item) { create(:content_item, :with_content_id) }
+        before :each do
+          item.links["related"] = [linked_item.content_id]
+          item.save!
+        end
+
+        it "includes the API URL for linked items" do
+          get "/content#{item.base_path}"
+
+          expect(response.status).to eq(200)
+
+          data = JSON.parse(response.body)
+          expect(data["links"]["related"].first["api_url"]).to eq("http://www.example.com/content#{linked_item.base_path}")
+        end
+
+        it "includes the public API URL when requested through the public endpoint" do
+          get "/api/content#{item.base_path}"
+
+          expect(response.status).to eq(200)
+
+          data = JSON.parse(response.body)
+          expect(data["links"]["related"].first["api_url"]).to eq("http://www.example.com/api/content#{linked_item.base_path}")
+        end
+      end
+
       it "does not use N+1 queries to expand linked items" do
         item.links["related"] = []
         20.times do

--- a/spec/routing/content_item_routing_spec.rb
+++ b/spec/routing/content_item_routing_spec.rb
@@ -25,6 +25,7 @@ describe "routing of content_item requests", :type => :routing do
         :controller => "content_items",
         :action => "show",
         :base_path => "/foo/bar",
+        :public_api_request => true,
       })
     end
 


### PR DESCRIPTION
When requesting content items through the public API endpoint
(/api/content/foo), we want the API URLs returned in linked content
items to also use public API URLs.