### PR TITLE
Add analytics identifier to links hash if exists

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -116,7 +116,7 @@ private
       .renderable_content
       .where(:content_id => {"$in" => links.values.flatten.uniq})
       .where(:locale => {"$in" => [I18n.default_locale.to_s, self.locale].uniq})
-      .only(:content_id, :locale, :base_path, :title, :description)
+      .only(:content_id, :locale, :base_path, :title, :description, :details)
       .sort(:updated_at => -1)
       .group_by(&:content_id)
 

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -26,7 +26,7 @@ private
   end
 
   def present_linked_item(linked_item)
-    {
+    presented = {
       "title" => linked_item.title,
       "base_path" => linked_item.base_path,
       "description" => linked_item.description,
@@ -34,6 +34,8 @@ private
       "web_url" => web_url(linked_item),
       "locale" => linked_item.locale,
     }
+    presented["analytics_identifier"] = analytics_identifier(linked_item) if analytics_identifier(linked_item)
+    presented
   end
 
   def api_url(item)
@@ -43,4 +45,9 @@ private
   def web_url(item)
     Plek.current.website_root + item.base_path
   end
+
+  def analytics_identifier(item)
+    item.has_attribute?(:details) && item.details.key?("analytics_identifier") && item.details[:analytics_identifier]
+  end
+
 end

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -18,7 +18,7 @@ describe ContentItemPresenter do
 
   context "with related links" do
     let(:linked_item1) { create(:content_item, :with_content_id, locale: I18n.default_locale.to_s) }
-    let(:linked_item2) { create(:content_item, :with_content_id, locale: "fr") }
+    let(:linked_item2) { create(:content_item, :with_content_id, locale: "fr", :details => { :analytics_identifier => 'D3' } ) }
     let(:item) {
       build(:content_item,
         :links => {"related" => [linked_item1.content_id, linked_item2.content_id]},
@@ -62,6 +62,11 @@ describe ContentItemPresenter do
           "#{site_root}#{linked_item2.base_path}",
         ]
       )
+    end
+
+    it "contains the analytics identifier" do
+      expect(related[1]).to have_key("analytics_identifier")
+      expect(related[1]["analytics_identifier"]).to eq('D3')
     end
   end
 end


### PR DESCRIPTION
If the analytics identifier exists in the details hash then it should be
part of the presented links hash object. This will let us add analytics
tracking for content which has an organisations associated to it.

https://trello.com/c/uXiRRmb1/74-send-organisation-data-to-google-analytics-for-pages-in-government-frontend-medium