### PR TITLE
Remove knowledge of update type.

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -18,7 +18,7 @@ class ContentItem
     end
     return result, item
   rescue Mongoid::Errors::UnknownAttribute => e
-    extra_fields = attributes.keys - self.fields.keys - %w(update_type)
+    extra_fields = attributes.keys - self.fields.keys
     item.errors.add(:base, "unrecognised field(s) #{extra_fields.join(', ')} in input")
     return false, item
   rescue Mongoid::Errors::InvalidValue => e
@@ -43,14 +43,12 @@ class ContentItem
   field :access_limited, :type => Hash, :default => {}
   field :phase, :type => String, :default => 'live'
   field :analytics_identifier, :type => String
-  attr_accessor :update_type
 
   scope :renderable_content, -> { where(:format.nin => NON_RENDERABLE_FORMATS) }
 
   validates :base_path, absolute_path: true
   validates :content_id, uuid: true, allow_nil: true
   validates :format, :publishing_app, presence: true
-  validates :format, :update_type, format: { with: /\A[a-z0-9_]+\z/i, allow_blank: true }
   validates :title, presence: true, if: :renderable_content?
   validates :rendering_app, presence: true, format: /\A[a-z0-9-]*\z/,if: :renderable_content?
   validates :public_updated_at, presence: true, if: :renderable_content?

--- a/doc/content_item_fields.md
+++ b/doc/content_item_fields.md
@@ -239,22 +239,6 @@ array contains an original path, a routing type, and a destination path. See
 For redirect content items, the behaviour is slightly different.  See
 redirect_item.md for details.
 
-## `update_type`
-
-A string. Present in storing and notifying contexts.
-
-This indicates the type of update that was made to the content item.
-It must be one of:
-
- - 'major' - major changes to a piece of content.
- - 'minor' - changes which don't affect the meaning of the
-   content, eg typo correction.
- - 'republish' - useful in situations such as when the data
-   structure has changed.
-
-Other types may be added in future, the content store will just pass them through
-to the fanout.
-
 ## `access_limited`
 
 A hash. Present in the storing and notifying context.

--- a/doc/gone_item.md
+++ b/doc/gone_item.md
@@ -14,7 +14,6 @@ For example, given the following request:
     {
       "format": "gone",
       "publishing_app": "publisher",
-      "update_type": "major",
       "routes": [
         {"path": "/gone-foo", "type": "exact"},
         {"path": "/gone-foo/bar", "type": "exact"}

--- a/doc/input_examples/frontend-app/quick_answer.json
+++ b/doc/input_examples/frontend-app/quick_answer.json
@@ -15,7 +15,6 @@
   "need_ids": ["100535"],
   "locale": "en",
   "public_updated_at": "2014-04-29T09:59:40+01:00",
-  "update_type": "major",
   "tags": "TBC",
   "details": {
     "language": "en",

--- a/doc/input_examples/generic.json
+++ b/doc/input_examples/generic.json
@@ -23,14 +23,5 @@
   ],
   "redirects": [
     {"path": "/base-path/obsolete-path", "type": "exact"}
-  ],
-  // One of:
-  //  'major' - major changes to a piece of content.
-  //  'minor' - changes which don't affect the meaning of the content, eg typo
-  //            correction.
-  //  'republish' - useful in situations such as when the data structure has
-  //                changed.
-  //
-  // Others can be added in future, content-store will just pass them through to the fanout.
-  "update_type": "republish"
+  ]
 }

--- a/doc/redirect_item.md
+++ b/doc/redirect_item.md
@@ -14,7 +14,6 @@ For example, given the following request:
     {
       "format": "redirect",
       "publishing_app": "publisher",
-      "update_type": "major",
       "redirects": [
         {"path": "/moved-foo", "type": "prefix", "destination": "/new-foo"},
         {"path": "/moved-foo.json", "type": "exact", "destination": "/api/moved-foo.json"}

--- a/spec/factories/content_item.rb
+++ b/spec/factories/content_item.rb
@@ -6,7 +6,6 @@ FactoryGirl.define do
     sequence(:base_path) {|n| "/test-content-#{n}" }
     format 'gone' # Using gone as it allows the smallest valid base
     publishing_app 'publisher'
-    update_type 'minor'
     routes { [{ 'path' => base_path, 'type' => 'exact' }] }
 
     trait :with_content_id do

--- a/spec/integration/end_to_end_spec.rb
+++ b/spec/integration/end_to_end_spec.rb
@@ -8,7 +8,6 @@ describe "End-to-end behaviour", :type => :request do
     "content_id" => SecureRandom.uuid,
     "title" => "VAT rates",
     "format" => "answer",
-    "update_type" => "major",
     "publishing_app" => "publisher",
     "rendering_app" => "frontend",
     "routes" => [

--- a/spec/integration/submitting_content_item_spec.rb
+++ b/spec/integration/submitting_content_item_spec.rb
@@ -11,7 +11,6 @@ describe "content item write API", :type => :request do
       "need_ids" => ["100123", "100124"],
       "locale" => "en",
       "public_updated_at" => "2014-05-14T13:00:06Z",
-      "update_type" => "major",
       "publishing_app" => "publisher",
       "rendering_app" => "frontend",
       "details" => {

--- a/spec/integration/submitting_gone_item_spec.rb
+++ b/spec/integration/submitting_gone_item_spec.rb
@@ -8,7 +8,6 @@ describe "submitting gone items to the content store", :type => :request do
         "base_path" => "/dodo-sanctuary",
         "format" => "gone",
         "publishing_app" => "publisher",
-        "update_type" => "major",
         "routes" => [
           {"path" => "/dodo-sanctuary", "type" => "prefix"},
           {"path" => "/dodo-sanctuary.json", "type" => "exact"}

--- a/spec/integration/submitting_placeholder_item_spec.rb
+++ b/spec/integration/submitting_placeholder_item_spec.rb
@@ -9,7 +9,6 @@ describe "submitting placeholder items to the content store", :type => :request 
       "description" => "Current VAT rates",
       "format" => "placeholder",
       "public_updated_at" => "2014-05-14T13:00:06Z",
-      "update_type" => "major",
       "publishing_app" => "publisher",
       "rendering_app" => "frontend",
       "routes" => [

--- a/spec/integration/submitting_redirect_item_spec.rb
+++ b/spec/integration/submitting_redirect_item_spec.rb
@@ -8,7 +8,6 @@ describe "submitting redirect items to the content store", :type => :request do
       "format" => "redirect",
       "public_updated_at" => "2014-05-14T13:00:06Z",
       "publishing_app" => "publisher",
-      "update_type" => "major",
       "redirects" => [
         {"path" => "/crb-checks", "type" => "prefix", "destination" => "/dbs-checks"},
         {"path" => "/crb-checks.json", "type" => "exact", "destination" => "/api/content/dbs-checks"}

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -356,16 +356,6 @@ describe ContentItem, :type => :model do
     end
   end
 
-  it "should not persist update_type" do
-    item = build(:content_item)
-    item.update_attributes!(:update_type => "minor")
-
-    expect(item.update_type).to eq("minor")
-
-    item = ContentItem.find(item.base_path)
-    expect(item.update_type).to be_nil
-  end
-
   describe "registering routes" do
     before do
       @routes = [


### PR DESCRIPTION
This was previously used in the representation which
was sent to the message bus.  This sending is now
done in the Publishing API, so Content Store no
longer uses it.

Because this was a virtual field on the content
item the field was never stored in the database.

https://trello.com/c/0vlt6iS0/355-remove-mentions-of-update-type-from-content-store