### PR TITLE
Split format into schema name and document type

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -11,6 +11,8 @@ class ContentItemPresenter
     content_id
     title
     format
+    schema_name
+    document_type
     need_ids
     locale
     updated_at

--- a/app/presenters/linked_item_presenter.rb
+++ b/app/presenters/linked_item_presenter.rb
@@ -24,8 +24,9 @@ class LinkedItemPresenter
       presented[attr.to_s] = linked_item.send(attr) if linked_item.has_attribute?(attr)
     end
 
-    case linked_item.format
-    # TODO: Remove placeholder case when Topical Events are migrated.
+    case linked_item.document_type
+    # TODO: Remove placeholder when whitehall's format split is deployed and republished
+    # as they will have a schema_name of 'placeholder' and a document_type of 'topical_event'
     when /(placeholder_)?topical_event/
       presented["details"] = linked_item.details.slice(:start_date, :end_date).stringify_keys
     end

--- a/app/presenters/linked_item_presenter.rb
+++ b/app/presenters/linked_item_presenter.rb
@@ -16,6 +16,8 @@ class LinkedItemPresenter
       "api_url" => api_url(linked_item),
       "web_url" => web_url(linked_item),
       "locale" => linked_item.locale,
+      "schema_name" => linked_item.schema_name,
+      "document_type" => linked_item.document_type
     }
 
     %i(analytics_identifier links).each do |attr|

--- a/app/queries/linked_items_query.rb
+++ b/app/queries/linked_items_query.rb
@@ -10,10 +10,10 @@ class LinkedItemsQuery
   def call
     items = linked_items
     items["available_translations"] = available_translations if available_translations.any?
-    if content_item.format == "working_group"
+    if content_item.schema_name == "working_group"
       merge_inverse_links(items, "policies", "working_groups", "policy")
-    elsif MIGRATED_EDITION_FORMATS.include? content_item.format
-      merge_inverse_links(items, "document_collections", "documents", "placeholder_document_collection")
+    elsif MIGRATED_EDITION_FORMATS.include? content_item.schema_name
+      merge_inverse_links(items, "document_collections", "documents", /document_collection$/)
     end
     items
   end
@@ -67,15 +67,15 @@ private
     content_item.links.values.flatten.uniq.reject { |link| link.is_a?(Hash) }
   end
 
-  def incoming_link_content_ids(link_type, linking_format)
-    content_item.incoming_links(link_type, linking_format: linking_format)
+  def incoming_link_content_ids(link_type, linking_document_type)
+    content_item.incoming_links(link_type, linking_document_type: linking_document_type)
       .only(:content_id)
       .map(&:content_id)
   end
 
-  def merge_inverse_links(items, link_type, incoming_link_type, linking_format)
+  def merge_inverse_links(items, link_type, incoming_link_type, linking_document_type)
     items[link_type] ||= []
-    items[link_type] += content_items(incoming_link_content_ids(incoming_link_type, linking_format))
+    items[link_type] += content_items(incoming_link_content_ids(incoming_link_type, linking_document_type))
     items[link_type].uniq!(&:content_id)
   end
 

--- a/spec/factories/content_item.rb
+++ b/spec/factories/content_item.rb
@@ -19,6 +19,8 @@ FactoryGirl.define do
 
     factory :content_item do
       format "answer"
+      schema_name "answer"
+      document_type "answer"
       title "Test content"
       rendering_app 'frontend'
       public_updated_at Time.now

--- a/spec/factories/content_item.rb
+++ b/spec/factories/content_item.rb
@@ -4,6 +4,8 @@ FactoryGirl.define do
   factory :base_content_item, class: ContentItem do
     sequence(:base_path) { |n| "/test-content-#{n}" }
     format 'gone' # Using gone as it allows the smallest valid base
+    schema_name { format }
+    document_type { format }
     publishing_app 'publisher'
     routes { [{ 'path' => base_path, 'type' => 'exact' }] }
     transmitted_at "1"
@@ -19,8 +21,6 @@ FactoryGirl.define do
 
     factory :content_item do
       format "answer"
-      schema_name "answer"
-      document_type "answer"
       title "Test content"
       rendering_app 'frontend'
       public_updated_at Time.now

--- a/spec/integration/end_to_end_spec.rb
+++ b/spec/integration/end_to_end_spec.rb
@@ -8,6 +8,8 @@ describe "End-to-end behaviour", type: :request do
     "content_id" => SecureRandom.uuid,
     "title" => "VAT rates",
     "format" => "answer",
+    "schema_name" => "answer",
+    "document_type" => "answer",
     "publishing_app" => "publisher",
     "rendering_app" => "frontend",
     "routes" => [

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -11,7 +11,9 @@ describe "Fetching content items", type: :request do
         content_id: SecureRandom.uuid,
         title: "VAT rates",
         description: "Current VAT rates",
-        format: "answer",
+        format: "publication",
+        schema_name: "publication",
+        document_type: "guidance",
         need_ids: ["100136"],
         public_updated_at: 30.minutes.ago,
         details: {
@@ -39,6 +41,8 @@ describe "Fetching content items", type: :request do
         title
         description
         format
+        schema_name
+        document_type
         need_ids
         locale
         analytics_identifier
@@ -56,7 +60,9 @@ describe "Fetching content items", type: :request do
         "content_id" => content_item.content_id,
         "title" => "VAT rates",
         "description" => "Current VAT rates",
-        "format" => "answer",
+        "format" => "publication",
+        "schema_name" => "publication",
+        "document_type" => "guidance",
         "need_ids" => ["100136"],
         "locale" => "en",
         "analytics_identifier" => nil,
@@ -165,6 +171,8 @@ describe "Fetching content items", type: :request do
         api_url
         web_url
         links
+        schema_name
+        document_type
       ])
 
       expect(linked_item_data).to include(
@@ -174,7 +182,9 @@ describe "Fetching content items", type: :request do
         "description" => linked_item.description,
         "locale" => linked_item.locale,
         "web_url" => Plek.new.website_root + linked_item.base_path,
-        "links" => {}
+        "links" => {},
+        "schema_name" => "answer",
+        "document_type" => "answer"
       )
     end
 
@@ -218,6 +228,8 @@ describe "Fetching content items", type: :request do
           locale
           api_url
           web_url
+          schema_name
+          document_type
         ])
       end
 
@@ -229,6 +241,8 @@ describe "Fetching content items", type: :request do
         "description" => linked_item.description,
         "locale" => linked_item.locale,
         "web_url" => Plek.new.website_root + linked_item.base_path,
+        "schema_name" => "answer",
+        "document_type" => "answer",
       )
 
       second_linked_item_data = data["links"]["related"].second
@@ -239,6 +253,8 @@ describe "Fetching content items", type: :request do
         "description" => nil,
         "locale" => "en",
         "web_url" => nil,
+        "schema_name" => nil,
+        "document_type" => nil,
       )
     end
   end

--- a/spec/integration/fetching_linked_items_spec.rb
+++ b/spec/integration/fetching_linked_items_spec.rb
@@ -19,6 +19,8 @@ describe "Fetching linked items", type: :request do
           "web_url" => "https://www.test.gov.uk/a",
           "locale" => "en",
           "links" => { "parent" => [item.content_id] },
+          "schema_name" => "answer",
+          "document_type" => "answer",
         },
         {
           "content_id" => "ID-2",
@@ -29,6 +31,8 @@ describe "Fetching linked items", type: :request do
           "web_url" => "https://www.test.gov.uk/b",
           "locale" => "en",
           "links" => { "parent" => [item.content_id] },
+          "schema_name" => "answer",
+          "document_type" => "answer",
         },
       ])
 

--- a/spec/integration/submitting_content_item_spec.rb
+++ b/spec/integration/submitting_content_item_spec.rb
@@ -9,6 +9,8 @@ describe "content item write API", type: :request do
       "title" => "VAT rates",
       "description" => "Current VAT rates",
       "format" => "answer",
+      "schema_name" => "answer",
+      "document_type" => "answer",
       "need_ids" => %w(100123 100124),
       "locale" => "en",
       "public_updated_at" => "2014-05-14T13:00:06Z",

--- a/spec/integration/submitting_gone_item_spec.rb
+++ b/spec/integration/submitting_gone_item_spec.rb
@@ -6,6 +6,8 @@ describe "submitting gone items to the content store", type: :request do
       @data = {
         "base_path" => "/dodo-sanctuary",
         "format" => "gone",
+        "schema_name" => "gone",
+        "document_type" => "gone",
         "publishing_app" => "publisher",
         "transmitted_at" => "2",
         "payload_version" => "1",

--- a/spec/integration/submitting_placeholder_item_spec.rb
+++ b/spec/integration/submitting_placeholder_item_spec.rb
@@ -8,6 +8,8 @@ describe "submitting placeholder items to the content store", type: :request do
       "title" => "VAT rates",
       "description" => "Current VAT rates",
       "format" => "placeholder",
+      "schema_name" => "placeholder",
+      "document_type" => "placeholder",
       "public_updated_at" => "2014-05-14T13:00:06Z",
       "transmitted_at" => "2",
       "payload_version" => "1",

--- a/spec/integration/submitting_redirect_item_spec.rb
+++ b/spec/integration/submitting_redirect_item_spec.rb
@@ -5,6 +5,8 @@ describe "submitting redirect items to the content store", type: :request do
     @data = {
       "base_path" => "/crb-checks",
       "format" => "redirect",
+      "schema_name" => "redirect",
+      "document_type" => "redirect",
       "public_updated_at" => "2014-05-14T13:00:06Z",
       "publishing_app" => "publisher",
       "redirects" => [

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -526,14 +526,14 @@ describe ContentItem, type: :model do
       expect(@item.incoming_links("related")).to eq([@other_item])
     end
 
-    context 'with the linking_format parameter' do
+    context 'with the linking_document_type parameter' do
       before :each do
-        create(:content_item, :with_content_id, format: "a", links: { "related" => [@item.content_id] })
-        @matching = create(:content_item, :with_content_id, format: "b", links: { "related" => [@item.content_id] })
+        create(:content_item, :with_content_id, document_type: "a", links: { "related" => [@item.content_id] })
+        @matching = create(:content_item, :with_content_id, document_type: "b", links: { "related" => [@item.content_id] })
       end
 
       it 'should return only the linking items which have that format' do
-        expect(@item.incoming_links("related", linking_format: "b")).to eq([@matching])
+        expect(@item.incoming_links("related", linking_document_type: "b")).to eq([@matching])
       end
     end
   end

--- a/spec/presenters/linked_item_presenter_spec.rb
+++ b/spec/presenters/linked_item_presenter_spec.rb
@@ -11,6 +11,8 @@ describe LinkedItemPresenter do
               content_id: 'AN-ID',
               title: "My Title",
               base_path: '/my-page',
+              schema_name: 'publication',
+              document_type: 'policy_paper',
               description: [
                 { content_type: "text/html", content: "<p>A HTML description.</p>" },
                 { content_type: "text/plain", content: "Short description." },
@@ -32,6 +34,8 @@ describe LinkedItemPresenter do
         "web_url" => "https://www.test.gov.uk/my-page",
         "locale" => "en",
         "links" => {},
+        "schema_name" => "publication",
+        "document_type" => "policy_paper"
       )
     end
 

--- a/spec/presenters/linked_item_presenter_spec.rb
+++ b/spec/presenters/linked_item_presenter_spec.rb
@@ -77,7 +77,7 @@ describe LinkedItemPresenter do
 
     context "with a topical_event link" do
       let(:content_item) do
-        build(:content_item, format: "topical_event", details: {
+        build(:content_item, document_type: "topical_event", details: {
           start_date: "2015-11-25T00:00:00.000+00:00",
           end_date: "2015-11-30T00:00:00.000+00:00",
         })
@@ -94,7 +94,7 @@ describe LinkedItemPresenter do
     # TODO: Remove when topical_events are migrated
     context "with a placeholder_topical_event link" do
       let(:content_item) do
-        build(:content_item, format: "placeholder_topical_event", details: {
+        build(:content_item, document_type: "placeholder_topical_event", details: {
           start_date: "2015-11-25T00:00:00.000+00:00",
           end_date: "2015-11-30T00:00:00.000+00:00",
         })


### PR DESCRIPTION
Companion to https://github.com/alphagov/whitehall/pull/2572. Best reviewed commit by commit.

The `format` field is being replaced by `schema_name` and `document_type`. The new fields have been backfilled in #207. This PR changes content store to use the new fields to inform its behaviour around linked items and route registration. It also exposes the new fields in expanded links.

This work is required to enable the migration of HTML publications from Whitehall to the new world. 

/cc @danielroseman @gpeng 