### PR TITLE
Handling for access-limited content

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,24 @@ To retrieve content from the content store, make a GET request:
 
 Examples of the JSON representation of content items can be found in [doc/output_examples](doc/output_examples).
 
+## Access-limited content items
+
+Retrieving an access-limited content item from the content store requires that
+an additional authentication header be provided:
+
+``` sh
+  curl -header "X-Govuk-Authenticated-User: f17150b0-7540-0131-f036-0050560123202" \
+    https://content-store.production.alphagov.co.uk/content<base_path>
+
+```
+
+If the supplied identifier is in the list of authorised users, the content item
+will be returned. If not, a 403 (Forbidden) response will be returned. For more
+details on how to create an access-limited content item, see
+[doc/content_item_fields.md#access_limited](doc/content_item_fields.md#access_limited)
+
+Note: the access-limiting behaviour should only be active on the draft stack.
+
 ## Post publishing/update notifications
 
 After a content item is added or updated, a message is published to RabbitMQ.

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 The central storage of *published* content on GOV.UK.
 
-The content store maps public-facing URLs to published items of content, represented
-as JSON data. It will replace [content API](https://github.com/alphagov/govuk_content_api)
+The content store maps public-facing URLs to published items of content,
+represented as JSON data. It will replace [content API](https://github.com/alphagov/govuk_content_api)
 in time.
 
-Publishing applications add content to the content store; public-facing
-applications read content from the content store and render them on GOV.UK.
+Publishing applications add content to the content store via the Publishing API;
+public-facing applications read content from the content store and render them
+on GOV.UK.
 
 ## Content items
 
@@ -19,8 +20,8 @@ representations and the meanings of the individual fields can be found in
 ## Writing content items to the content store
 
 Publishing applications will "publish" content on GOV.UK by sending them to
-the content store. To add or update a piece of content in the content store, make a PUT
-request:
+the content store. To add or update a piece of content in the content store,
+make a PUT request:
 
 ``` sh
 curl https://content-store.production.alphagov.co.uk/content<base_path> -X PUT \
@@ -49,8 +50,10 @@ Examples of the JSON representation of content items can be found in [doc/output
 
 ## Access-limited content items
 
-Retrieving an access-limited content item from the content store requires that
-an additional authentication header be provided:
+Some content can be marked as [access-limited](doc/content_item_fields.md#access_limited).
+This content can only be retrieved from the content store with the right
+authorisation. Authentication details can be provided with a GET request to
+identify an authenticated user:
 
 ``` sh
   curl -header "X-Govuk-Authenticated-User: f17150b0-7540-0131-f036-0050560123202" \
@@ -117,7 +120,7 @@ to accept draft content sent to publishing-api. You can:
   bowl draft-content-store
 ```
 
-from the development directory to run the content-store application
-at `draft-content-store.dev.gov.uk`. This instance stores data in a
-separate database: 'draft_content_store_development', and logs to
-the same rails log file as content-store, with a tag [DRAFT].
+from the development directory to run the content-store application at
+`draft-content-store.dev.gov.uk`. This instance stores data in a separate
+database: 'draft_content_store_development', and logs to the same rails log file
+as content-store, with a tag [DRAFT].

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -7,17 +7,21 @@ class ContentItemsController < ApplicationController
       ContentItem.find_by(:base_path => encoded_base_path)
     end
 
-    # The presenter needs context about routes and host names from controller
-    # to know how to generate API URLs, so we can take the Rails helper and
-    # pass that in as a callable
-    if params[:public_api_request]
-      api_url_method = method(:content_item_api_url)
-    else
-      api_url_method = method(:content_item_url)
-    end
-    presenter = PublicContentItemPresenter.new(item, api_url_method)
+    if item.viewable_by?(authenticated_user_id)
+      # The presenter needs context about routes and host names from controller
+      # to know how to generate API URLs, so we can take the Rails helper and
+      # pass that in as a callable
+      if params[:public_api_request]
+        api_url_method = method(:content_item_api_url)
+      else
+        api_url_method = method(:content_item_url)
+      end
+      presenter = PublicContentItemPresenter.new(item, api_url_method)
 
-    render :json => presenter
+      render :json => presenter
+    else
+      render forbidden_json_response
+    end
   end
 
   def update
@@ -36,6 +40,14 @@ class ContentItemsController < ApplicationController
   end
 
   private
+
+  def authenticated_user_id
+    request.headers['X-Govuk-Authenticated-User']
+  end
+
+  def forbidden_json_response
+    { :json => { :errors => { base: "Unauthorised" } }, status: 403 }
+  end
 
   def set_cache_headers
     intent = PublishIntent.where(:base_path => encoded_base_path).first

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -10,7 +10,7 @@ class ContentItemsController < ApplicationController
     if item.viewable_by?(authenticated_user_id)
       render :json => PublicContentItemPresenter.new(item, api_url_method)
     else
-      render forbidden_json_response
+      render :json => { }, status: 403
     end
   end
 
@@ -33,10 +33,6 @@ class ContentItemsController < ApplicationController
 
   def authenticated_user_id
     request.headers['X-Govuk-Authenticated-User']
-  end
-
-  def forbidden_json_response
-    { :json => { :errors => { base: "Unauthorised" } }, status: 403 }
   end
 
   # The presenter needs context about routes and host names from controller

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -8,6 +8,7 @@ class ContentItemsController < ApplicationController
     end
 
     if item.viewable_by?(authenticated_user_uid)
+      set_cache_control_private if item.access_limited?
       render :json => PublicContentItemPresenter.new(item, api_url_method)
     else
       render json_forbidden_response
@@ -66,6 +67,10 @@ class ContentItemsController < ApplicationController
     else
       expires_at config.default_ttl.from_now
     end
+  end
+
+  def set_cache_control_private
+    response.headers['Cache-Control'] = 'private'
   end
 
   # Calculate the TTL based on the publish_time but constrained to be within

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -8,17 +8,7 @@ class ContentItemsController < ApplicationController
     end
 
     if item.viewable_by?(authenticated_user_id)
-      # The presenter needs context about routes and host names from controller
-      # to know how to generate API URLs, so we can take the Rails helper and
-      # pass that in as a callable
-      if params[:public_api_request]
-        api_url_method = method(:content_item_api_url)
-      else
-        api_url_method = method(:content_item_url)
-      end
-      presenter = PublicContentItemPresenter.new(item, api_url_method)
-
-      render :json => presenter
+      render :json => PublicContentItemPresenter.new(item, api_url_method)
     else
       render forbidden_json_response
     end
@@ -47,6 +37,17 @@ class ContentItemsController < ApplicationController
 
   def forbidden_json_response
     { :json => { :errors => { base: "Unauthorised" } }, status: 403 }
+  end
+
+  # The presenter needs context about routes and host names from controller
+  # to know how to generate API URLs, so we can take the Rails helper and
+  # pass that in as a callable
+  def api_url_method
+    if params[:public_api_request]
+      method(:content_item_api_url)
+    else
+      method(:content_item_url)
+    end
   end
 
   def set_cache_headers

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -7,7 +7,7 @@ class ContentItemsController < ApplicationController
       ContentItem.find_by(:base_path => encoded_base_path)
     end
 
-    if item.viewable_by?(authenticated_user_id)
+    if item.viewable_by?(authenticated_user_uid)
       render :json => PublicContentItemPresenter.new(item, api_url_method)
     else
       render json_forbidden_response
@@ -31,7 +31,7 @@ class ContentItemsController < ApplicationController
 
   private
 
-  def authenticated_user_id
+  def authenticated_user_uid
     request.headers['X-Govuk-Authenticated-User']
   end
 

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -10,7 +10,7 @@ class ContentItemsController < ApplicationController
     if item.viewable_by?(authenticated_user_id)
       render :json => PublicContentItemPresenter.new(item, api_url_method)
     else
-      render :json => { }, status: 403
+      render json_forbidden_response
     end
   end
 
@@ -33,6 +33,19 @@ class ContentItemsController < ApplicationController
 
   def authenticated_user_id
     request.headers['X-Govuk-Authenticated-User']
+  end
+
+  def json_forbidden_response
+    {
+      :json => {
+        :errors => {
+          :type => "access_forbidden",
+          :code => "403",
+          :message => "You do not have permission to access this resource",
+        }
+      },
+      status: 403
+    }
   end
 
   # The presenter needs context about routes and host names from controller

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -36,6 +36,7 @@ class ContentItem
   field :routes, :type => Array, :default => []
   field :redirects, :type => Array, :default => []
   field :links, :type => Hash, :default => {}
+  field :access_limited, :type => Hash, :default => {}
   attr_accessor :update_type
 
   scope :renderable_content, -> { where(:format.nin => NON_RENDERABLE_FORMATS) }
@@ -99,6 +100,10 @@ class ContentItem
     items = load_linked_items
     items["available_translations"] = available_translations if available_translations.any?
     items
+  end
+
+  def viewable_by?(user_id)
+    !access_limited? || access_limited['users'].include?(user_id)
   end
 
 private

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -103,13 +103,13 @@ class ContentItem
     items
   end
 
-  def viewable_by?(user_id)
-    !access_limited? || authorised_user_ids.include?(user_id)
+  def viewable_by?(user_uid)
+    !access_limited? || authorised_user_uids.include?(user_uid)
   end
 
 private
 
-  def authorised_user_ids
+  def authorised_user_uids
     access_limited['users']
   end
 
@@ -175,7 +175,7 @@ private
   end
 
   def access_limited_values_valid?
-    authorised_user_ids.is_a?(Array) && authorised_user_ids.all? { |id| id.is_a?(String) }
+    authorised_user_uids.is_a?(Array) && authorised_user_uids.all? { |id| id.is_a?(String) }
   end
 
   def no_extra_route_keys

--- a/doc/content_item_fields.md
+++ b/doc/content_item_fields.md
@@ -265,13 +265,13 @@ the expected format is as follows:
 
 ```
     "access_limited": {
-      "users": ['USER-ID', 'ANOTHER-USER-ID']
+      "users": ['USER-UID', 'ANOTHER-USER-UID']
     }
 ```
 
 A content item with the above fields would be treated as access-limited, and
-only the users with IDs 'USER-ID' and 'ANOTHER-USER-ID' would be authorised to
-view it.
+only the users with UIDs 'USER-UID' and 'ANOTHER-USER-UID' would be authorised
+to view it.
 
 If `access_limited` is not present, or is an empty hash, the item will be
 treated as publicly visible.

--- a/doc/content_item_fields.md
+++ b/doc/content_item_fields.md
@@ -254,3 +254,24 @@ It must be one of:
 
 Other types may be added in future, the content store will just pass them through
 to the fanout.
+
+## `access_limited`
+
+A hash. Present in the storing and notifying context.
+
+This is an optional field that is used to identify access-limited content. It
+should identify the specific users that are authorised to view it. If present,
+the expected format is as follows:
+
+```
+    "access_limited": {
+      "users": ['USER-ID', 'ANOTHER-USER-ID']
+    }
+```
+
+A content item with the above fields would be treated as access-limited, and
+only the users with IDs 'USER-ID' and 'ANOTHER-USER-ID' would be authorised to
+view it.
+
+If `access_limited` is not present, or is an empty hash, the item will be
+treated as publicly visible.

--- a/spec/factories/content_item.rb
+++ b/spec/factories/content_item.rb
@@ -35,5 +35,12 @@ FactoryGirl.define do
       sequence(:base_path) {|n| "/dodo-sanctuary-#{n}" }
       format "gone"
     end
+
+    factory :access_limited_content_item do
+      sequence(:base_path) {|n| "/access-limited-#{n}" }
+      access_limited {
+        { "users" => [ "M6GdNZggrbGiJrLjMSbKqA", "f17250b0-7540-0131-f036-005056030202"] }
+      }
+    end
   end
 end

--- a/spec/integration/access_limited_spec.rb
+++ b/spec/integration/access_limited_spec.rb
@@ -13,7 +13,7 @@ describe "Fetching an access-limited content item", :type => :request do
       expect(response.status).to eq(403)
       data = JSON.parse(response.body)
 
-      expect(data['errors']).to eq({ 'base' => 'Unauthorised' })
+      expect(response.body).to eq("{}")
     end
   end
 

--- a/spec/integration/access_limited_spec.rb
+++ b/spec/integration/access_limited_spec.rb
@@ -5,11 +5,14 @@ describe "Fetching an access-limited content item", :type => :request do
   let(:authorised_user_id) { access_limited_content_item.access_limited['users'].first }
 
   context "request without an authentication header" do
-    it "returns an 403 (Forbidden) response" do
+    it "returns a 403 (Forbidden) response" do
       get "content/#{access_limited_content_item.base_path}"
 
+      json = JSON.parse(response.body)
+
       expect(response.status).to eq(403)
-      expect(response.body).to eq("{}")
+      expect(json["errors"]["type"]).to eq("access_forbidden")
+      expect(json["errors"]["code"]).to eq("403")
     end
   end
 
@@ -27,12 +30,15 @@ describe "Fetching an access-limited content item", :type => :request do
   end
 
   context "request with an unauthorised user ID specified in the header" do
-    it "returns an 403 (Forbidden) response" do
+    it "returns a 403 (Forbidden) response" do
       get "content/#{access_limited_content_item.base_path}",
         {}, { 'X-Govuk-Authenticated-User' => 'unauthorised-user' }
 
+      json = JSON.parse(response.body)
+
       expect(response.status).to eq(403)
-      expect(response.body).to eq("{}")
+      expect(json["errors"]["type"]).to eq("access_forbidden")
+      expect(json["errors"]["code"]).to eq("403")
     end
   end
 end

--- a/spec/integration/access_limited_spec.rb
+++ b/spec/integration/access_limited_spec.rb
@@ -17,15 +17,21 @@ describe "Fetching an access-limited content item", :type => :request do
   end
 
   context "request with an authorised user ID specified in the header" do
-    it "returns the details for the requested item" do
+    before do
       get "/content/#{access_limited_content_item.base_path}",
         {}, { 'X-Govuk-Authenticated-User' => authorised_user_uid }
+    end
 
+    it "returns the details for the requested item" do
       expect(response.status).to eq(200)
       expect(response.content_type).to eq("application/json")
 
       data = JSON.parse(response.body)
       expect(data['title']).to eq(access_limited_content_item.title)
+    end
+
+    it "marks the cache-control as private" do
+      expect(response.headers["Cache-Control"]).to eq('private')
     end
   end
 

--- a/spec/integration/access_limited_spec.rb
+++ b/spec/integration/access_limited_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe "Fetching an access-limited content item", :type => :request do
+  let!(:access_limited_content_item) {
+    create(:access_limited_content_item)
+  }
+  let(:authorised_user_id) { access_limited_content_item.access_limited['users'].first }
+
+  context "request without an authentication header" do
+    it "returns an 403 (Forbidden) response" do
+      get "content/#{access_limited_content_item.base_path}"
+
+      expect(response.status).to eq(403)
+      data = JSON.parse(response.body)
+
+      expect(data['errors']).to eq({ 'base' => 'Unauthorised' })
+    end
+  end
+
+  context "request with an authorised user id specified in the header" do
+    it "returns the details for the requested item" do
+      get "/content/#{access_limited_content_item.base_path}",
+        {}, { 'X-Govuk-Authenticated-User' => authorised_user_id }
+
+      expect(response.status).to eq(200)
+      expect(response.content_type).to eq("application/json")
+
+      data = JSON.parse(response.body)
+      expect(data['title']).to eq(access_limited_content_item.title)
+    end
+  end
+end

--- a/spec/integration/access_limited_spec.rb
+++ b/spec/integration/access_limited_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe "Fetching an access-limited content item", :type => :request do
   let(:access_limited_content_item) { create(:access_limited_content_item) }
-  let(:authorised_user_id) { access_limited_content_item.access_limited['users'].first }
+  let(:authorised_user_uid) { access_limited_content_item.access_limited['users'].first }
 
   context "request without an authentication header" do
     it "returns a 403 (Forbidden) response" do
@@ -19,7 +19,7 @@ describe "Fetching an access-limited content item", :type => :request do
   context "request with an authorised user ID specified in the header" do
     it "returns the details for the requested item" do
       get "/content/#{access_limited_content_item.base_path}",
-        {}, { 'X-Govuk-Authenticated-User' => authorised_user_id }
+        {}, { 'X-Govuk-Authenticated-User' => authorised_user_uid }
 
       expect(response.status).to eq(200)
       expect(response.content_type).to eq("application/json")

--- a/spec/integration/access_limited_spec.rb
+++ b/spec/integration/access_limited_spec.rb
@@ -1,9 +1,7 @@
 require 'rails_helper'
 
 describe "Fetching an access-limited content item", :type => :request do
-  let!(:access_limited_content_item) {
-    create(:access_limited_content_item)
-  }
+  let(:access_limited_content_item) { create(:access_limited_content_item) }
   let(:authorised_user_id) { access_limited_content_item.access_limited['users'].first }
 
   context "request without an authentication header" do
@@ -11,13 +9,11 @@ describe "Fetching an access-limited content item", :type => :request do
       get "content/#{access_limited_content_item.base_path}"
 
       expect(response.status).to eq(403)
-      data = JSON.parse(response.body)
-
       expect(response.body).to eq("{}")
     end
   end
 
-  context "request with an authorised user id specified in the header" do
+  context "request with an authorised user ID specified in the header" do
     it "returns the details for the requested item" do
       get "/content/#{access_limited_content_item.base_path}",
         {}, { 'X-Govuk-Authenticated-User' => authorised_user_id }
@@ -30,14 +26,12 @@ describe "Fetching an access-limited content item", :type => :request do
     end
   end
 
-  context "request with an unauthorised user id specified in the header" do
+  context "request with an unauthorised user ID specified in the header" do
     it "returns an 403 (Forbidden) response" do
       get "content/#{access_limited_content_item.base_path}",
         {}, { 'X-Govuk-Authenticated-User' => 'unauthorised-user' }
 
       expect(response.status).to eq(403)
-      data = JSON.parse(response.body)
-
       expect(response.body).to eq("{}")
     end
   end

--- a/spec/integration/access_limited_spec.rb
+++ b/spec/integration/access_limited_spec.rb
@@ -29,4 +29,16 @@ describe "Fetching an access-limited content item", :type => :request do
       expect(data['title']).to eq(access_limited_content_item.title)
     end
   end
+
+  context "request with an unauthorised user id specified in the header" do
+    it "returns an 403 (Forbidden) response" do
+      get "content/#{access_limited_content_item.base_path}",
+        {}, { 'X-Govuk-Authenticated-User' => 'unauthorised-user' }
+
+      expect(response.status).to eq(403)
+      data = JSON.parse(response.body)
+
+      expect(response.body).to eq("{}")
+    end
+  end
 end

--- a/spec/integration/submitting_content_item_spec.rb
+++ b/spec/integration/submitting_content_item_spec.rb
@@ -131,6 +131,27 @@ describe "content item write API", :type => :request do
     end
   end
 
+  describe "creating an access-limited content item" do
+    let(:authorised_users) { ['a-user-identifier', 'another-user-identifier'] }
+    before :each do
+      @data["access_limited"] = {
+        "users" => authorised_users
+      }
+      put_json "/content/vat-rates", @data
+    end
+
+    it "saves the access-limiting details" do
+      item = ContentItem.where(:base_path => "/vat-rates").first
+      expect(item).to be
+      expect(item.access_limited).to eq("users" => authorised_users)
+    end
+
+    it "responds with CREATED and an empty JSON response" do
+      expect(response.status).to eq(201)
+      expect(response.body).to eq('{}')
+    end
+  end
+
   context "given invalid JSON data" do
     before(:each) do
       put "/content/foo", "I'm not json", "CONTENT_TYPE" => "application/json"

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -621,5 +621,39 @@ describe ContentItem, :type => :model do
         end
       end
     end
+
+
+    describe 'access limiting' do
+      context 'a content item that is not access limited' do
+        let!(:content_item) { create(:content_item) }
+
+        it 'is not access limited' do
+          expect(content_item.access_limited?).to be(false)
+        end
+
+        it 'is viewable by all' do
+          expect(content_item.viewable_by?(nil)).to be(true)
+          expect(content_item.viewable_by?('a-user-id')).to be(true)
+        end
+      end
+
+      context 'an access-limited content item' do
+        let!(:content_item) { create(:access_limited_content_item) }
+        let(:authorised_user_id) { content_item.access_limited['users'].first }
+
+        it 'is access limited' do
+          expect(content_item.access_limited?).to be(true)
+        end
+
+        it 'is viewable by an authorised user' do
+          expect(content_item.viewable_by?(authorised_user_id)).to be(true)
+        end
+
+        it 'is not viewable by an unauthorised user' do
+          expect(content_item.viewable_by?('unauthorised-user')).to be(false)
+          expect(content_item.viewable_by?(nil)).to be(false)
+        end
+      end
+    end
   end
 end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -624,7 +624,6 @@ describe ContentItem, :type => :model do
 
 
     describe 'access limiting' do
-
       it "validates the format of the access_limited hash" do
         content_item = build(:content_item, access_limited: { 'bad-key' => []})
         expect(content_item).not_to be_valid

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -641,20 +641,20 @@ describe ContentItem, :type => :model do
 
         it 'is viewable by all' do
           expect(content_item.viewable_by?(nil)).to be(true)
-          expect(content_item.viewable_by?('a-user-id')).to be(true)
+          expect(content_item.viewable_by?('a-user-uid')).to be(true)
         end
       end
 
       context 'an access-limited content item' do
         let!(:content_item) { create(:access_limited_content_item) }
-        let(:authorised_user_id) { content_item.access_limited['users'].first }
+        let(:authorised_user_uid) { content_item.access_limited['users'].first }
 
         it 'is access limited' do
           expect(content_item.access_limited?).to be(true)
         end
 
         it 'is viewable by an authorised user' do
-          expect(content_item.viewable_by?(authorised_user_id)).to be(true)
+          expect(content_item.viewable_by?(authorised_user_uid)).to be(true)
         end
 
         it 'is not viewable by an unauthorised user' do

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -624,6 +624,15 @@ describe ContentItem, :type => :model do
 
 
     describe 'access limiting' do
+
+      it "validates the format of the access_limited hash" do
+        content_item = build(:content_item, access_limited: { 'bad-key' => []})
+        expect(content_item).not_to be_valid
+
+        content_item = build(:content_item, access_limited: { 'users' => { 'other' => 'stuff'}})
+        expect(content_item).not_to be_valid
+      end
+
       context 'a content item that is not access limited' do
         let!(:content_item) { create(:content_item) }
 


### PR DESCRIPTION
This adds support for access-limited content items in the content-store.

Content items can be marked as access-limited by including the following meta-data:

 ```JSON
    "access_limited": {
      "users": ['user-signon-uid', 'another-user-signor-uid']
    }
```

Such items will only be returned to frontend applications if appropriate authentication is provided. For example:

```sh
  curl -header "X-Govuk-Authenticated-User: user-signon-uid" \
    https://content-store.production.alphagov.co.uk/content/government/publications/access-limited
```

Non-authorised requests will receive a 403 response.

This will be used to control access to access-limited content in the draft stack.

Trello: https://trello.com/c/fc77YcqN/173-content-store-enforces-access-limiting-if-present