### PR TITLE
Fix content_id mismatches between draft and live content stores

### DIFF
--- a/lib/tasks/data_hygiene/draft_content_id_cleanup.rake
+++ b/lib/tasks/data_hygiene/draft_content_id_cleanup.rake
@@ -1,0 +1,47 @@
+namespace :data_hygiene do
+  namespace :draft_content_id_cleanup do
+    def report(cleanup: false)
+      unless ENV["MONGODB_URI"] && ENV["MONGODB_URI"].include?("draft")
+        raise "This should only be run against the draft content store"
+      end
+
+      file_path = ENV.fetch("FILE_PATH")
+      lines = File.read(file_path).split("\n")
+
+      substitution_formats = %w(redirect gone unpublishing)
+
+      lines.each do |line|
+        hash = JSON.parse(line).fetch("content_item")
+        item = ContentItem.where(base_path: hash.fetch("base_path")).first
+
+        if hash.fetch("content_id").nil?
+          raise "The file is missing content_ids. You need to generate them before dumping the file"
+        end
+
+        next unless item
+        next if substitution_formats.include?(item.format)
+        next if substitution_formats.include?(hash.fetch("format"))
+
+        unless hash.fetch("content_id") == item.content_id
+          puts "content_id mismatch: #{item.content_id} will be set to #{hash.fetch("content_id")}"
+          puts "  (base_path: #{item.base_path})"
+          puts
+
+          if cleanup
+            item.set(content_id: hash.fetch("content_id"))
+          end
+        end
+      end
+    end
+
+    desc "Report on content_id for items that mismatch with the given file"
+    task report: [:environment] do
+      report
+    end
+
+    desc "Clean the content_id for items that mismatch with the given file"
+    task cleanup: [:environment] do
+      report(cleanup: true)
+    end
+  end
+end

--- a/lib/tasks/data_hygiene/draft_content_id_cleanup.rake
+++ b/lib/tasks/data_hygiene/draft_content_id_cleanup.rake
@@ -1,6 +1,6 @@
 namespace :data_hygiene do
   namespace :draft_content_id_cleanup do
-    def report(cleanup: false)
+    def run(cleanup: false)
       unless ENV["MONGODB_URI"] && ENV["MONGODB_URI"].include?("draft")
         raise "This should only be run against the draft content store"
       end
@@ -36,12 +36,12 @@ namespace :data_hygiene do
 
     desc "Report on content_id for items that mismatch with the given file"
     task report: [:environment] do
-      report
+      run
     end
 
     desc "Clean the content_id for items that mismatch with the given file"
     task cleanup: [:environment] do
-      report(cleanup: true)
+      run(cleanup: true)
     end
   end
 end

--- a/lib/tasks/data_hygiene/locale_base_path_cleanup.rake
+++ b/lib/tasks/data_hygiene/locale_base_path_cleanup.rake
@@ -1,0 +1,37 @@
+namespace :data_hygiene do
+  namespace :locale_base_path_cleanup do
+    def report(cleanup: false)
+
+      ContentItem.where(:locale.nin => ["en", nil]).each do |item|
+
+        unless item.locale == item.base_path.split(".").last
+          puts "locale/base_path mismatch for locale #{item.locale}"
+          puts "    #{item.base_path} will be set to #{base_path_with_locale(item)}"
+          puts
+
+          if cleanup
+            cloned = item.clone
+            cloned.base_path = base_path_with_locale(item)
+            cloned.description = item.description
+            cloned.save!
+            item.destroy
+          end
+        end
+      end
+    end
+
+    def base_path_with_locale(item)
+      "#{item.base_path}.#{item.locale}"
+    end
+
+    desc "Report on content_id for items that mismatch with the given file"
+    task report: [:environment] do
+      report
+    end
+
+    desc "Clean the content_id for items that mismatch with the given file"
+    task cleanup: [:environment] do
+      report(cleanup: true)
+    end
+  end
+end


### PR DESCRIPTION
**TL;DR** Make mismatching content_ids match in both content stores.

We have content items for the same `base_path` in both content stores which do not have matching `content_id`s, this could be the result of formats changing, in most cases this appears to be a format change like `placeholder_specialist_publication` changing to `specialist_publication`, the theory being that if the draft has been updated to a `gone` or `redirect` then modified to the new format the `content_id` will have changed on the draft content store for the given `base_path`.

There are also a handful of cases where non-english locale suffixes are not present on `base_path`, this PR also adds a task to handle this.