### PR TITLE
Change assets config to future-proof version

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
   # config.action_dispatch.rack_cache = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.serve_static_assets = false
+  config.serve_static_files = false
 
 
   # Specifies the header that your server uses for sending files.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_assets  = true
+  config.serve_static_files  = true
   config.static_cache_control = 'public, max-age=3600'
 
   # Show full error reports and disable caching.


### PR DESCRIPTION
This avoids deprecation warnings like:

> DEPRECATION WARNING: The configuration option
  `config.serve_static_assets` has been renamed to
  `config.serve_static_files` to clarify its role (it merely enables
  serving everything in the `public` folder and is unrelated to the
  asset pipeline). The `serve_static_assets` alias will be removed in
  Rails 5.0. Please migrate your configuration files
  accordingly.