### PR TITLE
[Do Not Merge] Generate content ids when missing from ContentItem...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ else
 end
 
 gem 'govuk-content-schema-test-helpers', '1.3.0'
+gem 'uuidtools', '2.1.5'
 
 group :development, :test do
   gem 'rspec-rails', '~> 3.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,6 +224,7 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
+    uuidtools (2.1.5)
     webmock (1.18.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -255,5 +256,6 @@ DEPENDENCIES
   statsd-ruby (~> 1.2.1)
   timecop (= 0.7.1)
   unicorn (= 4.8.2)
+  uuidtools (= 2.1.5)
   webmock (~> 1.18.0)
   whenever (~> 0.9.4)

--- a/db/migrate/20151119100304_update_blank_content_item_content_ids.rb
+++ b/db/migrate/20151119100304_update_blank_content_item_content_ids.rb
@@ -3,7 +3,7 @@ class UpdateBlankContentItemContentIds < Mongoid::Migration
     content_items = []
 
     ContentItem.where(content_id: nil).each do |item|
-      item.update!(content_id: SecureRandom.uuid)
+      item.set(content_id: SecureRandom.uuid)
 
       content_items << "#{item.content_id},#{item.publishing_app},#{item.base_path}"
     end
@@ -17,7 +17,7 @@ class UpdateBlankContentItemContentIds < Mongoid::Migration
     content_items = []
 
     ContentItem.renderable_content.where(public_updated_at: nil).each do |item|
-      item.update!(public_updated_at: item.updated_at)
+      item.set(public_updated_at: item.updated_at)
       content_items << "#{item.public_updated_at},#{item.publishing_app},#{item.base_path}"
     end
 

--- a/db/migrate/20151119100304_update_blank_content_item_content_ids.rb
+++ b/db/migrate/20151119100304_update_blank_content_item_content_ids.rb
@@ -1,18 +1,26 @@
+require "uuidtools"
+
 class UpdateBlankContentItemContentIds < Mongoid::Migration
   def self.up
     content_items = []
 
+    ContentItem.where(content_id: nil, publishing_app: "hmrc-manuals-api").each do |item|
+      item.set(content_id: UUIDTools::UUID.sha1_create(UUIDTools::UUID_URL_NAMESPACE, item.base_path))
+      content_items << "#{item.content_id},#{item.publishing_app},#{item.base_path}"
+    end
+
+    report_path = "./tmp/generated_hmrc_manuals_api_content_ids.txt"
+    report_missing_content_ids(report_path, content_items)
+
+    content_items = []
+
     ContentItem.where(content_id: nil).each do |item|
       item.set(content_id: SecureRandom.uuid)
-
       content_items << "#{item.content_id},#{item.publishing_app},#{item.base_path}"
     end
 
     report_path = "./tmp/generated_content_ids.txt"
-    File.write(report_path, "content_id,publishing_app,base_path")
-    File.write(report_path, content_items.join("\n"))
-    puts "#{content_items.size} missing content_id values assigned."
-    puts "Details written to #{report_path}"
+    report_missing_content_ids(report_path, content_items)
 
     content_items = []
 
@@ -22,12 +30,24 @@ class UpdateBlankContentItemContentIds < Mongoid::Migration
     end
 
     report_path = "./tmp/assigned_public_updated_at.txt"
-    File.write(report_path, "public_updated_at,publishing_app,base_path")
-    File.write(report_path, content_items.join("\n"))
+    report_to_file(report_path, "public_updated_at,publishing_app,base_path", content_items)
     puts "#{content_items.size} missing public_updated_at values assigned."
     puts "Details written to #{report_path}"
   end
 
   def self.down
+  end
+
+private
+
+  def self.report_missing_content_ids(path, items)
+    report_to_file(path, "content_id,publishing_app,base_path", items)
+    puts "#{items.size} missing content_id values assigned."
+    puts "Details written to #{path}"
+  end
+
+  def self.report_to_file(path, headings, items)
+    File.write(path, headings)
+    File.write(path, items.join("\n"))
   end
 end

--- a/db/migrate/20151119100304_update_blank_content_item_content_ids.rb
+++ b/db/migrate/20151119100304_update_blank_content_item_content_ids.rb
@@ -1,0 +1,33 @@
+class UpdateBlankContentItemContentIds < Mongoid::Migration
+  def self.up
+    content_items = []
+
+    ContentItem.where(content_id: nil).each do |item|
+      item.update!(content_id: SecureRandom.uuid)
+
+      content_items << "#{item.content_id},#{item.publishing_app},#{item.base_path}"
+    end
+
+    report_path = "./tmp/generated_content_ids.txt"
+    File.write(report_path, "content_id,publishing_app,base_path")
+    File.write(report_path, content_items.join("\n"))
+    puts "#{content_items.size} missing content_id values assigned."
+    puts "Details written to #{report_path}"
+
+    content_items = []
+
+    ContentItem.renderable_content.where(public_updated_at: nil).each do |item|
+      item.update!(public_updated_at: item.updated_at)
+      content_items << "#{item.public_updated_at},#{item.publishing_app},#{item.base_path}"
+    end
+
+    report_path = "./tmp/assigned_public_updated_at.txt"
+    File.write(report_path, "public_updated_at,publishing_app,base_path")
+    File.write(report_path, content_items.join("\n"))
+    puts "#{content_items.size} missing public_updated_at values assigned."
+    puts "Details written to #{report_path}"
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
Please don't merge yet as there are a couple of applications that still require updates to how content_ids are generated and tracked before we can update the remaining data.
Generate `content_id` from `SecureRandom.uuid` for content items which do
not have a value.
Copy the `updated_at` value to `public_updated_at` field for renderable
content items which don't have a value.

Reports updates to files in `./tmp` 