### PR TITLE
Fix failing integration test

### DIFF
--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -50,7 +50,7 @@ describe "Fetching content items", :type => :request do
         "need_ids" => ["100136"],
         "locale" => "en",
         "analytics_identifier" => nil,
-        "phase" => nil,
+        "phase" => "live",
       )
       expect(data["details"]).to eq({
         "body" => "<div class=\"highlight-answer\">\n<p>The standard <abbr title=\"Value Added Tax\">VAT</abbr> rate is <em>20%</em></p>\n</div>\n",


### PR DESCRIPTION
This test is currently failing on master because `phase` is "live" by default now. 

It is a mystery why this test wasn't failing earlier when the default was introduced (https://github.com/alphagov/content-store/pull/146).