### PR TITLE
Add a taggings-per-app endpoint

### DIFF
--- a/app/controllers/debug_controller.rb
+++ b/app/controllers/debug_controller.rb
@@ -1,0 +1,7 @@
+require 'taggings_per_app'
+
+class DebugController < ApplicationController
+  def taggings_per_app
+    render json: TaggingsPerApp.new(params.fetch(:app)).taggings
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,4 +12,5 @@ Rails.application.routes.draw do
   end
 
   get "/healthcheck", :to => proc { [200, {}, ["OK"]] }
+  get "/debug/taggings-per-app" => "debug#taggings_per_app"
 end

--- a/lib/taggings_per_app.rb
+++ b/lib/taggings_per_app.rb
@@ -1,0 +1,19 @@
+class TaggingsPerApp
+  TAGS = %w[mainstream_browse_pages topics organisations parent]
+
+  def initialize(app_name)
+    @app_name = app_name
+  end
+
+  def taggings
+    relevant_content_items.each_with_object({}) do |content_item, result|
+      result[content_item.content_id] = content_item.links.slice(*TAGS)
+    end
+  end
+
+private
+
+  def relevant_content_items
+    ContentItem.where(publishing_app: @app_name)
+  end
+end

--- a/spec/lib/taggings_per_app_spec.rb
+++ b/spec/lib/taggings_per_app_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+require 'taggings_per_app'
+
+describe TaggingsPerApp do
+  describe "#taggings" do
+    it "returns taggings of the content items for an application" do
+      create(:content_item, content_id: '42de1d3f-5d73-48d2-bc0d-5317c330f21b', publishing_app: 'publisher')
+      create(:content_item,
+        content_id: 'bbcaf28a-1784-4d30-b6be-f4db4089432c',
+        publishing_app: 'smartanswers',
+        links: {
+          "mainstream_browse_pages" => ["56d4ec50-e0ad-44bd-8b49-4d47ddf68a24"]
+        }
+      )
+
+      taggings = TaggingsPerApp.new('smartanswers').taggings
+
+      expect(taggings).to eql(
+        {
+          'bbcaf28a-1784-4d30-b6be-f4db4089432c' => {
+            "mainstream_browse_pages" => ['56d4ec50-e0ad-44bd-8b49-4d47ddf68a24']
+          }
+        }
+      )
+    end
+  end
+end


### PR DESCRIPTION
/debug/taggings-per-app.json is a temporary endpoint which will be used to compare the taggings in panopti(con)tentapi with the taggings in the content-store.

This will aid us in the migration and will allow us to be confident that we haven't inadvertently removed any tagging.

Trello: https://trello.com/c/DLakGcP0
On content-api: https://github.com/alphagov/govuk_content_api/pull/233