### PR TITLE
Add analytics identifiers to links hash objects

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -134,7 +134,7 @@ private
       .renderable_content
       .where(:content_id => {"$in" => links.values.flatten.uniq})
       .where(:locale => {"$in" => [I18n.default_locale.to_s, self.locale].uniq})
-      .only(:content_id, :locale, :base_path, :title, :description)
+      .only(:content_id, :locale, :base_path, :title, :description, :analytics_identifier)
       .sort(:updated_at => -1)
       .group_by(&:content_id)
 

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -38,7 +38,7 @@ private
   end
 
   def present_linked_item(linked_item)
-    {
+    presented = {
       "title" => linked_item.title,
       "base_path" => linked_item.base_path,
       "description" => linked_item.description,
@@ -46,6 +46,10 @@ private
       "web_url" => web_url(linked_item),
       "locale" => linked_item.locale,
     }
+    if linked_item.has_attribute? :analytics_identifier
+      presented["analytics_identifier"] = linked_item.analytics_identifier
+    end
+    presented
   end
 
   def api_url(item)

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -18,7 +18,7 @@ describe ContentItemPresenter do
 
   context "with related links" do
     let(:linked_item1) { create(:content_item, :with_content_id, locale: I18n.default_locale.to_s) }
-    let(:linked_item2) { create(:content_item, :with_content_id, locale: "fr") }
+    let(:linked_item2) { create(:content_item, :with_content_id, locale: "fr", analytics_identifier: "D2") }
     let(:item) {
       build(:content_item,
         :links => {"related" => [linked_item1.content_id, linked_item2.content_id]},
@@ -62,6 +62,11 @@ describe ContentItemPresenter do
           "#{site_root}#{linked_item2.base_path}",
         ]
       )
+    end
+
+    it "contains the linked analytics identifier" do
+      expect(related[1]).to have_key("analytics_identifier")
+      expect(related[1]["analytics_identifier"]).to eq('D2')
     end
   end
 end


### PR DESCRIPTION
So that we can correctly set any related analytics identifiers on
frontend applications expose the analytics identifiers for all the items
in the links hash if they exist.

This is the new approach since the discussions which resulted from here: https://github.com/alphagov/content-store/pull/139

https://trello.com/c/uXiRRmb1/74-send-organisation-data-to-google-analytics-for-pages-in-government-frontend-medium