### PR TITLE
Make RabbitMQ heartbeats messages respect noop mode.

### DIFF
--- a/config/initializers/message_queue.rb
+++ b/config/initializers/message_queue.rb
@@ -1,6 +1,8 @@
 require 'queue_publisher'
 
-if Rails.env.test? || ENV['DISABLE_QUEUE_PUBLISHER']
+if ENV['DISABLE_QUEUE_PUBLISHER']
+  config = {noop: true}
+elsif Rails.env.test? && ENV['ENABLE_QUEUE_IN_TEST_MODE'].blank?
   config = {noop: true}
 else
   config = YAML.load_file(Rails.root.join("config", "rabbitmq.yml"))[Rails.env].symbolize_keys

--- a/lib/queue_publisher.rb
+++ b/lib/queue_publisher.rb
@@ -27,6 +27,7 @@ class QueuePublisher
   end
 
   def send_heartbeat
+    return if @noop
     body = {
       timestamp: Time.now.utc.iso8601,
       hostname: Socket.gethostname,

--- a/lib/tasks/heartbeat_messages.rake
+++ b/lib/tasks/heartbeat_messages.rake
@@ -3,9 +3,7 @@ namespace :heartbeat_messages do
 
   desc "Send heartmessages to queue"
   task :send => :environment do
-    require_relative '../queue_publisher'
-    config = YAML.load_file(Rails.root.join("config", "rabbitmq.yml"))[Rails.env].symbolize_keys
-    publisher = QueuePublisher.new(config)
+    publisher = Rails.application.queue_publisher
 
     puts "Sending heartbeat message..."
     publisher.send_heartbeat

--- a/spec/integration/heartbeat_message_publishing_spec.rb
+++ b/spec/integration/heartbeat_message_publishing_spec.rb
@@ -18,7 +18,7 @@ describe "sending a heartbeat message on the queue", :type => :request do
   end
 
   it "should place a heartbeat message on the queue" do
-    output, status = Open3.capture2e("bundle exec rake heartbeat_messages:send")
+    output, status = Open3.capture2e({"ENABLE_QUEUE_IN_TEST_MODE" => "1"}, "bundle exec rake heartbeat_messages:send")
     expect(status.exitstatus).to eq(0), "rake task errored. output: #{output}"
 
     delivery_info, properties, payload = wait_for_message_on(@queue)

--- a/spec/lib/queue_publisher_spec.rb
+++ b/spec/lib/queue_publisher_spec.rb
@@ -192,10 +192,16 @@ describe QueuePublisher do
   context "noop mode" do
     subject { QueuePublisher.new(noop: true) }
 
-    it 'does nothing when instantiated with noop' do
+    it 'does not send messages' do
       expect_any_instance_of(Bunny::Exchange).not_to receive(:publish)
 
       subject.send_message(:something)
+    end
+
+    it 'does not sent heartbeats' do
+      expect_any_instance_of(Bunny::Exchange).not_to receive(:publish)
+
+      subject.send_heartbeat
     end
   end
 


### PR DESCRIPTION
When queue publishing is disabled, nothing should be connecting/writing
to RabbitMQ. We therefore want the heartbeats not to be sent in this
case.

The heartbeats rake task was constructing its own QueuePublisher
instance, and therefore wasn't picking up the logic for disabling it in
the initializer.