### PR TITLE
Allow redirects from sub-locales

### DIFF
--- a/app/models/registerable_route_set.rb
+++ b/app/models/registerable_route_set.rb
@@ -145,7 +145,7 @@ private
   end
 
   def base_path_with_extension?(route)
-    route.path.match(%r(^#{base_path}\.\w+\z))
+    route.path.match(%r(^#{base_path}\.[\w-]+\z))
   end
 
   def beneath_base_path?(route)

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -275,6 +275,16 @@ describe ContentItem, :type => :model do
         expect(@item).to be_valid
       end
 
+      it "should be valid with a locale" do
+        @item.redirects << {"path" => @item.base_path + ".cy", "type" => "exact", "destination" => "/somewhere.cy"}
+        expect(@item).to be_valid
+      end
+
+      it "should be valid with a dashed locale" do
+        @item.redirects << {"path" => @item.base_path + ".es-419", "type" => "exact", "destination" => "/somewhere.es-419"}
+        expect(@item).to be_valid
+      end
+
       it "should be invalid with an invalid redirect" do
         @item.redirects.first['type'] = "fooey"
         expect(@item).not_to be_valid


### PR DESCRIPTION
`/xyz.es-419` isn’t considered part of the `/xyz` base path, so redirects
with that locale as part of the same piece of content are not
permitted. This fixes the regular expression that is used to validate
the source path
