### PR TITLE
Make expanded_links presentable

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -59,6 +59,7 @@ class ContentItem
   field :routes, type: Array, default: []
   field :redirects, type: Array, default: []
   field :links, type: Hash, default: {}
+  field :expanded_links, type: Hash, default: {}
   field :access_limited, type: Hash, default: {}
   field :phase, type: String, default: 'live'
   field :analytics_identifier, type: String

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -18,6 +18,7 @@ class ContentItemPresenter
     public_updated_at
     phase
     analytics_identifier
+    expanded_links
   ).freeze
 
   def initialize(item, api_url_method)

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -48,6 +48,7 @@ describe "Fetching content items", type: :request do
         updated_at
         details
         links
+        expanded_links
       ])
 
       expect(data).to include(

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -1,7 +1,21 @@
 require 'rails_helper'
 
 describe ContentItemPresenter do
-  let(:item) { build(:content_item, links: links, locale: locale) }
+  let(:expanded_links) do
+    {
+      "parent" => [
+        {
+          "base_path" => "/foo",
+          "title" => "foo",
+        },
+        {
+          "base_path" => "/bar",
+          "title" => "bar",
+        }
+      ]
+    }
+  end
+  let(:item) { build(:content_item, links: links, locale: locale, expanded_links: expanded_links) }
   let(:links) { {} }
   let(:locale) { "en" }
 
@@ -17,6 +31,10 @@ describe ContentItemPresenter do
 
   it "outputs the base_path correctly" do
     expect(presenter.as_json["base_path"]).to eq(item.base_path)
+  end
+
+  it "presents expanded_links" do
+    expect(presenter.as_json["expanded_links"]).to eq(expanded_links)
   end
 
   context "with related links" do


### PR DESCRIPTION
Part of https://trello.com/c/Ahj9lNB0/645-4-update-content-items-whose-dependencies-have-changed

Expanded links are resolved in the publishing api and passed
to the content store ready for presentation. This change adds
the necessary model and presentation logic to do this.