### PR TITLE
Include content_id in frontend representations.

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -160,7 +160,7 @@ private
     ContentItem
       .renderable_content
       .where(:content_id => content_id)
-      .only(:locale, :base_path, :title, :description)
+      .only(:content_id, :locale, :base_path, :title, :description)
       .sort(:locale => 1, :updated_at => 1)
       .group_by(&:locale)
       .map { |locale, items| items.last }

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -156,7 +156,7 @@ private
   end
 
   def load_available_translations
-    return [self] if self.content_id.blank?
+    return [] if self.content_id.blank?
     ContentItem
       .renderable_content
       .where(:content_id => content_id)

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -6,6 +6,7 @@
 class ContentItemPresenter
   PUBLIC_ATTRIBUTES = %w(
     base_path
+    content_id
     title
     description
     format
@@ -39,6 +40,7 @@ private
 
   def present_linked_item(linked_item)
     presented = {
+      "content_id" => linked_item.content_id,
       "title" => linked_item.title,
       "base_path" => linked_item.base_path,
       "description" => linked_item.description,

--- a/doc/content_item_fields.md
+++ b/doc/content_item_fields.md
@@ -40,7 +40,7 @@ set of fields than those listed below.
 ## `content_id`
 
 A UUID string as described in [RFC 4122](http://www.ietf.org/rfc/rfc4122.txt).
-Present only in the storing context.
+Present in all contexts.
 
 For example: `"30737dba-17f1-49b4-aff8-6dd4bff7fdca"`.
 
@@ -185,6 +185,7 @@ In the `notifying` context, the items are hashes containing: (TODO: confirm)
  - `base_path`: The base path of the content item
 
 In the `retrieving` context, the items are hashes containing:
+ - `content_id`: The Content ID of the linked content item
  - `title`: The title of the content item
  - `base_path`: The base path of the content
  - `description`: The description of the content

--- a/doc/output_examples/generic.json
+++ b/doc/output_examples/generic.json
@@ -1,5 +1,6 @@
 {
   "base_path": "/path-on-gov-uk",
+  "content_id": "04bfb9a8-895a-47c8-9ef9-e0a113ebc413",
   "title": "Content Title",
   "description": "Short description of content",
   "format": "the format of this content",
@@ -14,6 +15,7 @@
   "links": {
     "related_things": [
       {
+        "content_id": "a512c51b-b65b-45b4-94e2-ef4f69e0162f",
         "title": "Title of related thing",
         "base_path": "/path/of/related-thing",
         "api_url": "https://content-store.production.alphagov.co.uk/content/path/of/related-thing",
@@ -23,6 +25,7 @@
     ],
     "more_related_things": [
       {
+        "content_id": "e29e4cdc-518a-4f2c-b197-76fb1b3fae63",
         "title": "Another of related thing",
         "base_path": "/path/to/another-related-thing",
         "api_url": "https://content-store.production.alphagov.co.uk/content/path/to/another-related-thing",
@@ -32,6 +35,7 @@
     ],
     "available_translations": [
       {
+        "content_id": "5f18bab1-f503-496c-8054-ed05873b333d",
         "title": "Content Title",
         "base_path": "/path-on-gov-uk",
         "api_url": "https://content-store.production.alphagov.co.uk/content/path-on-gov-uk",
@@ -39,6 +43,7 @@
         "locale": "en"
       },
       {
+        "content_id": "42c6a0bf-3534-490a-a8ac-16cde1222d32",
         "title": "Titre de Contenu",
         "base_path": "/path-on-gov-uk.fr",
         "api_url": "https://content-store.production.alphagov.co.uk/content/path-on-gov-uk.fr",

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -1,9 +1,20 @@
 require 'rails_helper'
 
 describe "Fetching content items", :type => :request do
-  let(:content_item) { create(:content_item) }
 
   context "an existing content item" do
+    let(:content_item) {
+      create(:content_item,
+        :base_path => "/vat-rates",
+        :content_id => SecureRandom.uuid,
+        :title => "VAT rates",
+        :description => "Current VAT rates",
+        :format => "answer",
+        :need_ids => ["100136"],
+        :public_updated_at => 30.minutes.ago,
+        :details => {"body" => "<div class=\"highlight-answer\">\n<p>The standard <abbr title=\"Value Added Tax\">VAT</abbr> rate is <em>20%</em></p>\n</div>\n"},
+      )
+    }
     before(:each) { get_content content_item }
 
     it "returns a 200 OK response" do
@@ -12,7 +23,44 @@ describe "Fetching content items", :type => :request do
 
     it "returns the presented content item as JSON data" do
       expect(response.content_type).to eq("application/json")
-      expect(response.body).to eq(present(content_item))
+      data = JSON.parse(response.body)
+
+      expect(data.keys).to match_array(%w[
+        base_path
+        title
+        description
+        format
+        need_ids
+        locale
+        analytics_identifier
+        phase
+        public_updated_at
+        updated_at
+        details
+        links
+      ])
+
+      expect(data).to include(
+        "base_path" => "/vat-rates",
+        "title" => "VAT rates",
+        "description" => "Current VAT rates",
+        "format" => "answer",
+        "need_ids" => ["100136"],
+        "locale" => "en",
+        "analytics_identifier" => nil,
+        "phase" => nil,
+      )
+      expect(data["details"]).to eq({
+        "body" => "<div class=\"highlight-answer\">\n<p>The standard <abbr title=\"Value Added Tax\">VAT</abbr> rate is <em>20%</em></p>\n</div>\n",
+      })
+    end
+
+    it "outputs the timestamp fields correctly" do
+      content_item.reload # reload to pick up any time rounding in the database.
+
+      data = JSON.parse(response.body)
+      expect(data["public_updated_at"]).to eq(content_item.public_updated_at.as_json)
+      expect(Time.parse(data["updated_at"])).to be_within(1.second).of(Time.now.utc)
     end
 
     it "sets cache headers to expire in the default TTL" do
@@ -66,6 +114,28 @@ describe "Fetching content items", :type => :request do
 
     it "returns a 200 OK response" do
       expect(response.status).to eq(200)
+    end
+
+    it "includes the correct data in the expanded representation of the linked item" do
+      data = JSON.parse(response.body)
+
+      linked_item_data = data["links"]["related"].first
+      expect(linked_item_data.keys).to match_array(%w[
+        base_path
+        title
+        description
+        locale
+        api_url
+        web_url
+      ])
+
+      expect(linked_item_data).to include(
+        "base_path" => linked_item.base_path,
+        "title" => linked_item.title,
+        "description" => linked_item.description,
+        "locale" => linked_item.locale,
+        "web_url" => Plek.new.website_root + linked_item.base_path,
+      )
     end
 
     it "corrrectly expands linked items with internal API URLs" do

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -27,6 +27,7 @@ describe "Fetching content items", :type => :request do
 
       expect(data.keys).to match_array(%w[
         base_path
+        content_id
         title
         description
         format
@@ -42,6 +43,7 @@ describe "Fetching content items", :type => :request do
 
       expect(data).to include(
         "base_path" => "/vat-rates",
+        "content_id" => content_item.content_id,
         "title" => "VAT rates",
         "description" => "Current VAT rates",
         "format" => "answer",
@@ -122,6 +124,7 @@ describe "Fetching content items", :type => :request do
       linked_item_data = data["links"]["related"].first
       expect(linked_item_data.keys).to match_array(%w[
         base_path
+        content_id
         title
         description
         locale
@@ -131,6 +134,7 @@ describe "Fetching content items", :type => :request do
 
       expect(linked_item_data).to include(
         "base_path" => linked_item.base_path,
+        "content_id" => linked_item.content_id,
         "title" => linked_item.title,
         "description" => linked_item.description,
         "locale" => linked_item.locale,

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -645,8 +645,8 @@ describe ContentItem, :type => :model do
           end
         }
 
-        it 'should return only itself' do
-          expect(item_en.linked_items["available_translations"]).to eq([item_en])
+        it 'should not include available_translations' do
+          expect(item_en.linked_items).not_to have_key("available_translations")
         end
       end
     end

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -30,7 +30,7 @@ describe ContentItemPresenter do
 
     it "includes the link type" do
       expect(presenter.as_json).to have_key("links")
-      expect(presenter.as_json["links"].keys).to match_array(["available_translations", "related"])
+      expect(presenter.as_json["links"].keys).to include("related")
     end
 
     it "includes each linked item" do

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -37,8 +37,8 @@ describe ContentItemPresenter do
       expect(related.size).to be(2)
     end
 
-    it "includes the path, title and description for each item" do
-      expect(related).to all include("base_path", "title", "description")
+    it "includes the content_id, path, title and description for each item" do
+      expect(related).to all include("content_id", "base_path", "title", "description")
     end
 
     it "includes the locale for each item" do


### PR DESCRIPTION
As described in alphagov/govuk-content-schemas#121, it's becoming
nexessary for some of the frontend applications to know about
content_ids. This exposes them in both the base item, and the expanded
links.

This includes a change to stop returning self in available translations for
an item with no content_id (see commit c89f3c2 for details)