### PR TITLE
Generate HMRC Manuals content_ids from base path...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ else
 end
 
 gem 'govuk-content-schema-test-helpers', '1.3.0'
+gem 'uuidtools', '2.1.5'
 
 group :development, :test do
   gem 'rspec-rails', '~> 3.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,6 +224,7 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
+    uuidtools (2.1.5)
     webmock (1.18.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -255,5 +256,6 @@ DEPENDENCIES
   statsd-ruby (~> 1.2.1)
   timecop (= 0.7.1)
   unicorn (= 4.8.2)
+  uuidtools (= 2.1.5)
   webmock (~> 1.18.0)
   whenever (~> 0.9.4)

--- a/db/migrate/20151207120531_update_blank_hmrc_manuals_content_ids.rb
+++ b/db/migrate/20151207120531_update_blank_hmrc_manuals_content_ids.rb
@@ -1,0 +1,33 @@
+require "uuidtools"
+
+class UpdateBlankHmrcManualsContentIds < Mongoid::Migration
+  def self.up
+    content_items = []
+
+    ContentItem.where(content_id: nil, publishing_app: "hmrc-manuals-api").each do |item|
+      item.set(content_id: UUIDTools::UUID.sha1_create(UUIDTools::UUID_URL_NAMESPACE, item.base_path))
+      content_items << "#{item.content_id},#{item.base_path}"
+    end
+
+    report_path = "./tmp/generated_hmrc_manuals_api_content_ids.txt"
+    report_missing_content_ids(report_path, content_items)
+  end
+
+  def self.down
+  end
+
+private
+
+  def self.report_missing_content_ids(path, items)
+    report_to_file(path, "content_id,base_path", items)
+    puts "#{items.size} missing content_id values assigned."
+    puts "Details written to #{path}"
+  end
+
+  def self.report_to_file(path, headings, items)
+    File.open(path, "w") do |file|
+      file.puts headings
+      file.puts items.join("\n")
+    end
+  end
+end


### PR DESCRIPTION
HMRC manuals API generates v5 uuids from a sha1 hash of the base path.
This change ensures the content store employs the same method when
generating content ids.

Reports updates to content items in `./tmp/generated_hmrc_manuals_api_content_ids`

See
https://github.com/alphagov/hmrc-manuals-api/pull/122
for details.
