### PR TITLE
Add redirects for statistics-publications

### DIFF
--- a/db/migrate/20151015100245_redirect_publications_to_statistics.csv
+++ b/db/migrate/20151015100245_redirect_publications_to_statistics.csv
@@ -1,0 +1,11 @@
+/government/publications/funding-for-flood-and-coastal-erosion-risk-management-in-england,/government/statistics/funding-for-flood-and-coastal-erosion-risk-management-in-england
+/government/publications/statistics-of-scientific-procedures-on-living-animals-great-britain-2005,/government/statistics/statistics-of-scientific-procedures-on-living-animals-great-britain-2005
+/government/publications/annual-flu-reports,/government/statistics/annual-flu-reports
+/government/publications/strategic-export-controls-licensing-data-report-2013,/government/statistics/strategic-export-controls-licensing-data-report-2013
+/government/publications/strategic-export-controls-licensing-data-report-2012,/government/statistics/strategic-export-controls-licensing-data-report-2012
+/government/publications/strategic-export-controls-licensing-data-report-1-january-to-31-march-2013,/government/statistics/strategic-export-controls-licensing-data-report-1-january-to-31-march-2013
+/government/publications/strategic-export-controls-licensing-data-report-1-april-to-30-june-2013,/government/statistics/strategic-export-controls-licensing-data-report-1-april-to-30-june-2013
+/government/publications/strategic-export-controls-licensing-data-report-1-july-to-30-september-2013,/government/statistics/strategic-export-controls-licensing-data-report-1-july-to-30-september-2013
+/government/publications/strategic-export-controls-licensing-data-report-1-october-to-31-december-2013,/government/statistics/strategic-export-controls-licensing-data-report-1-october-to-31-december-2013
+/government/publications/strategic-export-controls-licensing-data-report-1-january-to-31-march-2014,/government/statistics/strategic-export-controls-licensing-data-report-1-january-to-31-march-2014
+/government/publications/central-and-local-rating-lists-summary-september-2014,/government/statistics/central-and-local-rating-lists-summary-september-2014

--- a/db/migrate/20151015100245_redirect_publications_to_statistics.rb
+++ b/db/migrate/20151015100245_redirect_publications_to_statistics.rb
@@ -1,0 +1,20 @@
+class RedirectPublicationsToStatistics < Mongoid::Migration
+  def self.up
+    existing_redirects = CSV.read("#{Rails.root}/db/migrate/20151015100245_redirect_publications_to_statistics.csv")
+
+    existing_redirects.each do |from_base_path, to_base_path|
+      content_item = ContentItem.find_by(base_path: from_base_path)
+      content_item.update_attributes!(
+        content_id: nil,
+        format: "redirect",
+        publishing_app: "whitehall",
+        rendering_app: nil,
+        redirects: [{ path: from_base_path, type: 'exact', destination: to_base_path }],
+        routes: [],
+      )
+    end
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
The publications in this CSV are being redirected by Whitehall from `/government/publications/:id` to `/government/statistics/:id`. Adding a redirect item for these fixes the problem that they have the same content_id.

Trello: https://trello.com/c/cme0kKzQ