### PR TITLE
Make cache test less sensitive to time.

### DIFF
--- a/spec/integration/fetching_publish_intent_spec.rb
+++ b/spec/integration/fetching_publish_intent_spec.rb
@@ -68,6 +68,7 @@ describe "Fetching a content item with a publish intent", :type => :request do
 
   context "a publish intent before the default TTL time" do
     before(:each) do
+      Timecop.freeze
       create(:publish_intent, :base_path => content_item.base_path, :publish_time => 5.minutes.from_now)
       get_content content_item
     end
@@ -89,6 +90,7 @@ end
 
 describe "Fetching a publish intent without a content item", :type => :request do
   before(:each) do
+    Timecop.freeze
     create(:publish_intent, :base_path => "/some/future/thing", :publish_time => 5.minutes.from_now)
     get "content/some/future/thing"
   end


### PR DESCRIPTION
Occasionally the test suite would fail on an expectation that the cache
timeout was exactly 300 seconds from now. Use Timecop.freeze to ensure
that no system time elapses between creating the item and verifying its
timeout.