### PR TITLE
Fix field overwrite warnings

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -22,7 +22,7 @@ class ContentItem
     return false, item
   end
 
-  field :_id, :as => :base_path, :type => String
+  field :_id, :as => :base_path, :type => String, :overwrite => true
   field :content_id, :type => String
   field :title, :type => String
   field :description, :type => String

--- a/app/models/publish_intent.rb
+++ b/app/models/publish_intent.rb
@@ -19,7 +19,7 @@ class PublishIntent
 
   PUBLISH_TIME_LEEWAY = 1.minute
 
-  field :_id, :as => :base_path, :type => String
+  field :_id, :as => :base_path, :type => String, :overwrite => true
   field :publish_time, :type => DateTime
   field :publishing_app, :type => String
   field :rendering_app, :type => String


### PR DESCRIPTION
Currently the following is being logged regularly in production:

```
Overwriting existing field _id in class ContentItem.
```

This is a warning generated by Mongoid when you define a field that's
already been defined as that's often in error.  In our case, this is
intentional because we're redefining the _id field. Adding the
`:overwrite => true` tells Mongoid that this is intentional and silences
the warning.

The `overwrite` param isn't mentioned in the documentation.  I found
mention of it in an issue on github - https://github.com/mongoid/mongoid/issues/3272