### PR TITLE
Add phase to Content Item

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -37,6 +37,7 @@ class ContentItem
   field :redirects, :type => Array, :default => []
   field :links, :type => Hash, :default => {}
   field :access_limited, :type => Hash, :default => {}
+  field :phase, :type => String
   attr_accessor :update_type
 
   scope :renderable_content, -> { where(:format.nin => NON_RENDERABLE_FORMATS) }
@@ -52,6 +53,10 @@ class ContentItem
   validate :no_extra_route_keys
   validate :links_are_valid
   validate :access_limited_is_valid
+  validates :phase,
+            inclusion: { in: ['alpha', 'beta'],
+                         allow_nil: true,
+                         message: 'must be either alpha, beta, or nil' }
   validates :locale,
             inclusion: { in: I18n.available_locales.map(&:to_s),
                          message: 'must be a supported locale' },

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -4,7 +4,7 @@
 # include their title, base_path, api_url and web_url. See doc/output_examples
 # for an example of what this representation looks like.
 class ContentItemPresenter
-  PUBLIC_ATTRIBUTES = %w(base_path title description format need_ids locale updated_at public_updated_at details).freeze
+  PUBLIC_ATTRIBUTES = %w(base_path title description format need_ids locale updated_at public_updated_at details phase).freeze
 
   def initialize(item, api_url_method)
     @item = item

--- a/spec/factories/content_item.rb
+++ b/spec/factories/content_item.rb
@@ -8,6 +8,7 @@ FactoryGirl.define do
     publishing_app 'publisher'
     update_type 'minor'
     routes { [{ 'path' => base_path, 'type' => 'exact' }] }
+    phase nil
 
     trait :with_content_id do
       content_id { SecureRandom.uuid }

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -87,6 +87,25 @@ describe ContentItem, :type => :model do
       end
     end
 
+    context 'phase' do
+      it 'allows no phase' do
+        expect(@item).to be_valid
+      end
+
+      it 'is valid with an alpha or beta phase' do
+        @item.phase = 'alpha'
+        expect(@item).to be_valid
+
+        @item.phase = 'beta'
+        expect(@item).to be_valid
+      end
+
+      it 'is invalid with any other phase' do
+        @item.phase = 'not-a-correct-phase'
+        expect(@item).to_not be_valid
+      end
+    end
+
     context 'links' do
       # We expect links to be hashes of type `{String => [UUID]}`. For example:
       #


### PR DESCRIPTION
In order to mark an item as either Alpha or Beta a `phase` attribute
has been added. This should only be `alpha`, `beta` or `nil` and can be
used on the Frontend to alter functionality or visual elements based on
its' state.