### PR TITLE
Content type presentation

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -46,7 +46,7 @@ class ContentItem
   field :_id, :as => :base_path, :type => String, :overwrite => true
   field :content_id, :type => String
   field :title, :type => String
-  field :description, :type => String
+  field :description, :type => Hash, :default => { "value" => nil }
   field :format, :type => String
   field :locale, :type => String, :default => I18n.default_locale.to_s
   field :need_ids, :type => Array, :default => []
@@ -80,6 +80,16 @@ class ContentItem
     super(options).tap do |hash|
       hash["base_path"] = hash.delete("_id")
     end
+  end
+
+  # We store the description in a hash because Publishing API can send through
+  # multiple content types.
+  def description=(value)
+    super("value" => value)
+  end
+
+  def description
+    super.fetch("value")
   end
 
   def redirect?

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -89,7 +89,16 @@ class ContentItem
   end
 
   def description
-    super.fetch("value")
+    description = super
+
+    if description.is_a?(Hash)
+      description.fetch("value")
+    else
+      # This is here to ensure backwards compatibility during data migration:
+      # db/migrate/20151130111755_description_value_hash.rb
+      # It can be removed afterwards.
+      description
+    end
   end
 
   def redirect?

--- a/app/presenters/content_type_resolver.rb
+++ b/app/presenters/content_type_resolver.rb
@@ -1,0 +1,44 @@
+class ContentTypeResolver
+  def initialize(content_type)
+    self.content_type = content_type
+  end
+
+  def resolve(object)
+    if object.is_a?(Hash)
+      resolve_hash(object)
+    elsif object.is_a?(Array)
+      resolve_array(object)
+    else
+      object
+    end
+  end
+
+private
+  def resolve_hash(hash)
+    hash.inject({}) do |hash, (key, value)|
+      hash.merge(key => resolve(value))
+    end
+  end
+
+  def resolve_array(array)
+    if has_content_types?(array)
+      extract_content(array)
+    else
+      array.map { |e| resolve(e) }
+    end
+  end
+
+  def has_content_types?(array)
+    return false unless array.all? { |v| v.is_a?(Hash) }
+
+    hash_keys = array.flat_map(&:keys).map(&:to_sym)
+    hash_keys.include?(:content_type)
+  end
+
+  def extract_content(array)
+    array = array.map(&:symbolize_keys)
+    array.detect { |h| h[:content_type] == content_type }[:content]
+  end
+
+  attr_accessor :content_type
+end

--- a/db/migrate/20151130111755_description_value_hash.rb
+++ b/db/migrate/20151130111755_description_value_hash.rb
@@ -1,0 +1,19 @@
+class DescriptionValueHash < Mongoid::Migration
+  def self.up
+    puts "Migrating description strings into value hashes, e.g."
+    puts "'some description' : { 'value' => 'some description' }"
+
+    ContentItem.all.each.with_index do |item, index|
+      print "." if (index % 100).zero?
+
+      description = item["description"]
+
+      unless description.is_a?(Hash)
+        item.description = description
+        item.save!(validate: false)
+      end
+    end
+
+    puts
+  end
+end

--- a/spec/integration/public_api_request_spec.rb
+++ b/spec/integration/public_api_request_spec.rb
@@ -1,14 +1,37 @@
 require 'rails_helper'
 
 describe "Public API requests for content items", :type => :request do
-  let(:content_item) { create(:content_item, links: { 'related' => [linked_item.content_id] }) }
-  let(:linked_item) { create(:content_item, :with_content_id) }
+  let(:content_item) do
+    FactoryGirl.create(
+      :content_item,
+      links: { 'related' => [linked_item.content_id] },
+      description: [
+        { content_type: "text/html", content: "<p>content</p>" },
+        { content_type: "text/plain", content: "content" },
+      ],
+      details: {
+        body: [
+          { content_type: "text/html", content: "<p>content</p>" },
+          { content_type: "text/plain", content: "content" },
+        ]
+      }
+    )
+  end
+
+  let(:linked_item) { FactoryGirl.create(:content_item, :with_content_id) }
 
   it "corrrectly expands linked items with Public API URLs" do
     get_api_content content_item
-
     data = JSON.parse(response.body)
 
     expect(data["links"]["related"].first["api_url"]).to eq("http://www.example.com/api/content#{linked_item.base_path}")
+  end
+
+  it "inlines the 'text/html' content type" do
+    get_api_content content_item
+    data = JSON.parse(response.body)
+
+    expect(data["description"]).to eq("<p>content</p>")
+    expect(data["details"]["body"]).to eq("<p>content</p>")
   end
 end

--- a/spec/integration/submitting_content_item_spec.rb
+++ b/spec/integration/submitting_content_item_spec.rb
@@ -65,6 +65,26 @@ describe "content item write API", :type => :request do
         expect(response.status).to eq(201)
       end
     end
+
+    context "with multiple content types" do
+      before do
+        @data.merge!("description" => [
+          { "content_type" => "text/html", "content" => "<p>content</p>" },
+          { "content_type" => "text/plain", "content" => "content" },
+        ])
+      end
+
+      it "creates the content item" do
+        put_json "/content/vat-rates", @data
+        expect(response.status).to eq(201)
+
+        item = ContentItem.where(:base_path => "/vat-rates").first
+        expect(item.description).to eq [
+          { "content_type" => "text/html", "content" => "<p>content</p>" },
+          { "content_type" => "text/plain", "content" => "content" },
+        ]
+      end
+    end
   end
 
   describe "creating a non-English content item" do

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -421,4 +421,13 @@ describe ContentItem, :type => :model do
       end
     end
   end
+
+  describe "description" do
+    it "wraps the description as a hash" do
+      content_item = FactoryGirl.create(:content_item, description: "foo")
+
+      expect(content_item.description).to eq("foo")
+      expect(content_item["description"]).to eq("value" => "foo")
+    end
+  end
 end

--- a/spec/presenters/content_type_resolver_spec.rb
+++ b/spec/presenters/content_type_resolver_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+
+RSpec.describe ContentTypeResolver do
+  subject { described_class.new("html") }
+
+  it "inlines content of the specified content type" do
+    result = subject.resolve(
+      body: [
+        { content_type: "html", content: "<p>body</p>" },
+        { content_type: "text", content: "body" },
+      ]
+    )
+
+    expect(result).to eq(
+      body: "<p>body</p>"
+    )
+  end
+
+  it "works for string keys as well as symbols" do
+    result = subject.resolve(
+      "body" => [
+        { "content_type" => "html", "content" => "<p>body</p>" },
+        { "content_type" => "text", "content" => "body" },
+      ]
+    )
+
+    expect(result).to eq(
+      "body" => "<p>body</p>"
+    )
+  end
+
+  it "does not affect other fields" do
+    result = subject.resolve(
+      string: "string",
+      array: [],
+      number: 123,
+    )
+
+    expect(result).to eq(
+      string: "string",
+      array: [],
+      number: 123,
+    )
+  end
+
+  it "recurses on nested hashes" do
+    result = subject.resolve(
+      details: {
+        foo: {
+          bar: {
+            content: [
+              { content_type: "html", content: "<p>body</p>" }
+            ]
+          }
+        }
+      }
+    )
+
+    expect(result).to eq(
+      details: {
+        foo: {
+          bar: {
+            content: "<p>body</p>"
+          }
+        }
+      }
+    )
+  end
+
+  it "recurses on nested arrays" do
+    result = subject.resolve(
+      paragraphs: [
+        [
+          [
+            {
+              body: [
+                { content_type: "html", content: "<p>body</p>" }
+              ]
+            }
+          ]
+        ]
+      ]
+    )
+
+    expect(result).to eq(
+      paragraphs: [
+        [
+          [
+            {
+              body: "<p>body</p>"
+            }
+          ]
+        ]
+      ]
+    )
+  end
+end


### PR DESCRIPTION
https://trello.com/c/nkofgTdj/372-govspeak-part-2-move-contenttyperesolver-to-a-presenter-in-the-contentstore

This is the other half of the govspeak story. We decided that it would be better to move the content type resolution into the content store presentation layer.

This pull request includes a data migration that is quite slow (~8 minutes), so I've made sure that the implementation is backwards compatible whilst it is migrating.

We can remove that backwards compatibility in a separate pull request later.

The publishing api pull request is here: https://github.com/alphagov/publishing-api/pull/156

This pull request needs to be merged first.