### PR TITLE
Present linked item links to enable breadcrumbs and related links...

### DIFF
--- a/app/presenters/linked_item_presenter.rb
+++ b/app/presenters/linked_item_presenter.rb
@@ -18,8 +18,8 @@ class LinkedItemPresenter
       "locale" => linked_item.locale,
     }
 
-    if linked_item.has_attribute?(:analytics_identifier)
-      presented["analytics_identifier"] = linked_item.analytics_identifier
+    %i(analytics_identifier links).each do |attr|
+      presented[attr.to_s] = linked_item.send(attr) if linked_item.has_attribute?(attr)
     end
 
     presented

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -173,7 +173,8 @@ describe "Fetching content items", :type => :request do
       data = JSON.parse(response.body)
 
       data["links"]["related"].each do |linked_item_data|
-        expect(linked_item_data.keys).to match_array(%w[
+        keys = linked_item_data.keys - %w[links] # links are optional
+        expect(keys).to match_array(%w[
           base_path
           content_id
           title

--- a/spec/integration/fetching_linked_items_spec.rb
+++ b/spec/integration/fetching_linked_items_spec.rb
@@ -18,6 +18,7 @@ describe "Fetching linked items", type: :request do
           "api_url" => "http://www.example.com/content/a",
           "web_url" => "https://www.test.gov.uk/a",
           "locale" => "en",
+          "links" => { "parent" => [item.content_id] },
         },
         {
           "content_id" => "ID-2",
@@ -27,6 +28,7 @@ describe "Fetching linked items", type: :request do
           "api_url" => "http://www.example.com/content/b",
           "web_url" => "https://www.test.gov.uk/b",
           "locale" => "en",
+          "links" => { "parent" => [item.content_id] },
         },
       ])
 

--- a/spec/presenters/linked_item_presenter_spec.rb
+++ b/spec/presenters/linked_item_presenter_spec.rb
@@ -26,7 +26,8 @@ describe LinkedItemPresenter do
         "description" => "<p>A HTML description.</p>",
         "api_url" => "http://api.example.com/content/my-page",
         "web_url" => "https://www.test.gov.uk/my-page",
-        "locale" => "en"
+        "locale" => "en",
+        "links" => {},
       })
     end
 
@@ -39,5 +40,34 @@ describe LinkedItemPresenter do
 
       expect(presenter.present['analytics_identifier']).to eql('UA-123123')
     end
+
+    it "adds links if present" do
+      content_item = create(:content_item,
+        links: {
+          parent: [
+            {
+              content_id: "794cdd3c-6633-47b4-9e25-fe6a3aa96fa9",
+              title: "The parent section",
+              web_url: "/browse/parent-section",
+            }
+          ]
+        },
+      )
+
+      presenter = LinkedItemPresenter.new(content_item, api_url_method)
+
+      expect(presenter.present['links']).to eql(
+        {
+          :parent =>[
+            {
+              :content_id => "794cdd3c-6633-47b4-9e25-fe6a3aa96fa9",
+              :title => "The parent section",
+              :web_url => "/browse/parent-section"
+            }
+          ]
+        }
+      )
+    end
+
   end
 end


### PR DESCRIPTION
https://trello.com/c/gOdHjFoZ/527-expose-links-in-content-store-linkeditempresenter

Linked items may contain links to other content items to infer a hierarchy or relationship
used to structure breadcrumbs or relatedness. This change exposes links in linked items
when present.