### PR TITLE
Allow phase to be live, and require a phase

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -59,9 +59,9 @@ class ContentItem
   validate :links_are_valid
   validate :access_limited_is_valid
   validates :phase,
-            inclusion: { in: ['alpha', 'beta'],
+            inclusion: { in: ['alpha', 'beta', 'live'],
                          allow_nil: true,
-                         message: 'must be either alpha, beta, or nil' }
+                         message: 'must be either alpha, beta, or live' }
   validates :locale,
             inclusion: { in: I18n.available_locales.map(&:to_s),
                          message: 'must be a supported locale' },

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -41,7 +41,7 @@ class ContentItem
   field :redirects, :type => Array, :default => []
   field :links, :type => Hash, :default => {}
   field :access_limited, :type => Hash, :default => {}
-  field :phase, :type => String
+  field :phase, :type => String, :default => 'live'
   field :analytics_identifier, :type => String
   attr_accessor :update_type
 
@@ -60,7 +60,6 @@ class ContentItem
   validate :access_limited_is_valid
   validates :phase,
             inclusion: { in: ['alpha', 'beta', 'live'],
-                         allow_nil: true,
                          message: 'must be either alpha, beta, or live' }
   validates :locale,
             inclusion: { in: I18n.available_locales.map(&:to_s),

--- a/db/migrate/20150916083409_populate_live_phase.rb
+++ b/db/migrate/20150916083409_populate_live_phase.rb
@@ -1,0 +1,8 @@
+class PopulateLivePhase < Mongoid::Migration
+  def self.up
+    ContentItem.where(:phase.exists => false).update_all(:phase => "live")
+  end
+
+  def self.down
+  end
+end

--- a/spec/integration/submitting_content_item_spec.rb
+++ b/spec/integration/submitting_content_item_spec.rb
@@ -38,6 +38,7 @@ describe "content item write API", :type => :request do
       expect(item.format).to eq("answer")
       expect(item.need_ids).to eq(["100123", "100124"])
       expect(item.locale).to eq("en")
+      expect(item.phase).to eq("live")
       expect(item.public_updated_at).to match_datetime("2014-05-14T13:00:06Z")
       expect(item.updated_at).to be_within(10.seconds).of(Time.zone.now)
       expect(item.details).to eq({"body" => "<p>Some body text</p>\n"})

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -92,12 +92,11 @@ describe ContentItem, :type => :model do
         expect(@item).to be_valid
       end
 
-      it 'is valid with an alpha or beta phase' do
-        @item.phase = 'alpha'
-        expect(@item).to be_valid
-
-        @item.phase = 'beta'
-        expect(@item).to be_valid
+      %w(alpha beta live).each do |phase|
+        it "is valid with #{phase} phase" do
+          @item.phase = phase
+          expect(@item).to be_valid
+        end
       end
 
       it 'is invalid with any other phase' do

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -88,8 +88,8 @@ describe ContentItem, :type => :model do
     end
 
     context 'phase' do
-      it 'allows no phase' do
-        expect(@item).to be_valid
+      it 'defaults to live' do
+        expect(ContentItem.new.phase).to eq('live')
       end
 
       %w(alpha beta live).each do |phase|
@@ -97,6 +97,12 @@ describe ContentItem, :type => :model do
           @item.phase = phase
           expect(@item).to be_valid
         end
+      end
+
+      it 'is invalid without a phase' do
+        @item.phase = nil
+        expect(@item).not_to be_valid
+        expect(@item.errors[:phase].size).to eq(1)
       end
 
       it 'is invalid with any other phase' do


### PR DESCRIPTION
This also makes phase default to 'live' when not given because that's generally correct.

This PR is the implementation of alphagov/govuk-content-schemas#114