### PR TITLE
Add data migration to include parent content ID on email signups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,5 +36,5 @@ group :development, :test do
   gem 'simplecov-rcov', '0.2.3', :require => false
   gem 'ci_reporter_rspec', '~> 1.0.0'
 
-  gem "byebug"
+  gem "pry-byebug"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,7 @@ GEM
     ci_reporter_rspec (1.0.0)
       ci_reporter (~> 2.0)
       rspec (>= 2.14, < 4)
+    coderay (1.1.0)
     columnize (0.9.0)
     connection_pool (2.1.0)
     crack (0.4.2)
@@ -79,6 +80,7 @@ GEM
       PriorityQueue (~> 0.1.2)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    method_source (0.8.2)
     mime-types (2.6.1)
     minitest (5.7.0)
     mongoid (4.0.0)
@@ -101,6 +103,13 @@ GEM
     optionable (0.2.0)
     origin (2.1.1)
     plek (1.11.0)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.2.0)
+      byebug (~> 5.0)
+      pry (~> 0.10)
     rack (1.5.5)
     rack-cache (1.2)
       rack (>= 0.4)
@@ -158,6 +167,7 @@ GEM
     simplecov-html (0.8.0)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
+    slop (3.6.0)
     sprockets (3.2.0)
       rack (~> 1.0)
     sprockets-rails (2.3.1)
@@ -188,7 +198,6 @@ PLATFORMS
 
 DEPENDENCIES
   airbrake (= 4.0.0)
-  byebug
   ci_reporter_rspec (~> 1.0.0)
   database_cleaner (~> 1.2)
   factory_girl (~> 4.4.0)
@@ -198,6 +207,7 @@ DEPENDENCIES
   mongoid (= 4.0.0)
   mongoid_rails_migrations (= 1.0.1)
   plek (~> 1.9)
+  pry-byebug
   rails (= 4.1.11)
   rails-api (= 0.2.1)
   rspec-rails (~> 3.0.2)

--- a/db/migrate/20151029154403_add_content_ids_to_email_signups.rb
+++ b/db/migrate/20151029154403_add_content_ids_to_email_signups.rb
@@ -1,0 +1,17 @@
+class AddContentIdsToEmailSignups < Mongoid::Migration
+  def self.up
+    ContentItem.any_of({base_path: /government\/policies\/.*email-signup$/}).each do |content_item|
+      policy_slug = content_item.details["tags"]["policy"].first
+      policy_content_id = ContentItem.any_of(
+        {base_path: "/government/policies/#{policy_slug}"}
+      ).first.content_id
+      content_item.links[:parent] = [policy_content_id]
+      content_item.save!
+    end
+  end
+
+  def self.down
+    # noop
+  end
+end
+


### PR DESCRIPTION
This is intended to be used by the email-alert-frontend to send on to the
email-alert-api, allowing policy subscriptions to be created by content
ID.

Trello: https://trello.com/c/ZD65QUBN/326-email-alerts-based-on-links-hash