### PR TITLE
Exclude all non-renderable formats from link expansion

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -38,7 +38,6 @@ class ContentItem
   field :links, :type => Hash, :default => {}
   attr_accessor :update_type
 
-  scope :excluding_redirects, ->{ where(:format.ne => "redirect") }
   scope :renderable_content, -> { where(:format.nin => NON_RENDERABLE_FORMATS) }
 
   validates :base_path, absolute_path: true
@@ -109,7 +108,7 @@ private
     # matching content_id in either this item's locale, or the default locale
     # with the most recently updated first.
     potential_items_by_id = ContentItem
-      .excluding_redirects
+      .renderable_content
       .where(:content_id => {"$in" => links.values.flatten.uniq})
       .where(:locale => {"$in" => [I18n.default_locale.to_s, self.locale].uniq})
       .only(:content_id, :locale, :base_path, :title)
@@ -136,7 +135,7 @@ private
   def load_available_translations
     return [self] if self.content_id.blank?
     ContentItem
-      .excluding_redirects
+      .renderable_content
       .where(:content_id => content_id)
       .only(:locale, :base_path, :title)
       .sort(:locale => 1, :updated_at => 1)

--- a/spec/factories/content_item.rb
+++ b/spec/factories/content_item.rb
@@ -1,14 +1,13 @@
 FactoryGirl.define do
 
-  factory :content_item do
+  # Base factory not intended to be used directly.  Present to contain common
+  # attributes and traits
+  factory :base_content_item, :class => ContentItem do
     sequence(:base_path) {|n| "/test-content-#{n}" }
-    format "answer"
-    title "Test content"
+    format 'gone' # Using gone as it allows the smallest valid base
     publishing_app 'publisher'
-    rendering_app 'frontend'
     update_type 'minor'
     routes { [{ 'path' => base_path, 'type' => 'exact' }] }
-    public_updated_at Time.now
 
     trait :with_content_id do
       content_id { SecureRandom.uuid }
@@ -17,21 +16,24 @@ FactoryGirl.define do
     trait :with_blank_title do
       title ""
     end
-  end
 
-  factory :redirect_content_item, :class => ContentItem do
-    sequence(:base_path) {|n| "/test-redirect-#{n}" }
-    format "redirect"
-    publishing_app 'publisher'
-    update_type 'minor'
-    redirects { [{ 'path' => base_path, 'type' => 'exact', 'destination' => '/somewhere' }] }
-  end
+    factory :content_item do
+      format "answer"
+      title "Test content"
+      rendering_app 'frontend'
+      public_updated_at Time.now
+    end
 
-  factory :gone_content_item, :class => ContentItem do
-    sequence(:base_path) {|n| "/dodo-sanctuary-#{n}" }
-    format "gone"
-    publishing_app 'publisher'
-    update_type 'minor'
-    routes { [{ 'path' => base_path, 'type' => 'exact' }] }
+    factory :redirect_content_item do
+      sequence(:base_path) {|n| "/test-redirect-#{n}" }
+      format "redirect"
+      routes []
+      redirects { [{ 'path' => base_path, 'type' => 'exact', 'destination' => '/somewhere' }] }
+    end
+
+    factory :gone_content_item do
+      sequence(:base_path) {|n| "/dodo-sanctuary-#{n}" }
+      format "gone"
+    end
   end
 end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -498,6 +498,16 @@ describe ContentItem, :type => :model do
       end
     end
 
+    context 'with non-renderable linked items' do
+      let(:redirect) { create(:redirect_content_item, :with_content_id) }
+      let(:gone) { create(:gone_content_item, :with_content_id) }
+      let(:item) { build(:content_item, :links => {"related" => [redirect.content_id, gone.content_id]}) }
+
+      it 'excludes the non-renderable items' do
+        expect(item.linked_items["related"]).to eq([])
+      end
+    end
+
     context 'with multiple published items' do
       before :each do
         shared_content_id = SecureRandom.uuid


### PR DESCRIPTION
Presently, this only excludes redirects.  This edge case is unlikely to
be an issue at the moment because we're unlikely to have any gone items
with content ids, but it's good to make this correct.