### PR TITLE
Change tagging of email alert signup content items

### DIFF
--- a/db/migrate/20151113171020_replace_tags_with_signup_tags_on_email_alerts.rb
+++ b/db/migrate/20151113171020_replace_tags_with_signup_tags_on_email_alerts.rb
@@ -1,0 +1,19 @@
+class ReplaceTagsWithSignupTagsOnEmailAlerts < Mongoid::Migration
+  def self.up
+    ContentItem.any_of({base_path: /government\/policies.*email-signup.*/, rendering_app: 'email-alert-frontend'}).each do |item|
+      policy = item.details["tags"]["policy"]
+      item.details.delete("tags")
+      item.details["signup_tags"] = { "policies" => policy }
+      item.save!
+    end
+  end
+
+  def self.down
+    ContentItem.any_of({base_path: /government\/policies.*email-signup.*/, rendering_app: 'email-alert-frontend'}).each do |item|
+      policy = item.details["signup_tags"]["policies"]
+      item.details.delete("signup_tags")
+      item.details["tags"] = { "policy" => policy }
+      item.save!
+    end
+  end
+end


### PR DESCRIPTION
Existing email_alert_signup items currently only relate to policy alerts.
These items should be tagged with some kind of reference to the policy
they handle signups for. Currently, this reference is stored as
"details" => { "tags" => "some-policy" }. 'Tags' is not a good name in
this context. It stomps over the existing semantics for the "tags" field,
i.e. - "this piece of content is tagged to this policy".

This commit introduces a data migration to change this field to "signup_tags".
It also takes this opportunity to pluralize 'policy' for consistency with
the links attribute. This change brings the content store in line with
concurrent changes being made to policy-publisher, which handles the
presentation of all existing email_alert_signup items.