### PR TITLE
Add endpoint for an item's incoming links

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,4 +27,15 @@ class ApplicationController < ActionController::API
   def base_path
     "/#{params[:base_path_without_root]}"
   end
+
+  # The presenter needs context about routes and host names from controller
+  # to know how to generate API URLs, so we can take the Rails helper and
+  # pass that in as a callable
+  def api_url_method
+    if params[:public_api_request]
+      method(:content_item_api_url)
+    else
+      method(:content_item_url)
+    end
+  end
 end

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -60,17 +60,6 @@ class ContentItemsController < ApplicationController
     }
   end
 
-  # The presenter needs context about routes and host names from controller
-  # to know how to generate API URLs, so we can take the Rails helper and
-  # pass that in as a callable
-  def api_url_method
-    if params[:public_api_request]
-      method(:content_item_api_url)
-    else
-      method(:content_item_url)
-    end
-  end
-
   def set_default_cache_headers
     intent = PublishIntent.where(:base_path => encoded_base_path).first
     if intent && !intent.past?

--- a/app/controllers/linked_items_controller.rb
+++ b/app/controllers/linked_items_controller.rb
@@ -1,0 +1,7 @@
+class LinkedItemsController < ApplicationController
+  def incoming_links
+    item = ContentItem.find_by(base_path: encoded_base_path)
+    links = IncomingLinksPresenter.new(item, params.fetch(:types), api_url_method)
+    render json: links
+  end
+end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -116,6 +116,10 @@ class ContentItem
     items
   end
 
+  def incoming_links(type)
+    ContentItem.where("links.#{type}" => { "$in" => [ content_id ]})
+  end
+
   def viewable_by?(user_uid)
     !access_limited? || authorised_user_uids.include?(user_uid)
   end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -42,26 +42,6 @@ private
   end
 
   def present_linked_item(linked_item)
-    presented = {
-      "content_id" => linked_item.content_id,
-      "title" => linked_item.title,
-      "base_path" => linked_item.base_path,
-      "description" => RESOLVER.resolve(linked_item.description),
-      "api_url" => api_url(linked_item),
-      "web_url" => web_url(linked_item),
-      "locale" => linked_item.locale,
-    }
-    if linked_item.has_attribute? :analytics_identifier
-      presented["analytics_identifier"] = linked_item.analytics_identifier
-    end
-    presented
-  end
-
-  def api_url(item)
-    @api_url_method.call(item.base_path_without_root)
-  end
-
-  def web_url(item)
-    Plek.current.website_root + item.base_path
+    LinkedItemPresenter.new(linked_item, @api_url_method).present
   end
 end

--- a/app/presenters/incoming_links_presenter.rb
+++ b/app/presenters/incoming_links_presenter.rb
@@ -1,0 +1,19 @@
+class IncomingLinksPresenter
+  def initialize(item, types, api_url_method)
+    @item = item
+    @types = types
+    @api_url_method = api_url_method
+  end
+
+  def as_json(*)
+    @types.each_with_object({}) do |type, hash|
+      incoming_links = @item.incoming_links(type)
+      hash[type] = incoming_links.map { |i| present_linked_item(i) }
+    end
+  end
+
+private
+  def present_linked_item(linked_item)
+    LinkedItemPresenter.new(linked_item, @api_url_method).present
+  end
+end

--- a/app/presenters/linked_item_presenter.rb
+++ b/app/presenters/linked_item_presenter.rb
@@ -26,7 +26,6 @@ class LinkedItemPresenter
   end
 
 private
-
   def api_url(item)
     @api_url_method.call(item.base_path_without_root)
   end

--- a/app/presenters/linked_item_presenter.rb
+++ b/app/presenters/linked_item_presenter.rb
@@ -1,0 +1,37 @@
+# Presenter for generating the public-facing representation of content item links.
+class LinkedItemPresenter
+  attr_reader :linked_item, :api_url_method
+
+  def initialize(linked_item, api_url_method)
+    @linked_item = linked_item
+    @api_url_method = api_url_method
+  end
+
+  def present
+    presented = {
+      "content_id" => linked_item.content_id,
+      "title" => linked_item.title,
+      "base_path" => linked_item.base_path,
+      "description" => ContentItemPresenter::RESOLVER.resolve(linked_item.description),
+      "api_url" => api_url(linked_item),
+      "web_url" => web_url(linked_item),
+      "locale" => linked_item.locale,
+    }
+
+    if linked_item.has_attribute?(:analytics_identifier)
+      presented["analytics_identifier"] = linked_item.analytics_identifier
+    end
+
+    presented
+  end
+
+private
+
+  def api_url(item)
+    @api_url_method.call(item.base_path_without_root)
+  end
+
+  def web_url(item)
+    Plek.current.website_root + item.base_path
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,9 @@ Rails.application.routes.draw do
     put "/content(/*base_path_without_root)" => "content_items#update"
     delete "/content(/*base_path_without_root)" => "content_items#destroy"
 
+    get "/incoming-links(/*base_path_without_root)" => "linked_items#incoming_links"
+    get "/api/incoming-links(/*base_path_without_root)" => "linked_items#incoming_links", :public_api_request => true
+
     get "/publish-intent(/*base_path_without_root)" => "publish_intents#show"
     put "/publish-intent(/*base_path_without_root)" => "publish_intents#update"
     delete "/publish-intent(/*base_path_without_root)" => "publish_intents#destroy"

--- a/spec/integration/fetching_linked_items_spec.rb
+++ b/spec/integration/fetching_linked_items_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+describe "Fetching linked items", type: :request do
+  describe "GET /incoming-links/:base_path_without_root" do
+    it "returns the items linked to an item" do
+      item = create(:content_item, :with_content_id)
+      create(:content_item, content_id: 'ID-1', base_path: '/a', title: "A", links: { "parent" => [item.content_id] })
+      create(:content_item, content_id: 'ID-2', base_path: '/b', title: "B", links: { "parent" => [item.content_id] })
+
+      get "/incoming-links#{item.base_path}?types[]=parent&types[]=topics"
+
+      expect(parsed_response["parent"]).to eql([
+        {
+          "content_id" => "ID-1",
+          "title" => "A",
+          "base_path" => "/a",
+          "description" => nil,
+          "api_url" => "http://www.example.com/content/a",
+          "web_url" => "https://www.test.gov.uk/a",
+          "locale" => "en",
+        },
+        {
+          "content_id" => "ID-2",
+          "title" => "B",
+          "base_path" => "/b",
+          "description" => nil,
+          "api_url" => "http://www.example.com/content/b",
+          "web_url" => "https://www.test.gov.uk/b",
+          "locale" => "en",
+        },
+      ])
+
+      expect(parsed_response["topics"]).to eql([])
+    end
+  end
+
+  describe "GET /api/incoming-links/:base_path_without_root" do
+    it "is the public version of the endpoint" do
+      item = create(:content_item, :with_content_id)
+      create(:content_item, content_id: 'ID-1', base_path: '/a', title: "A", links: { "parent" => [item.content_id] })
+
+      get "/api/incoming-links#{item.base_path}?types[]=parent&types[]=topics"
+
+      expect(response).to be_successful
+    end
+  end
+
+  def parsed_response
+    @parsed_response ||= JSON.parse(response.body)
+  end
+end

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -20,11 +20,9 @@ describe ContentItemPresenter do
   end
 
   context "with related links" do
-    let(:linked_item1) { create(:content_item, :with_content_id, locale: I18n.default_locale.to_s) }
-    let(:linked_item2) { create(:content_item, :with_content_id, locale: "fr", analytics_identifier: "D2") }
+    let(:linked_item1) { create(:content_item, :with_content_id) }
+    let(:linked_item2) { create(:content_item, :with_content_id) }
     let(:links) { { "related" => [linked_item1.content_id, linked_item2.content_id] } }
-    let(:locale) { "fr" }
-    let(:related) { presenter.as_json["links"]["related"] }
 
     it "includes the link type" do
       expect(presenter.as_json).to have_key("links")
@@ -32,39 +30,7 @@ describe ContentItemPresenter do
     end
 
     it "includes each linked item" do
-      expect(related.size).to be(2)
-    end
-
-    it "includes the content_id, path, title and description for each item" do
-      expect(related).to all include("content_id", "base_path", "title", "description")
-    end
-
-    it "includes the locale for each item" do
-      expect(related.map { |item| item['locale'] }).to eq(['en', 'fr'])
-    end
-
-    it "links to the API URL for each item" do
-      expect(related.map { |item| item["api_url"] }).to eq(
-        [
-          "http://api.example.com/content#{linked_item1.base_path}",
-          "http://api.example.com/content#{linked_item2.base_path}",
-        ]
-      )
-    end
-
-    it "links to the web URL for each item" do
-      site_root = Plek.current.website_root
-      expect(related.map { |item| item["web_url"] }).to eq(
-        [
-          "#{site_root}#{linked_item1.base_path}",
-          "#{site_root}#{linked_item2.base_path}",
-        ]
-      )
-    end
-
-    it "contains the linked analytics identifier" do
-      expect(related[1]).to have_key("analytics_identifier")
-      expect(related[1]["analytics_identifier"]).to eq('D2')
+      expect(presenter.as_json["links"]["related"].size).to be(2)
     end
   end
 
@@ -92,27 +58,6 @@ describe ContentItemPresenter do
 
     it "inlines the 'text/html' content type in the details" do
       expect(presenter.as_json["details"]).to eq(body: "<p>content</p>")
-    end
-
-    context "with related links" do
-      let(:linked_item) do
-        FactoryGirl.create(
-          :content_item,
-          :with_content_id,
-          locale: I18n.default_locale.to_s,
-          description: [
-            { content_type: "text/html", content: "<p>linked content</p>" },
-            { content_type: "text/plain", content: "linked content" },
-          ],
-        )
-      end
-
-      let(:links) { { "related" => [linked_item.content_id] } }
-
-      it "inlines the 'text/html' content type in the linked description" do
-        related = presenter.as_json["links"]["related"]
-        expect(related.first["description"]).to eq("<p>linked content</p>")
-      end
     end
   end
 end

--- a/spec/presenters/linked_item_presenter_spec.rb
+++ b/spec/presenters/linked_item_presenter_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe LinkedItemPresenter do
+  let(:api_url_method) do
+    lambda { |base_path| "http://api.example.com/content/#{base_path}" }
+  end
+
+  describe "#present" do
+    it "presents the correct data" do
+      content_item = create(:content_item,
+        content_id: 'AN-ID',
+        title: "My Title",
+        base_path: '/my-page',
+        description: [
+          { content_type: "text/html", content: "<p>A HTML description.</p>" },
+          { content_type: "text/plain", content: "Short description." },
+        ],
+      )
+
+      presenter = LinkedItemPresenter.new(content_item, api_url_method)
+
+      expect(presenter.present).to eql({
+        "content_id" => "AN-ID",
+        "title" => "My Title",
+        "base_path" => "/my-page",
+        "description" => "<p>A HTML description.</p>",
+        "api_url" => "http://api.example.com/content/my-page",
+        "web_url" => "https://www.test.gov.uk/my-page",
+        "locale" => "en"
+      })
+    end
+
+    it "adds the analytics identifier if present" do
+      content_item = create(:content_item,
+        analytics_identifier: 'UA-123123',
+      )
+
+      presenter = LinkedItemPresenter.new(content_item, api_url_method)
+
+      expect(presenter.present['analytics_identifier']).to eql('UA-123123')
+    end
+  end
+end


### PR DESCRIPTION
The `/incoming-links` endpoint can be used to get the "incoming" links for a content item.

It will be used by the collections to display a list of pages tagged to a particular topic.

There was some discussion beforehand about this, see RFC 37:

https://gov-uk.atlassian.net/wiki/display/FS/RFC+37%3A+Add+linked+items+to+content+items#

Related Trello ticket: https://trello.com/c/bsZAwZ35