### PR TITLE
Support `payload_version` in `ContentItem`

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -5,7 +5,7 @@ class ContentItem
   NON_RENDERABLE_FORMATS = %w(redirect gone)
 
   def self.create_or_replace(base_path, attributes)
-    previous_item = ContentItem.where(:base_path => base_path).first
+    previous_item = ContentItem.where(base_path: base_path).first
     lock = UpdateLock.new(previous_item)
 
     transmitted_at = attributes["transmitted_at"]
@@ -13,7 +13,7 @@ class ContentItem
 
     result = previous_item ? :replaced : :created
 
-    item = ContentItem.new(:base_path => base_path)
+    item = ContentItem.new(base_path: base_path)
     item.assign_attributes(attributes)
 
     if item.upsert
@@ -43,24 +43,24 @@ class ContentItem
     )
   end
 
-  field :_id, :as => :base_path, :type => String, :overwrite => true
-  field :content_id, :type => String
-  field :title, :type => String
-  field :description, :type => Hash, :default => { "value" => nil }
-  field :format, :type => String
-  field :locale, :type => String, :default => I18n.default_locale.to_s
-  field :need_ids, :type => Array, :default => []
-  field :public_updated_at, :type => DateTime
-  field :details, :type => Hash, :default => {}
-  field :publishing_app, :type => String
-  field :rendering_app, :type => String
-  field :routes, :type => Array, :default => []
-  field :redirects, :type => Array, :default => []
-  field :links, :type => Hash, :default => {}
-  field :access_limited, :type => Hash, :default => {}
-  field :phase, :type => String, :default => 'live'
-  field :analytics_identifier, :type => String
-  field :transmitted_at, :type => String
+  field :_id, as: :base_path, type: String, overwrite: true
+  field :content_id, type: String
+  field :title, type: String
+  field :description, type: Hash, default: { "value" => nil }
+  field :format, type: String
+  field :locale, type: String, default: I18n.default_locale.to_s
+  field :need_ids, type: Array, default: []
+  field :public_updated_at, type: DateTime
+  field :details, type: Hash, default: {}
+  field :publishing_app, type: String
+  field :rendering_app, type: String
+  field :routes, type: Array, default: []
+  field :redirects, type: Array, default: []
+  field :links, type: Hash, default: {}
+  field :access_limited, type: Hash, default: {}
+  field :phase, type: String, default: 'live'
+  field :analytics_identifier, type: String
+  field :transmitted_at, type: String
 
   scope :renderable_content, -> { where(:format.nin => NON_RENDERABLE_FORMATS) }
 
@@ -156,9 +156,9 @@ private
     # with the most recently updated first.
     potential_items_by_id = ContentItem
       .renderable_content
-      .where(:content_id => {"$in" => content_ids})
-      .where(:locale => {"$in" => [I18n.default_locale.to_s, self.locale].uniq})
-      .sort(:updated_at => -1)
+      .where(content_id: {"$in" => content_ids})
+      .where(locale: {"$in" => [I18n.default_locale.to_s, self.locale].uniq})
+      .sort(updated_at: -1)
       .group_by(&:content_id)
 
     # For each set of items for a given content_id, pick the first one that
@@ -187,8 +187,8 @@ private
     return [] if self.content_id.blank?
     ContentItem
       .renderable_content
-      .where(:content_id => content_id)
-      .sort(:locale => 1, :updated_at => 1)
+      .where(content_id: content_id)
+      .sort(locale: 1, updated_at: 1)
       .group_by(&:locale)
       .map { |locale, items| items.last }
   end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -61,6 +61,7 @@ class ContentItem
   field :phase, type: String, default: 'live'
   field :analytics_identifier, type: String
   field :transmitted_at, type: String
+  field :payload_version, type: Integer
 
   scope :renderable_content, -> { where(:format.nin => NON_RENDERABLE_FORMATS) }
 

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -8,8 +8,7 @@ class ContentItem
     previous_item = ContentItem.where(base_path: base_path).first
     lock = UpdateLock.new(previous_item)
 
-    transmitted_at = attributes["transmitted_at"]
-    lock.check_availability!(transmitted_at)
+    lock.check_availability!(attributes)
 
     result = previous_item ? :replaced : :created
 

--- a/app/models/update_lock.rb
+++ b/app/models/update_lock.rb
@@ -2,28 +2,66 @@ class UpdateLock
   def initialize(lockable)
     @lockable = lockable
 
-    if lockable && !lockable.respond_to?(:transmitted_at)
-      raise ArgumentError.new("#{lockable.class} must implement transmitted_at")
+    unless object_is_lockable?(lockable)
+      raise ArgumentError.new("#{lockable.class} must implement transmitted_at or payload_version")
     end
   end
 
   def check_availability!(attributes)
-    transmitted_at = attributes.with_indifferent_access[:transmitted_at]
-    raise MissingAttributeError, "transmitted_at is mandatory" unless transmitted_at
     return unless lockable.present?
 
-    request_transmitted_at = Integer(transmitted_at)
-    database_transmitted_at = Integer(lockable.transmitted_at)
+    attributes = attributes.with_indifferent_access
 
-    if database_transmitted_at >= request_transmitted_at
-      error = "Tried to process request with transmitted_at #{request_transmitted_at},"
-      error += " but the latest #{lockable.class} has a newer (or equal) transmitted_at of #{lockable.transmitted_at}"
-      raise OutOfOrderTransmissionError, error
-    end
+    validate_attributes(attributes)
+
+    payload_version, transmitted_at = attributes.values_at(:payload_version, :transmitted_at)
+
+    perform_check(payload_version, transmitted_at, lockable)
   end
 
 private
+
   attr_reader :lockable, :locked_at
+
+  def object_is_lockable?(subject)
+    subject.nil? ||
+      subject.respond_to?(:transmitted_at) ||
+      subject.respond_to?(:payload_version)
+  end
+
+  def validate_attributes(attributes)
+    if attributes[:transmitted_at].blank? && attributes[:payload_version].blank?
+      raise MissingAttributeError,
+        "transmitted_at or payload_version is required"
+    end
+  end
+
+  def perform_check(payload_version, transmitted_at, lockable)
+    if payload_version
+      check_payload_version(payload_version, lockable)
+    else
+      check_transmitted_at(transmitted_at, lockable)
+    end
+  end
+
+  def check_transmitted_at(transmitted_at, lockable)
+    if lockable.transmitted_at.to_i >= transmitted_at.to_i
+      raise_out_of_order_error(lockable, :transmitted_at, transmitted_at)
+    end
+  end
+
+  def check_payload_version(payload_version, lockable)
+    if lockable.payload_version.to_i >= payload_version.to_i
+      raise_out_of_order_error(lockable, :payload_version, payload_version)
+    end
+  end
+
+  def raise_out_of_order_error(lockable, field, value)
+    error = "Tried to process request with #{field} #{value}, "\
+            "but the latest ContentItem has a newer (or equal) "\
+            "#{field} of #{lockable.send(field)}"
+    raise OutOfOrderTransmissionError, error
+  end
 
   class ::MissingAttributeError < StandardError; end
   class ::OutOfOrderTransmissionError < StandardError; end

--- a/app/models/update_lock.rb
+++ b/app/models/update_lock.rb
@@ -7,7 +7,8 @@ class UpdateLock
     end
   end
 
-  def check_availability!(transmitted_at)
+  def check_availability!(attributes)
+    transmitted_at = attributes.with_indifferent_access[:transmitted_at]
     raise MissingAttributeError, "transmitted_at is mandatory" unless transmitted_at
     return unless lockable.present?
 

--- a/db/migrate/20160224143207_add_default_payload_version_to_content_items.rb
+++ b/db/migrate/20160224143207_add_default_payload_version_to_content_items.rb
@@ -1,0 +1,5 @@
+class AddDefaultPayloadVersionToContentItems < Mongoid::Migration
+  def self.up
+    ContentItem.where(payload_version: nil).update_all(payload_version: 0)
+  end
+end

--- a/spec/factories/content_item.rb
+++ b/spec/factories/content_item.rb
@@ -8,6 +8,7 @@ FactoryGirl.define do
     publishing_app 'publisher'
     routes { [{ 'path' => base_path, 'type' => 'exact' }] }
     transmitted_at "1"
+    payload_version 0
 
     trait :with_content_id do
       content_id { SecureRandom.uuid }

--- a/spec/integration/end_to_end_spec.rb
+++ b/spec/integration/end_to_end_spec.rb
@@ -15,6 +15,7 @@ describe "End-to-end behaviour", :type => :request do
     ],
     "public_updated_at" => Time.now,
     "transmitted_at" => "2",
+    "payload_version" => "1"
   }}
 
   def create_item(data_hash)

--- a/spec/integration/submitting_content_item_spec.rb
+++ b/spec/integration/submitting_content_item_spec.rb
@@ -269,11 +269,19 @@ describe "content item write API", :type => :request do
     end
   end
 
-  context "without the transmitted_at" do
-    it "creates the content item" do
+  context "without transmitted_at" do
+    before do
+      create(
+        :content_item,
+        :base_path => "/vat-rates",
+          :transmitted_at => "2"
+      )
+    end
+
+    it "raises a MissingAttributeError" do
       expect {
         put_json "/content/vat-rates", @data.except("transmitted_at")
-      }.to raise_error(MissingAttributeError, /transmitted_at/)
+      }.to raise_error(MissingAttributeError)
     end
   end
 end

--- a/spec/integration/submitting_content_item_spec.rb
+++ b/spec/integration/submitting_content_item_spec.rb
@@ -13,6 +13,7 @@ describe "content item write API", :type => :request do
       "locale" => "en",
       "public_updated_at" => "2014-05-14T13:00:06Z",
       "transmitted_at" => "2",
+      "payload_version" => 1,
       "publishing_app" => "publisher",
       "rendering_app" => "frontend",
       "details" => {
@@ -246,41 +247,73 @@ describe "content item write API", :type => :request do
 
   context "with stale attributes" do
     before do
-      create(:content_item,
-             :base_path => "/vat-rates",
-             :transmitted_at => "2")
-
-      put_json "/content/vat-rates", @data
+        create(
+          :content_item,
+          :base_path => "/vat-rates",
+          :transmitted_at => "2",
+          :payload_version => "2"
+        )
     end
 
-    it "responds with a HTTP 'conflict' status" do
-      expect(response.status).to eq(409)
+    context "transmitted_at based" do
+      before do
+        put_json "/content/vat-rates", @data.except("payload_version")
+      end
+
+      it "responds with a HTTP 'conflict' status" do
+        expect(response.status).to eq(409)
+      end
+
+      it "provides a helpful error body" do
+        expect(response.body).to include(
+          "the latest ContentItem has a newer (or equal) transmitted_at of 2"
+        )
+      end
+
+      it "doesn't perform an update" do
+        content_item = ContentItem.where(base_path: "/vat-rates").first
+        expect(content_item.transmitted_at).to eq("2")
+      end
     end
 
-    it "provides a helpful error body" do
-      expect(response.body).to include(
-        "the latest ContentItem has a newer (or equal) transmitted_at of 2"
-      )
-    end
+    context "payload_version based" do
+      before do
+        put_json "/content/vat-rates", @data.except("transmitted_at")
+      end
 
-    it "doesn't perform an update" do
-      content_item = ContentItem.where(base_path: "/vat-rates").first
-      expect(content_item.transmitted_at).to eq("2")
+      it "responds with a HTTP 'conflict' status" do
+        expect(response.status).to eq(409)
+      end
+
+      it "provides a helpful error body" do
+        expect(response.body).to include(
+          "the latest ContentItem has a newer (or equal) payload_version of 2"
+        )
+      end
+
+      it "doesn't perform an update" do
+        content_item = ContentItem.where(base_path: "/vat-rates").first
+        expect(content_item.payload_version).to eq(2)
+      end
     end
   end
 
-  context "without transmitted_at" do
+  context "without transmitted_at or payload_version" do
     before do
       create(
         :content_item,
         :base_path => "/vat-rates",
-          :transmitted_at => "2"
+        :transmitted_at => "2",
+        :payload_version => "1"
       )
     end
 
     it "raises a MissingAttributeError" do
       expect {
-        put_json "/content/vat-rates", @data.except("transmitted_at")
+        put_json "/content/vat-rates", @data.except(
+          "transmitted_at",
+          "payload_version"
+        )
       }.to raise_error(MissingAttributeError)
     end
   end

--- a/spec/integration/submitting_gone_item_spec.rb
+++ b/spec/integration/submitting_gone_item_spec.rb
@@ -9,6 +9,7 @@ describe "submitting gone items to the content store", :type => :request do
         "format" => "gone",
         "publishing_app" => "publisher",
         "transmitted_at" => "2",
+        "payload_version" => "1",
         "routes" => [
           {"path" => "/dodo-sanctuary", "type" => "prefix"},
           {"path" => "/dodo-sanctuary.json", "type" => "exact"}

--- a/spec/integration/submitting_placeholder_item_spec.rb
+++ b/spec/integration/submitting_placeholder_item_spec.rb
@@ -10,6 +10,7 @@ describe "submitting placeholder items to the content store", :type => :request 
       "format" => "placeholder",
       "public_updated_at" => "2014-05-14T13:00:06Z",
       "transmitted_at" => "2",
+      "payload_version" => "1",
       "publishing_app" => "publisher",
       "rendering_app" => "frontend",
       "routes" => [

--- a/spec/integration/submitting_redirect_item_spec.rb
+++ b/spec/integration/submitting_redirect_item_spec.rb
@@ -12,7 +12,8 @@ describe "submitting redirect items to the content store", :type => :request do
         {"path" => "/crb-checks", "type" => "prefix", "destination" => "/dbs-checks"},
         {"path" => "/crb-checks.json", "type" => "exact", "destination" => "/api/content/dbs-checks"}
       ],
-      "transmitted_at" => "2"
+      "transmitted_at" => "2",
+      "payload_version" => 1,
     }
   end
 

--- a/spec/models/update_lock_spec.rb
+++ b/spec/models/update_lock_spec.rb
@@ -17,41 +17,110 @@ describe UpdateLock, :type => :model do
 
       it "does not raise an error" do
         expect {
-          subject.check_availability!({transmitted_at: "1"})
+          subject.check_availability!(transmitted_at: "1")
         }.to_not raise_error
       end
     end
 
     context "for a locked item" do
+      let(:lockable) {
+        double(
+          :lockable,
+          transmitted_at: "10",
+          payload_version: "20"
+
+        )
+      }
+      context "with neither transmitted_at or payload_version" do
+        let(:attributes){ {} }
+        it "raises an error" do
+          expect {
+            subject.check_availability!(attributes)
+          }.to raise_error(
+            MissingAttributeError
+          )
+        end
+      end
+
       context "with transmitted_at" do
-        let(:lockable) { double(:lockable, transmitted_at: "10") }
-        context "existing is higher" do
+        context "where existing is higher" do
           let(:attributes){ { transmitted_at: "9" } }
 
           it "raises an error" do
             expect {
               subject.check_availability!(attributes)
-            }.to raise_error(OutOfOrderTransmissionError, /has a newer/)
+            }.to raise_error(
+              OutOfOrderTransmissionError,
+              /has a newer \(or equal\) transmitted_at/
+            )
           end
         end
 
-        context "existing is equal" do
+        context "where existing is equal" do
           let(:attributes){ { transmitted_at: "10" } }
 
           it "raises an error" do
             expect {
               subject.check_availability!(attributes)
-            }.to raise_error(OutOfOrderTransmissionError, /has a newer/)
+            }.to raise_error(
+              OutOfOrderTransmissionError,
+              /has a newer \(or equal\) transmitted_at/
+            )
           end
         end
 
-        context "existing is lower" do
+        context "where existing is lower" do
           let(:attributes){ { transmitted_at: "12" } }
           it "does not raise an error" do
             expect {
               subject.check_availability!(attributes)
             }.to_not raise_error
           end
+        end
+      end
+
+      context "with payload_version" do
+        context "where existing is higher" do
+          let(:attributes){ { payload_version: "19" } }
+
+          it "raises an error" do
+            expect {
+              subject.check_availability!(attributes)
+            }.to raise_error(
+              OutOfOrderTransmissionError,
+              /has a newer \(or equal\) payload_version/
+            )
+          end
+        end
+
+        context "where existing is equal" do
+          let(:attributes){ { payload_version: "20" } }
+
+          it "raises an error" do
+            expect {
+              subject.check_availability!(attributes)
+            }.to raise_error(
+              OutOfOrderTransmissionError,
+              /has a newer \(or equal\) payload_version/)
+          end
+        end
+
+        context "where existing is lower" do
+          let(:attributes){ { payload_version: "21" } }
+          it "does not raise an error" do
+            expect {
+              subject.check_availability!(attributes)
+            }.to_not raise_error
+          end
+        end
+      end
+
+      context "with both transmitted_at and payload_version" do
+        let(:attributes){ { transmitted_at: "5", payload_version: "21"} }
+        it "prefers payload_version does not raise" do
+          expect {
+            subject.check_availability!(attributes)
+          }.to_not raise_error
         end
       end
     end

--- a/spec/models/update_lock_spec.rb
+++ b/spec/models/update_lock_spec.rb
@@ -17,41 +17,42 @@ describe UpdateLock, :type => :model do
 
       it "does not raise an error" do
         expect {
-          subject.check_availability!(2)
+          subject.check_availability!({transmitted_at: "1"})
         }.to_not raise_error
       end
     end
 
     context "for a locked item" do
-      let(:lockable) { double(:lockable, transmitted_at: "10") }
-      it "raises an error when the lock is checked with a lesser value" do
-        expect {
-          subject.check_availability!(9)
-        }.to raise_error(OutOfOrderTransmissionError, /has a newer/)
-      end
+      context "with transmitted_at" do
+        let(:lockable) { double(:lockable, transmitted_at: "10") }
+        context "existing is higher" do
+          let(:attributes){ { transmitted_at: "9" } }
 
-      it "raises an error when the lock is checked with an equal value" do
-        expect {
-          subject.check_availability!(10)
-        }.to raise_error(OutOfOrderTransmissionError, /has a newer/)
-      end
+          it "raises an error" do
+            expect {
+              subject.check_availability!(attributes)
+            }.to raise_error(OutOfOrderTransmissionError, /has a newer/)
+          end
+        end
 
-      it "does not raise an error when the lock is checked with a greater value" do
-        expect {
-          subject.check_availability!(11)
-        }.to_not raise_error
-      end
+        context "existing is equal" do
+          let(:attributes){ { transmitted_at: "10" } }
 
-      it "raises an error when the lock is checked against nil" do
-        expect {
-          subject.check_availability!(nil)
-        }.to raise_error
-      end
+          it "raises an error" do
+            expect {
+              subject.check_availability!(attributes)
+            }.to raise_error(OutOfOrderTransmissionError, /has a newer/)
+          end
+        end
 
-      it "coerces strings to integers" do
-        expect {
-          subject.check_availability!("11")
-        }.to_not raise_error
+        context "existing is lower" do
+          let(:attributes){ { transmitted_at: "12" } }
+          it "does not raise an error" do
+            expect {
+              subject.check_availability!(attributes)
+            }.to_not raise_error
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This PR adds support for `payload_version` without yet deprecating `transmitted_at`. This will allow us to update Publishing API to start sending `payload_version` after which `transmitted_at` can be removed.

`payload_version` is essentially a locking mechanism between Publishing API and Content Store to prevent out of order 'old' content overwriting a newer version. This can be caused during the asynchronous queueing of payloads on their way from Publishing API. It will be set on the content item payloads as they are queued in Publishing API.

I've not updated the pact tests as yet but will do that when `transmitted_at` is added to Publishing API and then removed from Content Store in subsequent PRs.

[Trello](https://trello.com/c/dBmI96gI/304-change-locking-criteria-on-content-store)