### PR TITLE
Don't crash on related links containing hashes

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -182,7 +182,7 @@ private
 
     bad_values = links.values.reject { |value|
       value.is_a?(Array) && value.all? { |content_id|
-        UUIDValidator::UUID_PATTERN.match(content_id)
+        UUIDValidator.valid?(content_id)
       }
     }
     unless bad_values.empty?

--- a/app/validators/uuid_validator.rb
+++ b/app/validators/uuid_validator.rb
@@ -24,9 +24,13 @@ class UUIDValidator < ActiveModel::EachValidator
   }x
 
   def validate_each(record, attribute, value)
-    unless UUID_PATTERN.match(value)
+    unless self.class.valid?(value)
       message = options[:message] || "is not a canonical UUID"
       record.errors[attribute] << message
     end
+  end
+
+  def self.valid?(value)
+    value =~ UUID_PATTERN
   end
 end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -165,6 +165,12 @@ describe ContentItem, :type => :model do
           expect(@item).not_to be_valid
           expect(@item.errors[:links]).to eq(["must map to lists of UUIDs"])
         end
+
+        it 'rejects content IDs which are hashes' do
+          @item.links = {"related" => [{}]}
+          expect(@item).not_to be_valid
+          expect(@item.errors[:links]).to eq(["must map to lists of UUIDs"])
+        end
       end
     end
 


### PR DESCRIPTION
I tried to send a frontend example to the content store and the content
store crashed because the validation algorithm did not check whether the
content item is a string before comparing it to a regexp.

I've added a unit test for this scenario and refactored the validation
code to handle this case.

The change made is to use `#=~` rather than `Regexp#match`. Note that
`#=~` is defined on `Object` to always return false.