### PR TITLE
Add official redirects for RAIB pages

### DIFF
--- a/db/migrate/20151014135153_add_redirects_for_raib.rb
+++ b/db/migrate/20151014135153_add_redirects_for_raib.rb
@@ -1,0 +1,20 @@
+class AddRedirectsForRaib < Mongoid::Migration
+  def self.up
+    existing_redirects = CSV.read("#{Rails.root}/db/migrate/files/raib_redirects.csv")
+
+    existing_redirects.each do |from_base_path, to_base_path|
+      content_item = ContentItem.find_by(base_path: from_base_path)
+      content_item.update_attributes!(
+        content_id: nil,
+        format: "redirect",
+        publishing_app: "whitehall",
+        rendering_app: nil,
+        redirects: [{ path: from_base_path, type: 'exact', destination: to_base_path }],
+        routes: [],
+      )
+    end
+  end
+
+  def self.down
+  end
+end

--- a/db/migrate/files/raib_redirects.csv
+++ b/db/migrate/files/raib_redirects.csv
@@ -1,0 +1,6 @@
+/government/organisations/rail-accidents-investigation-branch,/government/organisations/rail-accident-investigation-branch
+/government/organisations/rail-accidents-investigation-branch/about,/government/organisations/rail-accident-investigation-branch/about
+/government/organisations/rail-accidents-investigation-branch/about/complaints-procedure,/government/organisations/rail-accident-investigation-branch/about/complaints-procedure
+/government/organisations/rail-accidents-investigation-branch/about/media-enquiries,/government/organisations/rail-accident-investigation-branch/about/media-enquiries
+/government/organisations/rail-accidents-investigation-branch/about/recruitment,/government/organisations/rail-accident-investigation-branch/about/recruitment
+/government/organisations/rail-accidents-investigation-branch/about/social-media-use,/government/organisations/rail-accident-investigation-branch/about/social-media-use


### PR DESCRIPTION
The pages here were redirected in router-data in https://github.gds/gds/router-data/commit/15be25b94ef6e0b12f16669d632617d8005f23a2 because it's "Rail Accident", not "Accidents".

When the redirection happened the corresponding content items have not been updated. This means that the pages on the new URLs have the same content_id. This interferes with our work to create a new tagging infrastructure.

We will remove the redirects from router-data as well: https://github.gds/gds/router-data/pull/485

Trello: https://trello.com/c/i1TwVwpN/382-fix-redirects-for-raib-pages