### PR TITLE
Fix deprecation warning for default_ttl

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,7 +42,7 @@ module ContentStore
 
     # Caching
     config.cache_control_directive = 'public'
-    config.default_ttl = ENV.fetch('DEFAULT_TTL', 30.minutes).to_i
+    config.default_ttl = ENV.fetch('DEFAULT_TTL', 30.minutes).to_i.seconds
     config.minimum_ttl = [config.default_ttl, 5.seconds].min
 
     def router_api


### PR DESCRIPTION
When setting the cache headers, the controller calls
`config.default_ttl.from_now`.  This was triggering the following
deprecation warning because default_ttl is an integer, not an
ActiveSupport::Duration.

```
DEPRECATION WARNING: Calling #since or #from_now on a number (e.g.
5.since) is deprecated and will be removed in the future, use
5.seconds.since instead. (called from set_cache_headers at
/var/govuk/content-store/app/controllers/content_items_controller.rb:45)
```