### PR TITLE
Data cleanup

### DIFF
--- a/lib/tasks/data_hygiene/missing_attributes.rake
+++ b/lib/tasks/data_hygiene/missing_attributes.rake
@@ -1,0 +1,61 @@
+namespace :data_hygiene do
+  def write_file(report_path, content_items)
+    File.open(report_path, "w") do |file|
+      file.puts "content_id,public_updated_at,publishing_app,base_path"
+      file.puts content_items.join("\n")
+    end
+
+    puts "#{content_items.size} missing values assigned."
+    puts "Details written to #{report_path}"
+  end
+
+  desc "Generates a content_id for content items that do not have one"
+  task generate_content_id: :environment do
+    content_items = []
+
+    ContentItem.where(content_id: nil).each do |item|
+      item.set(content_id: SecureRandom.uuid)
+
+      content_items << "#{item.content_id},#{item.public_updated_at},#{item.publishing_app},#{item.base_path}"
+    end
+
+    write_file("./tmp/generated_content_ids.txt", content_items)
+  end
+
+  desc "Generate a content_id where missing, but reuse where possible from IMPORT_PATH"
+  task reuse_content_id: :environment do
+    import_path = ENV.fetch("IMPORT_PATH")
+    lines = File.read(import_path).split("\n")
+    lines = lines[1..-1]
+
+    hash = lines.each.with_object({}) do |line, hash|
+      content_id, _, _, base_path = line.split(",")
+      hash[base_path] = content_id
+    end
+
+    content_items = []
+
+    ContentItem.where(content_id: nil).each do |item|
+      content_id = hash[item.base_path]
+
+      item.set(content_id: content_id || SecureRandom.uuid)
+
+      content_items << "#{item.content_id},#{item.public_updated_at},#{item.publishing_app},#{item.base_path}"
+    end
+
+    write_file("./tmp/reused_content_ids.txt", content_items)
+  end
+
+  desc "Assigns a public_updated_at for content items that do not have one"
+  task assign_public_updated_at: :environment do
+    content_items = []
+
+    ContentItem.where(public_updated_at: nil).each do |item|
+      item.set(public_updated_at: item.updated_at)
+
+      content_items << "#{item.public_updated_at},#{item.public_updated_at},#{item.publishing_app},#{item.base_path}"
+    end
+
+    write_file("./tmp/assigned_public_updated_at.txt", content_items)
+  end
+end

--- a/lib/tasks/data_hygiene/missing_attributes.rake
+++ b/lib/tasks/data_hygiene/missing_attributes.rake
@@ -53,7 +53,7 @@ namespace :data_hygiene do
     ContentItem.where(public_updated_at: nil).each do |item|
       item.set(public_updated_at: item.updated_at)
 
-      content_items << "#{item.public_updated_at},#{item.public_updated_at},#{item.publishing_app},#{item.base_path}"
+      content_items << "#{item.content_id},#{item.public_updated_at},#{item.publishing_app},#{item.base_path}"
     end
 
     write_file("./tmp/assigned_public_updated_at.txt", content_items)

--- a/lib/tasks/data_hygiene/whitehall_report.rake
+++ b/lib/tasks/data_hygiene/whitehall_report.rake
@@ -1,0 +1,17 @@
+require "tasks/data_hygiene/whitehall_report"
+
+namespace :data_hygiene do
+  desc "Report on content items from Whitehall data based on the publishing_export task in Whitehall"
+  task whitehall_report: :environment do
+    csv_path = ENV["CSV_PATH"]
+
+    unless csv_path
+      message = "You need to set the CSV_PATH environment variable"
+      message << "\nYou can generate the CSV by running rake publishing_export in Whitehall"
+
+      raise ArgumentError, message
+    end
+
+    WhitehallReport.run(csv_path)
+  end
+end

--- a/lib/tasks/data_hygiene/whitehall_report.rb
+++ b/lib/tasks/data_hygiene/whitehall_report.rb
@@ -1,0 +1,108 @@
+require "csv"
+
+module WhitehallReport
+  def self.run(csv_path)
+    matched_content_items = []
+    in_whitehall_but_not_in_content_store = []
+    no_whitehall_content_id = []
+    no_content_store_content_id = []
+    mismatched_content_id = []
+
+    CSV.foreach(csv_path, headers: true) do |row|
+      whitehall_db_id = row["whitehall_db_id"]
+      content_id = row["content_id"]
+      base_path = row["base_path"]
+      locale = row["locale"]
+      state = row["state"]
+      model = row["model"]
+      updated_at = row["updated_at"]
+
+      content_item = ContentItem.where(
+        publishing_app: "whitehall",
+        base_path: base_path
+      ).first
+
+      unless content_item
+        in_whitehall_but_not_in_content_store << OpenStruct.new(
+          content_id: content_id,
+          base_path: base_path,
+          format: model,
+          locale: locale,
+          updated_at: updated_at
+        )
+        next
+      end
+
+      matched_content_items << content_item
+
+      unless content_id
+        no_whitehall_content_id << content_item
+        next
+      end
+
+      unless content_item.content_id
+        no_content_store_content_id << content_item
+        next
+      end
+
+      if content_id != content_item.content_id
+        mismatched_content_id << content_item
+        next
+      end
+    end
+
+    matched_content_items.uniq!
+
+    in_content_store_but_not_in_whitehall = ContentItem.where(
+      publishing_app: 'whitehall',
+      :id.nin => matched_content_items.map(&:id),
+      :format.ne => "special_route"
+    ).to_a
+
+    redirects_with_new_content_ids, in_content_store_but_not_in_whitehall = slice_off_items_for_format!(
+      in_content_store_but_not_in_whitehall, "redirect"
+    )
+
+    coming_soons_with_new_content_ids, in_content_store_but_not_in_whitehall = slice_off_items_for_format!(
+      in_content_store_but_not_in_whitehall, "coming_soon"
+    )
+
+    gones_with_new_content_ids, in_content_store_but_not_in_whitehall = slice_off_items_for_format!(
+      in_content_store_but_not_in_whitehall, "gone"
+    )
+
+    output(in_whitehall_but_not_in_content_store, "in_whitehall_but_not_in_content_store")
+    output(in_content_store_but_not_in_whitehall, "in_content_store_but_not_in_whitehall")
+    in_content_store_but_not_in_whitehall.group_by(&:format).each do |format, items|
+      total = ContentItem.where(publishing_app: "whitehall", format: format).count
+      percent = (items.size.to_f / total * 100).round(2)
+      puts "  - #{items.size} items for #{format} (#{percent}%)"
+    end
+    output(mismatched_content_id, "mismatched_content_id")
+    output(no_whitehall_content_id, "no_whitehall_content_id")
+    output(no_content_store_content_id, "no_content_store_content_id")
+    output(redirects_with_new_content_ids, "redirects_with_new_content_ids")
+    output(coming_soons_with_new_content_ids, "coming_soons_with_new_content_ids")
+    output(gones_with_new_content_ids, "gones_with_new_content_ids")
+  end
+
+  def self.output(content_items, filename)
+    path = "tmp/#{filename}.txt"
+
+    File.open(path, "w") do |file|
+      content_items.each do |item|
+        file.puts "#{item.content_id}, #{item.base_path}, #{item.format}, #{item.locale}, #{item.updated_at}"
+      end
+    end
+
+    puts "Written #{content_items.size} lines to #{path}"
+  end
+
+  def self.slice_off_items_for_format!(content_items, format)
+    format_items, everything_else = content_items.partition do |item|
+      item.format == format && item.content_id.blank?
+    end
+
+    [format_items, everything_else]
+  end
+end


### PR DESCRIPTION
These are some rake tasks that we intend to use for the data cleanup work where content store will be set to a valid state, i.e. all content items have content_ids and public_updated_at timestamps. We will then export this data to a JSON file and import it into the Publishing API.