### PR TITLE
Add first_published_at

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -51,6 +51,7 @@ class ContentItem
   field :schema_name, type: String
   field :locale, type: String, default: I18n.default_locale.to_s
   field :need_ids, type: Array, default: []
+  field :first_published_at, type: DateTime
   field :public_updated_at, type: DateTime
   field :details, type: Hash, default: {}
   field :publishing_app, type: String

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -14,6 +14,7 @@ class ContentItemPresenter
     need_ids
     locale
     updated_at
+    first_published_at
     public_updated_at
     phase
     analytics_identifier

--- a/doc/content_item_fields.md
+++ b/doc/content_item_fields.md
@@ -118,6 +118,10 @@ This is the update date that should be surfaced to the user. This is used for
 sorting documents by update date. It should change when there is a major
 update and should not change for a minor update.
 
+## `first_published_at`
+
+ISO 8601 formatted timestamp. Present when the content item has been published.
+
 ## `details`
 
 A hash. Present in all contexts.

--- a/doc/input_examples/generic.json
+++ b/doc/input_examples/generic.json
@@ -6,6 +6,7 @@
   "format": "the format of this content",
   "need_ids": ["array", "of", "need", "ids"],
   "locale": "en",
+  "first_published_at": "2014-01-02T03:04:05+00:00",
   "public_updated_at": "2014-03-04T13:58:11+00:00", // the time the content was updated.
   "publishing_app": "base-hostname-of-app-that-owns-this-content", // must be resolvable with Plek.find(publishing_app)
   "rendering_app": "base-hostname-of-app-that-renders-this-content", // must be resolvable with Plek.find(rendering_app)

--- a/doc/output_examples/generic.json
+++ b/doc/output_examples/generic.json
@@ -6,6 +6,7 @@
   "format": "the format of this content",
   "need_ids": ["array", "of", "need", "ids"],
   "locale": "en",
+  "first_published_at": "2014-01-02T03:04:05+00:00",
   "public_updated_at": "2014-03-04T13:58:11+00:00",
   "updated_at": "2014-03-04T14:15:17+00:00",
   "details": {

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -43,6 +43,7 @@ describe "Fetching content items", type: :request do
         locale
         analytics_identifier
         phase
+        first_published_at
         public_updated_at
         updated_at
         details


### PR DESCRIPTION
This is a new field in the publishing API which
seems more sensible to send through to the content
store rather than skip it in the publishing API.

https://trello.com/c/Si54omdL/698-return-the-first-published-at-time-to-publishing-apps-for-content-items