### PR TITLE
Upgrade govuk-content-schema-test-helpers to 1.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ else
   gem 'gds-api-adapters', '~> 16.3.1'
 end
 
-gem 'govuk-content-schema-test-helpers', '1.2.0'
+gem 'govuk-content-schema-test-helpers', '1.3.0'
 
 group :development, :test do
   gem 'rspec-rails', '~> 3.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,7 +60,7 @@ GEM
       plek
       rack-cache
       rest-client (~> 1.6.3)
-    govuk-content-schema-test-helpers (1.2.0)
+    govuk-content-schema-test-helpers (1.3.0)
       json-schema (~> 2.5.1)
     hike (1.2.3)
     i18n (0.6.11)
@@ -188,7 +188,7 @@ DEPENDENCIES
   database_cleaner (~> 1.2)
   factory_girl (~> 4.4.0)
   gds-api-adapters (~> 16.3.1)
-  govuk-content-schema-test-helpers (= 1.2.0)
+  govuk-content-schema-test-helpers (= 1.3.0)
   logstasher (= 0.5.0)
   mongoid (= 4.0.0)
   mongoid_rails_migrations (= 1.0.1)


### PR DESCRIPTION
We want to [change the directory structure inside govuk-content-schemas](https://github.com/alphagov/govuk-content-schemas/pull/60). The
test helpers encapsulate the directory structure, but we still need to bump the
gem to a version which works with the new (and old) structure.