### PR TITLE
Resolve arrays with regular content types.

### DIFF
--- a/app/presenters/content_type_resolver.rb
+++ b/app/presenters/content_type_resolver.rb
@@ -33,7 +33,7 @@ private
     return false unless array.all? { |v| v.is_a?(Hash) }
 
     hash_keys = array.flat_map(&:keys).map(&:to_sym)
-    hash_keys.include?(:content_type)
+    hash_keys.include?(:content_type) && hash_keys.include?(:content)
   end
 
   def extract_content(array)

--- a/spec/presenters/content_type_resolver_spec.rb
+++ b/spec/presenters/content_type_resolver_spec.rb
@@ -43,6 +43,18 @@ RSpec.describe ContentTypeResolver do
     )
   end
 
+  it "handles hashes with content types but no content field" do
+    result = subject.resolve([
+      content_type: "application/pdf",
+      path: "some/document.pdf",
+    ])
+
+    expect(result).to eq([
+      content_type: "application/pdf",
+      path: "some/document.pdf",
+    ])
+  end
+
   it "recurses on nested hashes" do
     result = subject.resolve(
       details: {


### PR DESCRIPTION
Such as PDF attachments.

Fixes https://errbit.publishing.service.gov.uk/apps/537de1230da115fb25004224/problems/570f522a65786378ecdd0900