### PR TITLE
Include specific incoming links in content

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -111,9 +111,7 @@ class ContentItem
 
   # Return a Hash of link types to lists of related items
   def linked_items
-    items = load_linked_items
-    items["available_translations"] = available_translations if available_translations.any?
-    items
+    LinkedItemsQuery.new(self).call
   end
 
   def incoming_links(type)
@@ -146,50 +144,5 @@ private
 
   def authorised_user_uids
     access_limited['users']
-  end
-
-  def load_linked_items
-    content_ids = links.values.flatten.uniq.reject { |link| link.is_a?(Hash) }
-
-    # For each linked content_id find all non-redirect content items with
-    # matching content_id in either this item's locale, or the default locale
-    # with the most recently updated first.
-    potential_items_by_id = ContentItem
-      .renderable_content
-      .where(content_id: { "$in" => content_ids })
-      .where(locale: { "$in" => [I18n.default_locale.to_s, self.locale].uniq })
-      .sort(updated_at: -1)
-      .group_by(&:content_id)
-
-    # For each set of items for a given content_id, pick the first one that
-    # matches this item's locale, or fall back to the first one matching the
-    # default locale.
-    required_items = potential_items_by_id.each_with_object({}) do |(content_id, items), results|
-      results[content_id] = items.find { |i| i.locale == self.locale } || items.find { |i| i.locale == I18n.default_locale.to_s }
-    end
-
-    # build up the links hash using the selected items above
-    links.each_with_object({}) do |(link_type, uuids), result|
-      passthrough_hashes, uuids = uuids.partition { |link| link.is_a?(Hash) }
-      passthrough_content_items = passthrough_hashes.map {|attributes|
-        ContentItem.new(attributes)
-      }
-
-      result[link_type] = uuids.map { |id| required_items[id] }.compact + passthrough_content_items
-    end
-  end
-
-  def available_translations
-    @available_translations ||= load_available_translations
-  end
-
-  def load_available_translations
-    return [] if self.content_id.blank?
-    ContentItem
-      .renderable_content
-      .where(content_id: content_id)
-      .sort(locale: 1, updated_at: 1)
-      .group_by(&:locale)
-      .map { |_locale, items| items.last }
   end
 end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -114,8 +114,10 @@ class ContentItem
     LinkedItemsQuery.new(self).call
   end
 
-  def incoming_links(type)
-    ContentItem.where("links.#{type}" => { "$in" => [content_id] })
+  def incoming_links(link_type, linking_format: nil)
+    scope = ContentItem.where("links.#{link_type}" => { "$in" => [content_id] })
+    scope = scope.where(format: linking_format) if linking_format
+    scope
   end
 
   def viewable_by?(user_uid)

--- a/app/queries/linked_items_query.rb
+++ b/app/queries/linked_items_query.rb
@@ -1,0 +1,78 @@
+class LinkedItemsQuery
+  attr_reader :content_item
+
+  def initialize(content_item)
+    @content_item = content_item
+  end
+
+  def call
+    items = linked_items
+    items["available_translations"] = available_translations if available_translations.any?
+    items
+  end
+
+private
+
+  # Return the extant and renderable linked_items and any "passthrough" items
+  # which aren't really content_items, but are instead hardcoded hashes.
+  def linked_items
+    outgoing_content_items = content_items
+    content_item.links.each_with_object({}) do |(link_type, raw_content_ids), result|
+      passthrough_hashes, raw_content_ids = raw_content_ids.partition { |link| link.is_a?(Hash) }
+      passthrough_content_items = passthrough_hashes.map do |attributes|
+        ContentItem.new(attributes)
+      end
+
+      real_content_items = raw_content_ids.map do |id|
+        outgoing_content_items.find { |ci| ci.content_id == id }
+      end
+      real_content_items.compact!
+      result[link_type] = real_content_items + passthrough_content_items
+    end
+  end
+
+  # Return the renderable items based on `content_ids`, in the most appropriate
+  # locale
+  def content_items
+    # For each linked content_id find all non-redirect content items with
+    # matching content_id in either this item's locale, or the default locale
+    # with the most recently updated first.
+    locales = [I18n.default_locale.to_s, content_item.locale].uniq
+    renderable_items_by_id = ContentItem
+      .renderable_content
+      .where(content_id: { "$in" => all_content_ids })
+      .where(locale: { "$in" => locales })
+      .sort(updated_at: -1)
+      .group_by(&:content_id)
+
+    # For each set of items for a given content_id, pick the first one that
+    # matches this item's locale, or fall back to the first one matching the
+    # default locale.
+    renderable_items_by_id.map do |_content_id, items|
+      in_same_locale = items.find { |i| i.locale == content_item.locale }
+      in_default_locale = items.find { |i| i.locale == I18n.default_locale.to_s }
+      in_same_locale || in_default_locale
+    end
+  end
+
+  # Returns the content_ids for all types of link, and ignore the passthrough
+  # hashes
+  def all_content_ids
+    content_item.links.values.flatten.uniq.reject { |link| link.is_a?(Hash) }
+  end
+
+  def available_translations
+    @_available_translations ||= begin
+      if content_item.content_id.blank?
+        []
+      else
+        ContentItem
+          .renderable_content
+          .where(content_id: content_item.content_id)
+          .sort(locale: 1, updated_at: 1)
+          .group_by(&:locale)
+          .map { |_locale, items| items.last }
+      end
+    end
+  end
+end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -444,6 +444,17 @@ describe ContentItem, type: :model do
     it 'should return the linking item' do
       expect(@item.incoming_links("related")).to eq([@other_item])
     end
+
+    context 'with the linking_format parameter' do
+      before :each do
+        create(:content_item, :with_content_id, format: "a", links: { "related" => [@item.content_id] })
+        @matching = create(:content_item, :with_content_id, format: "b", links: { "related" => [@item.content_id] })
+      end
+
+      it 'should return only the linking items which have that format' do
+        expect(@item.incoming_links("related", linking_format: "b")).to eq([@matching])
+      end
+    end
   end
 
   describe 'access limiting' do

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -435,6 +435,17 @@ describe ContentItem, type: :model do
     end
   end
 
+  describe '#incoming_links' do
+    before :each do
+      @item = create(:content_item, :with_content_id)
+      @other_item = create(:content_item, :with_content_id, links: { "related" => [@item.content_id] })
+    end
+
+    it 'should return the linking item' do
+      expect(@item.incoming_links("related")).to eq([@other_item])
+    end
+  end
+
   describe 'access limiting' do
     context 'a content item that is not access limited' do
       let!(:content_item) { create(:content_item) }

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -433,6 +433,46 @@ describe ContentItem, type: :model do
         end
       end
     end
+
+    context 'formats which should include specific incoming_links' do
+      context 'working_group' do
+        before :each do
+          @working_group = create(:content_item, :with_content_id, format: "working_group")
+          @policy = create(:content_item, :with_content_id, format: "policy", links: { "working_groups" => [@working_group.content_id] })
+        end
+
+        it 'should include the key' do
+          expect(@working_group.linked_items.keys).to include("policies")
+        end
+
+        it 'should include the linked item' do
+          expect(@working_group.linked_items["policies"]).to eq([@policy])
+        end
+
+        describe 'when the item already has links of that type' do
+          before :each do
+            @another_policy = create(:content_item, :with_content_id, format: "policy")
+            @working_group.update(links: { "policies" => [@another_policy.content_id] })
+          end
+
+          it 'should append to that list' do
+            expect(@working_group.linked_items["policies"]).to include(@policy, @another_policy)
+          end
+        end
+
+        describe 'when the item links to another policy but with a different link type' do
+          before :each do
+            @special_policy = create(:content_item, :with_content_id, format: "policy")
+            @working_group.update(links: { "special_policies" => [@special_policy.content_id] })
+          end
+
+          it 'should not mix them into the policies list' do
+            expect(@working_group.linked_items["policies"]).to eq([@policy])
+            expect(@working_group.linked_items["special_policies"]).to eq([@special_policy])
+          end
+        end
+      end
+    end
   end
 
   describe '#incoming_links' do


### PR DESCRIPTION
The interesting change is in the last commit.

To render a working_group, you need the list of policies which link to that
working_group.

We could fulfill that by adding special knowledge to the frontend so that it
knows to make a second request, to /incoming-links. There are a few issues with
that:
* one of the design goals of the content-store is that it includes everything
needed to render that page
* it complicates the frontend
* we think that when dependency resolution is implemented, the API of
content-store will change to match this implementation, and that the
/incoming-links endpoint could be removed

If the API design does change in this way, then we don't need to do anything to
our frontends when we implement dependency resolution.

I'd rather it wasn't so directly hardcoded - instead having a list with an
entry for each format, containing the various strings - but I had difficulty
with naming. Probably best to refactor when we get to the second or third use
case.

We are reasonably confident that there will be other formats where this
functionality will be required.

I see this change as being similar to 04368e5.