### PR TITLE
Only register routes for an item when they've changed.

### DIFF
--- a/spec/integration/submitting_content_item_spec.rb
+++ b/spec/integration/submitting_content_item_spec.rb
@@ -111,9 +111,15 @@ describe "content item write API", :type => :request do
       expect(@item.details).to eq({"body" => "<p>Some body text</p>\n"})
     end
 
-    it "updates routes for the content item" do
+    it "does not register routes when they haven't changed" do
       put_json "/content/vat-rates", @data
-      assert_routes_registered("frontend", [['/vat-rates', 'exact']])
+      refute_routes_registered("frontend", [['/vat-rates', 'exact']])
+    end
+
+    it "registers routes for the content item when they have changed" do
+      @data["routes"] << { "path" => "/vat-rates.json", "type" => 'exact' }
+      put_json "/content/vat-rates", @data
+      assert_routes_registered("frontend", [['/vat-rates', 'exact'], ['/vat-rates.json', 'exact']])
     end
   end
 

--- a/spec/integration/submitting_placeholder_item_spec.rb
+++ b/spec/integration/submitting_placeholder_item_spec.rb
@@ -56,6 +56,7 @@ describe "submitting placeholder items to the content store", :type => :request 
     end
 
     it "does not update routes for the content item" do
+      @data["routes"] << { "path" => "/vat-rates.json", "type" => 'exact' }
       put_json "/content/vat-rates", @data
       refute_routes_registered("frontend", [['/vat-rates', 'exact']])
     end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -342,17 +342,17 @@ describe ContentItem, :type => :model do
 
   describe "registering routes" do
     before do
-      routes = [
+      @routes = [
         { 'path' => '/a-path', 'type' => 'exact' },
         { 'path' => '/a-path.json', 'type' => 'exact' },
         { 'path' => '/a-path/subpath', 'type' => 'prefix' }
       ]
 
-      @item = build(:content_item, base_path: '/a-path', rendering_app: 'an-app', routes: routes)
+      @item = build(:content_item, base_path: '/a-path', rendering_app: 'an-app', routes: @routes)
     end
 
-    it 'registers the assigned routes when created' do
-      @item.save!
+    it 'registers the assigned routes' do
+      @item.register_routes
       assert_routes_registered('an-app', [
         ['/a-path', 'exact'],
         ['/a-path.json', 'exact'],
@@ -360,13 +360,51 @@ describe ContentItem, :type => :model do
       ])
     end
 
-    it 'registers the assigned routes when upserted' do
-      @item.upsert
-      assert_routes_registered('an-app', [
-        ['/a-path', 'exact'],
-        ['/a-path.json', 'exact'],
-        ['/a-path/subpath', 'prefix']
-      ])
+    context "with a previous item" do
+      before :each do
+        # dup the routes so they can be modified without affecting @item
+        previous_routes = @routes.map(&:dup)
+        @previous_item = build(:content_item, base_path: '/a-path', rendering_app: 'an-app', routes: previous_routes)
+      end
+
+      it 'does not register the routes when they are unchanged' do
+        @item.register_routes(previous_item: @previous_item)
+        refute_routes_registered('an-app', [
+          ['/a-path', 'exact'],
+          ['/a-path.json', 'exact'],
+          ['/a-path/subpath', 'prefix']
+        ])
+      end
+
+      it 'registers routes when the routes are different' do
+        @previous_item.routes[1]['type'] = 'prefix'
+        @item.register_routes(previous_item: @previous_item)
+        assert_routes_registered('an-app', [
+          ['/a-path', 'exact'],
+          ['/a-path.json', 'exact'],
+          ['/a-path/subpath', 'prefix']
+        ])
+      end
+
+      it 'registers routes when the redirects are different' do
+        @previous_item.redirects << { 'path' => '/a-path/old-part', 'type' => 'exact', 'destination' => '/somewhere' }
+        @item.register_routes(previous_item: @previous_item)
+        assert_routes_registered('an-app', [
+          ['/a-path', 'exact'],
+          ['/a-path.json', 'exact'],
+          ['/a-path/subpath', 'prefix']
+        ])
+      end
+
+      it 'registers routes when the rendering_app is different' do
+        @previous_item.rendering_app = 'another-app'
+        @item.register_routes(previous_item: @previous_item)
+        assert_routes_registered('an-app', [
+          ['/a-path', 'exact'],
+          ['/a-path.json', 'exact'],
+          ['/a-path/subpath', 'prefix']
+        ])
+      end
     end
   end
 


### PR DESCRIPTION
In order to avoid unnecessary router reloads, we should avoid sending
routes to the router when they haven't changed.

This updates the router reload logic to take note of the previously
existing content_item, and skip registering routes, if there is a
previous item with an identical route set.

This will make most bulk re-registering processes much more efficient.