### PR TITLE
WIP - Add migration for adding organisation to contact content items links

### DIFF
--- a/db/migrate/20151214164625_add_organisation_to_contact_links.rb
+++ b/db/migrate/20151214164625_add_organisation_to_contact_links.rb
@@ -1,0 +1,20 @@
+class AddOrganisationToContactLinks < Mongoid::Migration
+  def self.up
+    ContentItem.where(format: "contact").each do |contact|
+      organisation_title = contact.details["organisation"]["title"]
+      contact.links[:organisations] = [content_store_organisation(organisation_title).content_id]
+      contact.save!
+    end
+  end
+
+  def self.down
+  end
+
+  def self.content_store_organisation(organisation_title)
+    content_store_organisations.select { |org| org.title == organisation_title }.last
+  end
+
+  def self.content_store_organisations
+    @_content_store_organisations ||= ContentItem.where(format: 'placeholder_organisation')
+  end
+end


### PR DESCRIPTION
In order to add organisations as links for `contact` content items, we add the organisation `content_id` to the `contact` content item `links` section. We do this by comparing the current contact organisation title (stored as a whitehall derived organisation in the details hash) with the organisations present in the `content-store` (of format `placeholder_organisation`).

I'm wondering what else we might need to do in order to apply this 'cleanly'? 
- How to apply this to draft content store?
- Do we need to do anything to publishing-api to represent this change?