### PR TITLE
Fix redirects for unpublishing that redirects

### DIFF
--- a/db/migrate/20151020130422_set_redirects_for_odd_unpublishings.csv
+++ b/db/migrate/20151020130422_set_redirects_for_odd_unpublishings.csv
@@ -1,0 +1,6 @@
+/government/publications/north-east-norfolk-and-north-suffolk-sixth-form-college-commissioner-summary-report,/government/collections/sixth-form-college-commissioner-summary-reports-and-letters
+/government/publications/radon-in-dwellings-in-northern-ireland,/government/collections/radiation-hpa-rpd-report-series
+/government/collections/uk-greenhouse-gas-emissions-statistics--2,/government/collections/uk-greenhouse-gas-emissions-statistics
+/government/publications/introducing-the-guidance-guarantee,/pensionwise
+/government/publications/inspections-of-residential-family-centres-framework-for-inspection-from-6-october-2014,/government/publications/inspecting-residential-family-centres-guidance-for-inspectors
+/guidance/school-direct-recruitment-and-marketing-guide,/guidance/initial-teacher-training-marketing-and-recruitment-guide

--- a/db/migrate/20151020130422_set_redirects_for_odd_unpublishings.rb
+++ b/db/migrate/20151020130422_set_redirects_for_odd_unpublishings.rb
@@ -1,0 +1,20 @@
+class SetRedirectsForOddUnpublishings < Mongoid::Migration
+  def self.up
+    existing_redirects = CSV.read("#{Rails.root}/db/migrate/20151020130422_set_redirects_for_odd_unpublishings.csv")
+
+    existing_redirects.each do |from_base_path, to_base_path|
+      content_item = ContentItem.find_by(base_path: from_base_path)
+      content_item.update_attributes!(
+        content_id: nil,
+        format: "redirect",
+        publishing_app: "whitehall",
+        rendering_app: nil,
+        redirects: [{ path: from_base_path, type: 'exact', destination: to_base_path }],
+        routes: [],
+      )
+    end
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
These special items have a duplicated content_id, but redirect to a third URL. As discussed with @rboulton it's probably best to fix these redirects here, as it's caused by a special workflow issue in
Whitehall.