### PR TITLE
Add email_alert_type to email signup items

### DIFF
--- a/db/migrate/20151110173144_add_signup_type_to_email_alert_signups.rb
+++ b/db/migrate/20151110173144_add_signup_type_to_email_alert_signups.rb
@@ -1,0 +1,15 @@
+class AddSignupTypeToEmailAlertSignups < Mongoid::Migration
+  def self.up
+    ContentItem.any_of({base_path: /.*government.*email-signup.*/, rendering_app: "email-alert-frontend"}).each do |policy_email_signup|
+      policy_email_signup.details[:email_alert_type] = "policies"
+      policy_email_signup.save!
+    end
+  end
+
+  def self.down
+    ContentItem.any_of({base_path: /.*government.*email-signup.*/, rendering_app: "email-alert-frontend"}).each do |policy_email_signup|
+      policy_email_signup.details.delete("email_alert_type")
+      policy_email_signup.save!
+    end
+  end
+end


### PR DESCRIPTION


This will support the email-alert-frontend by providing it with the
information it needs to correctly construct a subscription request for
the email-alert-api.