### PR TITLE
Remove content items that 404

### DIFF
--- a/db/migrate/20151015111051_fix404ing_content_items.csv
+++ b/db/migrate/20151015111051_fix404ing_content_items.csv
@@ -1,0 +1,8 @@
+/government/collections/ots-tax-complexity
+/government/collections/ppp-procurement-guidance
+/government/news/sentenced-for-providing-unlawful-immigration-advice
+/government/policies/preventing-and-reducing-anti-competitive-activities/supporting-pages/settling-consumer-disputes
+/government/publications/highways-agency-2014-people-survey-results
+/government/publications/mhra-fees-201415
+/government/publications/resolving-complaints-on-immigration-services-oisc-best-practice
+/government/world-location-news/clickbook-outage-in-china

--- a/db/migrate/20151015111051_fix404ing_content_items.rb
+++ b/db/migrate/20151015111051_fix404ing_content_items.rb
@@ -1,0 +1,13 @@
+class Fix404ingContentItems < Mongoid::Migration
+  def self.up
+    existing_redirects = CSV.read("#{Rails.root}/db/migrate/20151015111051_fix404ing_content_items.csv")
+
+    existing_redirects.each do |row|
+      content_item = ContentItem.find_by(base_path: row.first)
+      content_item.delete
+    end
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
The paths in the CSV return 404 on the site. For example:

https://www.gov.uk/government/collections/ots-tax-complexity

However, they do have content items.

https://www.gov.uk/api/content/government/collections/ots-tax-complexity

The content_ids for these items are duplicated. In the above case it duplicates:

https://www.gov.uk/api/content/government/collections/hmt-ots-tax-complexity

Because they return 404, we think its best to remove these content items, as the items have not previously worked.

Trello: https://trello.com/c/cme0kKzQ