### PR TITLE
Add redirects for previously 404'ing pages

### DIFF
--- a/db/migrate/20151015115116_fix_orgs_special_cases.rb
+++ b/db/migrate/20151015115116_fix_orgs_special_cases.rb
@@ -1,0 +1,26 @@
+class FixOrgsSpecialCases < Mongoid::Migration
+  def self.up
+    existing_redirects = {
+      "/government/world/organisations/british-trade-cultural-office-taiwan/about/recruitment" =>
+        "/government/world/organisations/british-office-taipei/about/recruitment",
+      "/government/organisations/court-of-protection" =>
+        "/courts-tribunals/court-of-protection"
+    }
+
+    existing_redirects.each do |from_base_path, to_base_path|
+      content_item = ContentItem.find_by(base_path: from_base_path)
+      content_item.update_attributes!(
+        content_id: nil,
+        format: "redirect",
+        publishing_app: "whitehall",
+        rendering_app: nil,
+        redirects: [{ path: from_base_path, type: 'exact', destination: to_base_path }],
+        routes: [],
+      )
+    end
+  rescue Mongoid::Errors::DocumentNotFound
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
These two pages return 404, but have the same content_id as similar pages.

- /government/world/organisations/british-trade-cultural-office-taiwan/about/recruitment is a sub page of an organisation that has been renamed in https://github.com/alphagov/whitehall/pull/2245. This subpage have not been renamed in this case. This PR fixes that.

- /government/organisations/court-of-protection seems to have existed but dissapeared. It has the same content_id as /government/organisations/court-of-protection

Trello: https://trello.com/c/cme0kKzQ/366-fix-duplicate-content-ids