### PR TITLE
Add rake task for exporting content items to JSON.

### DIFF
--- a/lib/tasks/data_hygiene/export_data.rake
+++ b/lib/tasks/data_hygiene/export_data.rake
@@ -1,0 +1,12 @@
+require "tasks/data_hygiene/export_data"
+
+namespace :data_hygiene do
+  namespace :export_content_items do
+    desc "Exports all content items to ./tmp as JSON, including separate timestamps"
+    task all: [:environment] do
+      File.open(Rails.root + "tmp/content_items_#{Time.now.strftime("%Y-%m-%d_%H-%M-%S")}.json", "w") do |file|
+        Tasks::DataHygiene::ExportData.new(file, STDOUT).export_all
+      end
+    end
+  end
+end

--- a/lib/tasks/data_hygiene/export_data.rb
+++ b/lib/tasks/data_hygiene/export_data.rb
@@ -1,0 +1,44 @@
+module Tasks
+  module DataHygiene
+    class ExportData
+      def initialize(file, stdout)
+        @file = file
+        @stdout = stdout
+      end
+
+      def export_all
+        total = ContentItem.count
+
+        ContentItem.all.each.with_index(1) do |content_item, index|
+          content_item_hash = content_item.as_json
+          updated_at = content_item_hash.delete("updated_at")
+
+          json = {
+            updated_at: updated_at,
+            content_item: content_item_hash,
+          }.to_json
+
+          file.puts(json)
+
+          print_progress(index, total)
+        end
+
+        stdout.puts
+      end
+
+    private
+
+      attr_reader :file, :stdout
+
+      def print_progress(completed, total)
+        percent_complete = ((completed.to_f / total) * 100).round
+        percent_remaining = 100 - percent_complete
+
+        stdout.print "\r"
+        stdout.flush
+        stdout.print "Progress [#{"=" * percent_complete}>#{"." * percent_remaining}] (#{percent_complete}%)"
+        stdout.flush
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/AgfGK1lz/325-importing-existing-data

This produces a file with one JSON document per line
in ./tmp with each document having the structure:

```
{
  updated_at: "2015-10-14T15:07:09+01:00",
  content_item: {
    content_id: "2e2d3551-4147-4136-8c0d-f0904b69c8c6",
    etc..
  }
}
```

These files are intended for use by the publishing
API when importing documents.

Example usage:
```
$ rake data_hygiene:export_content_items:all
Progress [====>................................................................................................] (4%)
```