### PR TITLE
Add analytics identifier to root object

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -38,6 +38,7 @@ class ContentItem
   field :links, :type => Hash, :default => {}
   field :access_limited, :type => Hash, :default => {}
   field :phase, :type => String
+  field :analytics_identifier, :type => String
   attr_accessor :update_type
 
   scope :renderable_content, -> { where(:format.nin => NON_RENDERABLE_FORMATS) }

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -4,7 +4,19 @@
 # include their title, base_path, api_url and web_url. See doc/output_examples
 # for an example of what this representation looks like.
 class ContentItemPresenter
-  PUBLIC_ATTRIBUTES = %w(base_path title description format need_ids locale updated_at public_updated_at details phase).freeze
+  PUBLIC_ATTRIBUTES = %w(
+    base_path
+    title
+    description
+    format
+    need_ids
+    locale
+    updated_at
+    public_updated_at
+    details
+    phase
+    analytics_identifier
+  ).freeze
 
   def initialize(item, api_url_method)
     @item = item

--- a/spec/factories/content_item.rb
+++ b/spec/factories/content_item.rb
@@ -8,7 +8,6 @@ FactoryGirl.define do
     publishing_app 'publisher'
     update_type 'minor'
     routes { [{ 'path' => base_path, 'type' => 'exact' }] }
-    phase nil
 
     trait :with_content_id do
       content_id { SecureRandom.uuid }

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -106,6 +106,17 @@ describe ContentItem, :type => :model do
       end
     end
 
+    context 'analytics_identifier' do
+      it 'is valid without an analytics_identifier' do
+        expect(@item).to be_valid
+      end
+
+      it 'is valid with an analytics identifier' do
+        @item.analytics_identifier = 'D3'
+        expect(@item).to be_valid
+      end
+    end
+
     context 'links' do
       # We expect links to be hashes of type `{String => [UUID]}`. For example:
       #


### PR DESCRIPTION
Analytics identifiers are short codes which we can use to represent
objects in character restricted environments (like Google Analytics
custom dimensions). Having them on the root lets us easily pull them out
to be part of the links hash so that content can be correctly marked
with all related dimensions.