### PR TITLE
Expand extra fields for Topical Events in links hash

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -158,7 +158,6 @@ private
       .renderable_content
       .where(:content_id => {"$in" => content_ids})
       .where(:locale => {"$in" => [I18n.default_locale.to_s, self.locale].uniq})
-      .only(:content_id, :locale, :base_path, :title, :description, :analytics_identifier)
       .sort(:updated_at => -1)
       .group_by(&:content_id)
 
@@ -189,7 +188,6 @@ private
     ContentItem
       .renderable_content
       .where(:content_id => content_id)
-      .only(:content_id, :locale, :base_path, :title, :description)
       .sort(:locale => 1, :updated_at => 1)
       .group_by(&:locale)
       .map { |locale, items| items.last }

--- a/app/presenters/linked_item_presenter.rb
+++ b/app/presenters/linked_item_presenter.rb
@@ -22,6 +22,12 @@ class LinkedItemPresenter
       presented[attr.to_s] = linked_item.send(attr) if linked_item.has_attribute?(attr)
     end
 
+    case linked_item.format
+    # TODO: Remove placeholder case when Topical Events are migrated.
+    when /(placeholder_)?topical_event/
+      presented["details"] = linked_item.details.slice(:start_date, :end_date).stringify_keys
+    end
+
     presented
   end
 

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -130,6 +130,7 @@ describe "Fetching content items", :type => :request do
         locale
         api_url
         web_url
+        links
       ])
 
       expect(linked_item_data).to include(
@@ -139,6 +140,7 @@ describe "Fetching content items", :type => :request do
         "description" => linked_item.description,
         "locale" => linked_item.locale,
         "web_url" => Plek.new.website_root + linked_item.base_path,
+        "links" => {}
       )
     end
 

--- a/spec/presenters/linked_item_presenter_spec.rb
+++ b/spec/presenters/linked_item_presenter_spec.rb
@@ -6,8 +6,8 @@ describe LinkedItemPresenter do
   end
 
   describe "#present" do
-    it "presents the correct data" do
-      content_item = create(:content_item,
+    let(:content_item) do
+      build(:content_item,
         content_id: 'AN-ID',
         title: "My Title",
         base_path: '/my-page',
@@ -16,10 +16,14 @@ describe LinkedItemPresenter do
           { content_type: "text/plain", content: "Short description." },
         ],
       )
+    end
 
-      presenter = LinkedItemPresenter.new(content_item, api_url_method)
+    let(:presenter) { LinkedItemPresenter.new(content_item, api_url_method) }
 
-      expect(presenter.present).to eql({
+    subject(:presented_item) { presenter.present }
+
+    it do
+      is_expected.to eql({
         "content_id" => "AN-ID",
         "title" => "My Title",
         "base_path" => "/my-page",
@@ -31,19 +35,19 @@ describe LinkedItemPresenter do
       })
     end
 
-    it "adds the analytics identifier if present" do
-      content_item = create(:content_item,
-        analytics_identifier: 'UA-123123',
-      )
+    context "for a content item with an analytics_identifier" do
+      before do
+        content_item.analytics_identifier = "UA-123123"
+      end
 
-      presenter = LinkedItemPresenter.new(content_item, api_url_method)
-
-      expect(presenter.present['analytics_identifier']).to eql('UA-123123')
+      it "includes the analytics_identifier" do
+        expect(presented_item["analytics_identifier"]).to eq("UA-123123")
+      end
     end
 
-    it "adds links if present" do
-      content_item = create(:content_item,
-        links: {
+    context "for a content item with links" do
+      before do
+        content_item.links = {
           parent: [
             {
               content_id: "794cdd3c-6633-47b4-9e25-fe6a3aa96fa9",
@@ -51,23 +55,22 @@ describe LinkedItemPresenter do
               web_url: "/browse/parent-section",
             }
           ]
-        },
-      )
-
-      presenter = LinkedItemPresenter.new(content_item, api_url_method)
-
-      expect(presenter.present['links']).to eql(
-        {
-          :parent =>[
-            {
-              :content_id => "794cdd3c-6633-47b4-9e25-fe6a3aa96fa9",
-              :title => "The parent section",
-              :web_url => "/browse/parent-section"
-            }
-          ]
         }
-      )
-    end
+      end
 
+      it "adds one level of links" do
+        expect(presented_item['links']).to eql(
+          {
+            parent: [
+              {
+                content_id: "794cdd3c-6633-47b4-9e25-fe6a3aa96fa9",
+                title: "The parent section",
+                web_url: "/browse/parent-section",
+              }
+            ]
+          }
+        )
+      end
+    end
   end
 end

--- a/spec/presenters/linked_item_presenter_spec.rb
+++ b/spec/presenters/linked_item_presenter_spec.rb
@@ -72,5 +72,42 @@ describe LinkedItemPresenter do
         )
       end
     end
+
+    context "with a topical_event link" do
+      let(:content_item) do
+        build(:content_item, format: "topical_event", details: {
+          start_date: "2015-11-25T00:00:00.000+00:00",
+          end_date: "2015-11-30T00:00:00.000+00:00",
+        })
+      end
+
+      it "adds the start and end date from the details hash" do
+        expect(presented_item['details']).to eql(
+          {
+            "start_date" => "2015-11-25T00:00:00.000+00:00",
+            "end_date" => "2015-11-30T00:00:00.000+00:00",
+          }
+        )
+      end
+    end
+
+    # TODO: Remove when topical_events are migrated
+    context "with a placeholder_topical_event link" do
+      let(:content_item) do
+        build(:content_item, format: "placeholder_topical_event", details: {
+          start_date: "2015-11-25T00:00:00.000+00:00",
+          end_date: "2015-11-30T00:00:00.000+00:00",
+        })
+      end
+
+      it "adds the start and end date from the details hash" do
+        expect(presented_item['details']).to eql(
+          {
+            "start_date" => "2015-11-25T00:00:00.000+00:00",
+            "end_date" => "2015-11-30T00:00:00.000+00:00",
+          }
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
The start and end dates for Topical Events are needed to render Topical
Event About Pages. We expand these fields in the links hash to simplify
the logic in the frontend.

We need to remove the returned field filter for linked items in order
to achieve this, as changing these `only` lines for each format is not
sustainable.

We benchmarked the removal of the `only` lines from the queries, and also
tried using `without("details.body")` which is apparently slower (thanks, Mongo(id)?).

```
Benchmark.bm(15) do |x|
  x.report("only") { 1000.times { ContentItem.only(:content_id, :locale, :base_path, :title, :description).first.to_json } }
  x.report("without body") { 1000.times { ContentItem.without("details.body").first.to_json } }
  x.report("all") { 1000.times { ContentItem.first.to_json } }
end

                      user     system      total        real
only              0.930000   0.030000   0.960000 (  1.144666)
without body      1.330000   0.030000   1.360000 (  1.567574)
all               1.130000   0.040000   1.170000 (  1.369165)
```

/cc @danielroseman 