### PR TITLE
Include description in linked item expansion

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -111,7 +111,7 @@ private
       .renderable_content
       .where(:content_id => {"$in" => links.values.flatten.uniq})
       .where(:locale => {"$in" => [I18n.default_locale.to_s, self.locale].uniq})
-      .only(:content_id, :locale, :base_path, :title)
+      .only(:content_id, :locale, :base_path, :title, :description)
       .sort(:updated_at => -1)
       .group_by(&:content_id)
 
@@ -137,7 +137,7 @@ private
     ContentItem
       .renderable_content
       .where(:content_id => content_id)
-      .only(:locale, :base_path, :title)
+      .only(:locale, :base_path, :title, :description)
       .sort(:locale => 1, :updated_at => 1)
       .group_by(&:locale)
       .map { |locale, items| items.last }

--- a/app/presenters/public_content_item_presenter.rb
+++ b/app/presenters/public_content_item_presenter.rb
@@ -29,6 +29,7 @@ private
     {
       "title" => linked_item.title,
       "base_path" => linked_item.base_path,
+      "description" => linked_item.description,
       "api_url" => api_url(linked_item),
       "web_url" => web_url(linked_item),
       "locale" => linked_item.locale,

--- a/spec/presenters/public_content_item_presenter_spec.rb
+++ b/spec/presenters/public_content_item_presenter_spec.rb
@@ -37,8 +37,8 @@ describe PublicContentItemPresenter do
       expect(related.size).to be(2)
     end
 
-    it "includes the path and title for each item" do
-      expect(related).to all include("base_path", "title")
+    it "includes the path, title and description for each item" do
+      expect(related).to all include("base_path", "title", "description")
     end
 
     it "includes the locale for each item" do


### PR DESCRIPTION
This is necessary to allow the rendering of mainstream browse pages (eg
https://www.gov.uk/browse/benefits) from the content-store.

This field has already been added to the schemas in
https://github.com/alphagov/govuk-content-schemas/pull/69