### PR TITLE
Allow regular content items to include redirects.

### DIFF
--- a/app/models/registerable_route_set.rb
+++ b/app/models/registerable_route_set.rb
@@ -75,6 +75,7 @@ class RegisterableRouteSet < OpenStruct
     else
       register_rendering_app
       registerable_routes.each { |route| route.register!(rendering_app) }
+      registerable_redirects.map(&:register!)
     end
     commit_routes
   end
@@ -131,7 +132,7 @@ private
       errors[:registerable_routes] << 'must have unique paths'
     end
 
-    paths = registerable_redirects.map(&:path)
+    paths += registerable_redirects.map(&:path)
     unless paths == paths.uniq
       errors[:registerable_redirects] << 'must have unique paths'
     end

--- a/doc/content_item_fields.md
+++ b/doc/content_item_fields.md
@@ -233,13 +233,11 @@ contains a path and a routing type. See
 An array of hashes. Present only in storing context.
 
 The redirects from old paths associated with the content item. Each hash in the
-array contains an original path, a routing type, and an optional destination
-path. See [`route_registration`](route_registration.md) for
-more details.
+array contains an original path, a routing type, and a destination path. See
+[`route_registration`](route_registration.md) for more details.
 
-TODO: Currently, redirects for normal content can be registered with the
-content item itself. We need to decide if this is what we want, or whether
-redirects are only included in `redirect` content items.
+For redirect content items, the behaviour is slightly different.  See
+redirect_item.md for details.
 
 ## `update_type`
 

--- a/doc/route_registration.md
+++ b/doc/route_registration.md
@@ -8,7 +8,7 @@ All items listed in the routes array will be created as routes pointing at the
 All entries in the routes array must be under the `base_path` (ie either a
 subpath of the `base_path`, or the `base_path` with an extension)
 
-Given the following request:
+Given a request including the following fields:
 
     PUT /content/foo
     {
@@ -41,16 +41,15 @@ cases where the structure within a piece of content has changed (eg a part of a 
 **Note:** it is invalid for the redirects array to include the base_path.  The only exception is redirect items,
 which are described in redirect_item.md.
 
-Redirects are specified in the redirects array.  These optionally specify a destination path, which if
-ommitted defaults to the base_path.
+Redirects are specified in the redirects array, and specify a destination as well as a path and type.
 
-e.g. given the following request:
+e.g. given a request including the following fields:
 
     PUT /content/foo
     {
       "redirects": [
         {"path": "/foo.json", "type": "exact", "destination": "/api/foo.json"},
-        {"path": "/foo/obsolete-part", "type": "exact"}
+        {"path": "/foo/obsolete-part", "type": "exact", "destination": "/foo"}
       ]
     }
 

--- a/spec/factories/registerable_routes.rb
+++ b/spec/factories/registerable_routes.rb
@@ -7,7 +7,7 @@ FactoryGirl.define do
     type "prefix"
   end
 
-  factory :registerable_gone_route, parent: :registerable_route do
+  factory :registerable_gone_route, parent: :registerable_route, class: RegisterableGoneRoute do
   end
 
   factory :registerable_redirect do

--- a/spec/integration/submitting_content_item_spec.rb
+++ b/spec/integration/submitting_content_item_spec.rb
@@ -82,7 +82,7 @@ describe "content item write API", :type => :request do
     end
   end
 
-  context 'updating an existing content item' do
+  describe 'updating an existing content item' do
     before(:each) do
       Timecop.travel(30.minutes.ago) do
         @item = create(:content_item,
@@ -114,6 +114,20 @@ describe "content item write API", :type => :request do
     it "updates routes for the content item" do
       put_json "/content/vat-rates", @data
       assert_routes_registered("frontend", [['/vat-rates', 'exact']])
+    end
+  end
+
+  describe "creating a content item with both routes and redirects" do
+    before :each do
+      @data["redirects"] = [
+        {"path" => "/vat-rates.json", "type" => "exact", "destination" => "/api/content/vat-rates"}
+      ]
+    end
+
+    it "registeres the routes and the redirects" do
+      put_json "/content/vat-rates", @data
+      assert_routes_registered("frontend", [['/vat-rates', 'exact']])
+      assert_redirect_routes_registered([['/vat-rates.json', 'exact', '/api/content/vat-rates']])
     end
   end
 


### PR DESCRIPTION
There are cases where a content item needs to provide both routes and
redirects. Most mainstream content provides a `.json` route that serves a
redirect to the public api endpoint (currently handled by the frontend
app). Multi-part content will need to support re-slugged/removed parts
by redirecting to an appropriate alternative part.

This adds support for providing redirects along with routes to
facilitate this.