### PR TITLE
Expand linked organisation branding

### DIFF
--- a/app/presenters/linked_item_presenter.rb
+++ b/app/presenters/linked_item_presenter.rb
@@ -29,6 +29,8 @@ class LinkedItemPresenter
     # as they will have a schema_name of 'placeholder' and a document_type of 'topical_event'
     when /(placeholder_)?topical_event/
       presented["details"] = linked_item.details.slice(:start_date, :end_date).stringify_keys
+    when /(placeholder_)?organisation/
+      presented["details"] = linked_item.details.slice(:brand, :logo).deep_stringify_keys
     end
 
     presented

--- a/spec/presenters/linked_item_presenter_spec.rb
+++ b/spec/presenters/linked_item_presenter_spec.rb
@@ -107,5 +107,49 @@ describe LinkedItemPresenter do
         )
       end
     end
+
+    context "with an organisation link" do
+      let(:content_item) do
+        build(:content_item, document_type: "organisation", details: {
+          brand: "ministry-mcministryface",
+          logo: {
+            formatted_title: "Ministry<br/>McMinistryface",
+            crest: "mmmf"
+          }
+        })
+      end
+
+      it "adds the start and end date from the details hash" do
+        expect(presented_item['details']).to eql(
+          "brand" => "ministry-mcministryface",
+          "logo" => {
+            "formatted_title" => "Ministry<br/>McMinistryface",
+            "crest" => "mmmf"
+          }
+        )
+      end
+    end
+
+    context "with a placeholder_organisation link" do
+      let(:content_item) do
+        build(:content_item, document_type: "placeholder_organisation", details: {
+          brand: "ministry-mcministryface",
+          logo: {
+            formatted_title: "Ministry<br/>McMinistryface",
+            crest: "mmmf"
+          }
+        })
+      end
+
+      it "adds the start and end date from the details hash" do
+        expect(presented_item['details']).to eql(
+          "brand" => "ministry-mcministryface",
+          "logo" => {
+            "formatted_title" => "Ministry<br/>McMinistryface",
+            "crest" => "mmmf"
+          }
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
Exposes the brand and logo details for linked organisations. These are needed for HTML Publications

/cc @fofr @gpeng 