### PR TITLE
Only return renderable content for debug endpoint

### DIFF
--- a/lib/taggings_per_app.rb
+++ b/lib/taggings_per_app.rb
@@ -14,6 +14,6 @@ class TaggingsPerApp
 private
 
   def relevant_content_items
-    ContentItem.where(publishing_app: @app_name)
+    ContentItem.renderable_content.where(publishing_app: @app_name)
   end
 end

--- a/spec/lib/taggings_per_app_spec.rb
+++ b/spec/lib/taggings_per_app_spec.rb
@@ -23,5 +23,15 @@ describe TaggingsPerApp do
         }
       )
     end
+
+    it "does not return unrenderable items like redirects" do
+      renderable = create(:content_item, content_id: SecureRandom.uuid, format: 'topic', publishing_app: 'publisher')
+      redirect = create(:content_item, content_id: SecureRandom.uuid, format: 'redirect', publishing_app: 'publisher')
+
+      taggings = TaggingsPerApp.new('publisher').taggings
+
+      expect(taggings.keys).to include(renderable.content_id)
+      expect(taggings.keys).not_to include(redirect.content_id)
+    end
   end
 end


### PR DESCRIPTION
Currently the debug taggings-per-app endpoint returns the taggings of all content items, including the (mostly empty) taggings for redirects. This causes the tagging migration verifier to think that there are differences between contentapi and content-store. This is because contentapi does filter for `live` content: https://github.com/alphagov/govuk_content_api/blob/master/lib/taggings_per_app.rb#L30

We are only interested in the taggings of renderable items, not redirects.

Trello: https://trello.com/c/1QMuBOSN