### PR TITLE
Add rake task to inspect missing content_ids

### DIFF
--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -1,0 +1,12 @@
+namespace :data_hygiene do
+  desc "See which documents don't have content IDs"
+  task :inspect_content_ids => [:environment] do
+    publishing_apps = ContentItem.all.distinct("publishing_app")
+    publishing_apps.each do |publishing_app|
+      without_content_id = ContentItem.where(content_id: nil, publishing_app: publishing_app).count
+      with_content_id = ContentItem.where(publishing_app: publishing_app).count - without_content_id
+
+      puts "#{publishing_app}: #{without_content_id} without, #{with_content_id} with"
+    end
+  end
+end


### PR DESCRIPTION
`rake data_hygiene:inspect_content_ids` will give you a list of publishing apps and the number of content items with / without content_id in the database. We'll use this to verify we're sending the content_id for all documents.

Current output on my development VM:

```shell
vagrant@development:~/govuk/content-store (add-content-id-task)$ be rake data_hygiene:inspect_content_ids
frontend: 0 without, 8 with
publisher: 1719 without, 0 with
whitehall: 4652 without, 164698 with
short-url-manager: 788 without, 0 with
specialist-publisher: 48 without, 13925 with
govuk_content_api: 0 without, 1 with
static: 0 without, 12 with
collections-publisher: 450 without, 534 with
feedback: 0 without, 8 with
contacts: 134 without, 133 with
design-principles: 34 without, 3 with
contacts-admin: 0 without, 1 with
policy-publisher: 0 without, 440 with
manuals-frontend: 0 without, 2 with
hmrc-manuals-api: 2352 without, 0 with
info-frontend: 0 without, 1 with
rummager: 0 without, 2 with
tariff: 0 without, 1 with
calculators: 0 without, 1 with
```