### PR TITLE
Fill schema_name and document_type with format

### DIFF
--- a/db/migrate/20160503152550_backfill_schema_name_and_document_type.rb
+++ b/db/migrate/20160503152550_backfill_schema_name_and_document_type.rb
@@ -1,0 +1,21 @@
+class BackfillSchemaNameAndDocumentType < Mongoid::Migration
+  def self.up
+    js = <<-EOF
+    db.content_items.find({"schema_name": null}).forEach( function (content_item) {
+      content_item.schema_name = content_item.format;
+      content_item.document_type = content_item.format;
+      db.content_items.save(content_item);
+    });
+    EOF
+
+    cmd = {
+      '$eval' => js,
+      'nolock' => true
+    }
+
+    result = ContentItem.collection.database.command(cmd)
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
As part of the split of format into schema_name and document_type, we
need to have consistent data in content store. For newer items pushed
to content store from publishing api, the schema_name and document_type
are defaulted to format if they’re not provided in the content item in
the publishing api. This backfills other content items in content store
to have the same data.

This migration takes about a minute to run on the VM. It shouldn’t
block other operations.

/cc @danielroseman @elliotcm 