### PR TITLE
Pass through links hashes

### DIFF
--- a/app/presenters/linked_item_presenter.rb
+++ b/app/presenters/linked_item_presenter.rb
@@ -27,10 +27,14 @@ class LinkedItemPresenter
 
 private
   def api_url(item)
+    return nil unless item.base_path
+
     @api_url_method.call(item.base_path_without_root)
   end
 
   def web_url(item)
+    return nil unless item.base_path
+
     Plek.current.website_root + item.base_path
   end
 end

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -148,4 +148,61 @@ describe "Fetching content items", :type => :request do
       expect(data["links"]["related"].first["api_url"]).to eq("http://www.example.com/content#{linked_item.base_path}")
     end
   end
+
+  context "a content item with mixed linked items and passthrough hashes" do
+    let(:content_item) {
+      create(:content_item, links: {
+        'related' => [
+          linked_item.content_id,
+          {
+            content_id: "passthrough-content-id",
+            title: "Passthrough title",
+          }
+        ]
+      })
+    }
+    let(:linked_item) { create(:content_item, :with_content_id) }
+
+    before(:each) { get_content content_item }
+
+    it "returns a 200 OK response" do
+      expect(response.status).to eq(200)
+    end
+
+    it "includes the correct data in the expanded representation of the linked items" do
+      data = JSON.parse(response.body)
+
+      data["links"]["related"].each do |linked_item_data|
+        expect(linked_item_data.keys).to match_array(%w[
+          base_path
+          content_id
+          title
+          description
+          locale
+          api_url
+          web_url
+        ])
+      end
+
+      first_linked_item_data = data["links"]["related"].first
+      expect(first_linked_item_data).to include(
+        "base_path" => linked_item.base_path,
+        "content_id" => linked_item.content_id,
+        "title" => linked_item.title,
+        "description" => linked_item.description,
+        "locale" => linked_item.locale,
+        "web_url" => Plek.new.website_root + linked_item.base_path,
+      )
+
+      second_linked_item_data = data["links"]["related"].second
+      expect(second_linked_item_data).to include(
+        "base_path" => nil,
+        "content_id" => "passthrough-content-id",
+        "title" => "Passthrough title",
+        "description" => nil,
+        "locale" => "en",
+        "web_url" => nil,
+      )
+    end
+  end
 end

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -142,7 +142,7 @@ describe "Fetching content items", :type => :request do
       )
     end
 
-    it "corrrectly expands linked items with internal API URLs" do
+    it "correctly expands linked items with internal API URLs" do
       data = JSON.parse(response.body)
 
       expect(data["links"]["related"].first["api_url"]).to eq("http://www.example.com/content#{linked_item.base_path}")

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -386,38 +386,37 @@ describe ContentItem, :type => :model do
         end
       end
     end
+  end
 
+  describe 'access limiting' do
+    context 'a content item that is not access limited' do
+      let!(:content_item) { create(:content_item) }
 
-    describe 'access limiting' do
-      context 'a content item that is not access limited' do
-        let!(:content_item) { create(:content_item) }
-
-        it 'is not access limited' do
-          expect(content_item.access_limited?).to be(false)
-        end
-
-        it 'is viewable by all' do
-          expect(content_item.viewable_by?(nil)).to be(true)
-          expect(content_item.viewable_by?('a-user-uid')).to be(true)
-        end
+      it 'is not access limited' do
+        expect(content_item.access_limited?).to be(false)
       end
 
-      context 'an access-limited content item' do
-        let!(:content_item) { create(:access_limited_content_item) }
-        let(:authorised_user_uid) { content_item.access_limited['users'].first }
+      it 'is viewable by all' do
+        expect(content_item.viewable_by?(nil)).to be(true)
+        expect(content_item.viewable_by?('a-user-uid')).to be(true)
+      end
+    end
 
-        it 'is access limited' do
-          expect(content_item.access_limited?).to be(true)
-        end
+    context 'an access-limited content item' do
+      let!(:content_item) { create(:access_limited_content_item) }
+      let(:authorised_user_uid) { content_item.access_limited['users'].first }
 
-        it 'is viewable by an authorised user' do
-          expect(content_item.viewable_by?(authorised_user_uid)).to be(true)
-        end
+      it 'is access limited' do
+        expect(content_item.access_limited?).to be(true)
+      end
 
-        it 'is not viewable by an unauthorised user' do
-          expect(content_item.viewable_by?('unauthorised-user')).to be(false)
-          expect(content_item.viewable_by?(nil)).to be(false)
-        end
+      it 'is viewable by an authorised user' do
+        expect(content_item.viewable_by?(authorised_user_uid)).to be(true)
+      end
+
+      it 'is not viewable by an unauthorised user' do
+        expect(content_item.viewable_by?('unauthorised-user')).to be(false)
+        expect(content_item.viewable_by?(nil)).to be(false)
       end
     end
   end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -386,6 +386,51 @@ describe ContentItem, :type => :model do
         end
       end
     end
+
+    context "if a link hash is provided for pass-through" do
+      let(:passthrough_link_hash) {
+        {
+          content_id: "some-content-id",
+          title: "A title",
+          description: "A description",
+          base_path: nil,
+          locale: "fr",
+        }
+      }
+
+      let!(:content_item) {
+        create(:content_item, links: {
+          passthrough_links: [passthrough_link_hash]
+        })
+      }
+
+      it "creates a ContentItem with matching fields" do
+        linked_content_item = content_item.linked_items[:passthrough_links].first
+
+        expect(linked_content_item.content_id).to eq("some-content-id")
+        expect(linked_content_item.locale).to eq("fr")
+        expect(linked_content_item.title).to eq("A title")
+        expect(linked_content_item.description).to eq("A description")
+        expect(linked_content_item.base_path).to eq(nil)
+        expect(linked_content_item.base_path_without_root).to eq(nil)
+      end
+
+      context "without a locale specified" do
+        let(:passthrough_link_hash) {
+          {
+            content_id: "some-content-id",
+            title: "A title",
+            base_path: nil,
+          }
+        }
+
+        it "defaults the locale to 'en'" do
+          linked_content_item = content_item.linked_items[:passthrough_links].first
+
+          expect(linked_content_item.locale).to eq("en")
+        end
+      end
+    end
   end
 
   describe 'access limiting' do


### PR DESCRIPTION
This allows the publishing API to provide
"hard-coded" content for linked items in the cases
where we cannot currently represent them as dynamic
items in the publishing API, for example governments
(for history mode).

This is a temporary measure until a publishing API
refactor takes over the expansion of these links
hashes.

https://trello.com/c/ZahFZJR3/510-pass-through-expanded-links