### PR TITLE
Don't send access_limited items on queue.

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -218,7 +218,7 @@ private
   end
 
   def send_message
-    Rails.application.queue_publisher.send_message(self)
+    Rails.application.queue_publisher.send_message(self) unless access_limited?
   end
 
   def renderable_content?

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -211,6 +211,20 @@ describe ContentItem, :type => :model do
       end
     end
 
+    context "queue publishing" do
+      it "sends the item on the message queue" do
+        expect(Rails.application.queue_publisher).to receive(:send_message)
+        item = build(:content_item)
+        item.upsert
+      end
+
+      it "does not send the item on the message queue for access_limited items" do
+        expect(Rails.application.queue_publisher).to_not receive(:send_message)
+        item = build(:access_limited_content_item)
+        item.upsert
+      end
+    end
+
     context 'fields used in message queue routing key' do
       [
         "format",


### PR DESCRIPTION
As items that are explicitly access limited are only intended for viewing by the listed individuals, and we aren't currently enforcing access limiting anywhere else, they should not be sent on the message queue.