### PR TITLE
De-duplicate content items...

### DIFF
--- a/lib/tasks/data_hygiene/content_item_deduplicator.rake
+++ b/lib/tasks/data_hygiene/content_item_deduplicator.rake
@@ -1,0 +1,15 @@
+require "tasks/data_hygiene/content_item_deduplicator"
+
+namespace :data_hygiene do
+  namespace :content_items do
+    desc "De-duplicate content items with matching content ids and locales by removing all but the latest record in each set of duplicates"
+    task deduplicate: [:environment] do
+      Tasks::DataHygiene::ContentItemDeduplicator.new.deduplicate
+    end
+
+    desc "Report on content items with matching content ids and locales"
+    task report_duplicates: [:environment] do
+      Tasks::DataHygiene::ContentItemDeduplicator.new.report_duplicates
+    end
+  end
+end

--- a/lib/tasks/data_hygiene/content_item_deduplicator.rb
+++ b/lib/tasks/data_hygiene/content_item_deduplicator.rb
@@ -1,0 +1,90 @@
+module Tasks
+  module DataHygiene
+    class ContentItemDeduplicator
+
+      attr_reader :do_destroy, :total, :deduplicated, :preserved
+
+      def report_duplicates
+        @do_destroy = false
+        process_duplicates
+      end
+
+      def deduplicate
+        @do_destroy = true
+        process_duplicates
+      end
+
+      private
+
+      def process_duplicates
+        @deduplicated = []
+        @preserved = []
+
+        # Iterate each array of dupes sorting them by updated_at
+        # preserving the latest record and destroying the rest
+        duplicates = fetch_duplicates_arrays
+        @total = duplicates.flatten.size
+
+        duplicates.each do |duplicate_set|
+
+          # Sort by updated_at and preserve the latest record.
+          duplicate_set.sort! {|x,y| x.updated_at <=> y.updated_at}
+          latest = duplicate_set.pop
+          @preserved << "#{latest.content_id},#{latest.locale},#{latest.updated_at},#{latest.base_path}"
+
+          # Usually this is a single item array as we typically have pairs of duplicates.
+          duplicate_set.each do |duplicate|
+            @deduplicated << "#{duplicate.content_id},#{duplicate.locale},#{duplicate.updated_at},#{duplicate.base_path}"
+
+            duplicate.destroy if do_destroy
+          end
+        end
+
+        report
+      end
+
+      # Produce an array of arrays containing duplicate ContentItems
+      def fetch_duplicates_arrays
+        [].tap do |ary|
+          duplicate_content_id_aggregation.each do |content_id_count|
+            ary << ContentItem.where(
+              content_id: content_id_count["_id"]["content_id"],
+              locale: content_id_count["_id"]["locale"]
+            ).to_a
+          end
+        end
+      end
+
+      # Fetch a count of all content items with content ids / locale duplicates.
+      def duplicate_content_id_aggregation
+        @duplicate_content_id_aggregation ||= ContentItem.collection.aggregate([
+          {
+            "$group" => {
+              "_id" => {"content_id" => "$content_id", "locale" => "$locale"},
+              "uniqueIds" => {"$addToSet" => "$_id"},
+              "count" => {"$sum" => 1}
+            }
+          },
+          {"$match" => {"_id.content_id" => {"$ne" => nil}, "count" => {"$gt" => 1}}}
+        ])
+      end
+
+      def report
+        aux_verb = do_destroy ? "were" : "would be"
+        puts "These duplicates #{aux_verb} destroyed..."
+        puts deduplicated.join("\n")
+
+        puts "-----------------------------------------------------------------"
+
+        puts "These records #{aux_verb} preserved..."
+        puts preserved.join("\n")
+
+        puts "-----------------------------------------------------------------"
+
+        puts "#{total} duplicates found."
+        puts "#{preserved.size} records #{aux_verb} removed."
+        puts "#{deduplicated.size} records #{aux_verb} preserved."
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/data_hygiene/content_item_deduplicator_spec.rb
+++ b/spec/lib/tasks/data_hygiene/content_item_deduplicator_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+require "tasks/data_hygiene/content_item_deduplicator"
+
+describe Tasks::DataHygiene::ContentItemDeduplicator do
+  let(:fake_stdout) { StringIO.new }
+
+  before do
+    @real_stdout = $stdout
+    $stdout = fake_stdout
+  end
+
+  after { $stdout = @real_stdout }
+
+  describe "#deduplicate" do
+    it "runs without issue" do
+      content_item = create(:content_item_with_content_id, locale: 'cy')
+      dupe = create(:content_item, content_id: content_item.content_id, locale: 'cy')
+      locale_variant = create(:content_item, content_id: content_item.content_id, locale: 'en')
+
+      expect { subject.deduplicate }.to change(ContentItem, :count).by(-1)
+
+      fake_stdout.rewind
+      output = fake_stdout.read
+      expect(output).to match(/2 duplicates found/)
+      expect(output).to match(/1 records were removed/)
+    end
+  end
+
+  describe "#report_duplicates" do
+    it "runs without issue" do
+      content_item = create(:content_item_with_content_id, locale: 'en')
+      create(:content_item, content_id: content_item.content_id, locale: 'en')
+      create(:content_item, content_id: content_item.content_id, locale: 'fr')
+
+      expect { subject.report_duplicates }.not_to change(ContentItem, :count)
+
+      fake_stdout.rewind
+      output = fake_stdout.read
+
+      expect(output).to match(/2 duplicates found/)
+      expect(output).to match(/1 records would be removed/)
+    end
+  end
+end


### PR DESCRIPTION
Duplicate content items sharing the same `content_id` and `locale`
periodically get added to the content store. A detailed explanation
of how this happens can be found here:
https://gov-uk.atlassian.net/wiki/display/FS/Duplicate+content-ids

This pull request adds tasks to find duplicates and report or
de-duplicate by destroying the older record(s) in a duplicate set.

To report:
```
rake data_hygiene:content_items:report_duplicates
```

To deduplicate:
```
rake data_hygiene:content_items:deduplicate
```