### PR TITLE
Add redirects for school commissioner URLs and like pages

### DIFF
--- a/db/migrate/20151015103826_fix_redirects_for_schools_commissioner.csv
+++ b/db/migrate/20151015103826_fix_redirects_for_schools_commissioner.csv
@@ -1,3 +1,4 @@
 /government/organisations/schools-commissioner,/government/organisations/schools-commissioners-group
 /government/organisations/schools-commissioner/about/our-governance,/government/organisations/schools-commissioners-group/about/our-governance
 /government/organisations/office-of-qualifications-and-examinations-regulation,/government/organisations/ofqual
+/government/collections/hs2-planning-forum,/government/collections/hs2-phase-one-planning-forum

--- a/db/migrate/20151015103826_fix_redirects_for_schools_commissioner.csv
+++ b/db/migrate/20151015103826_fix_redirects_for_schools_commissioner.csv
@@ -1,2 +1,3 @@
 /government/organisations/schools-commissioner,/government/organisations/schools-commissioners-group
 /government/organisations/schools-commissioner/about/our-governance,/government/organisations/schools-commissioners-group/about/our-governance
+/government/organisations/office-of-qualifications-and-examinations-regulation,/government/organisations/ofqual

--- a/db/migrate/20151015103826_fix_redirects_for_schools_commissioner.csv
+++ b/db/migrate/20151015103826_fix_redirects_for_schools_commissioner.csv
@@ -1,0 +1,2 @@
+/government/organisations/schools-commissioner,/government/organisations/schools-commissioners-group
+/government/organisations/schools-commissioner/about/our-governance,/government/organisations/schools-commissioners-group/about/our-governance

--- a/db/migrate/20151015103826_fix_redirects_for_schools_commissioner.rb
+++ b/db/migrate/20151015103826_fix_redirects_for_schools_commissioner.rb
@@ -1,0 +1,20 @@
+class FixRedirectsForSchoolsCommissioner < Mongoid::Migration
+  def self.up
+    existing_redirects = CSV.read("#{Rails.root}/db/migrate/20151015103826_fix_redirects_for_schools_commissioner.csv")
+
+    existing_redirects.each do |from_base_path, to_base_path|
+      content_item = ContentItem.find_by(base_path: from_base_path)
+      content_item.update_attributes!(
+        content_id: nil,
+        format: "redirect",
+        publishing_app: "whitehall",
+        rendering_app: nil,
+        redirects: [{ path: from_base_path, type: 'exact', destination: to_base_path }],
+        routes: [],
+      )
+    end
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
These URLs redirect to a new spelling of the organisation, much like
the RAIB case (#154). In this case we can't find redirects in
router-data, so we assume they have been added via another way.

We need to make them redirects without content_id because the
content_id are duplicated.

Trello: https://trello.com/c/cme0kKzQ