### PR TITLE
Only attempt to resolve valid, relevant multi-type content...

### DIFF
--- a/app/presenters/content_type_resolver.rb
+++ b/app/presenters/content_type_resolver.rb
@@ -22,23 +22,20 @@ private
   end
 
   def resolve_array(array)
-    if has_content_types?(array)
-      extract_content(array)
+    if array.all? { |v| v.is_a?(Hash) }
+      array = array.map(&:symbolize_keys)
+      content_for_type = extract_content(array)
+    end
+
+    if content_for_type
+      content_for_type[:content]
     else
       array.map { |e| resolve(e) }
     end
   end
 
-  def has_content_types?(array)
-    return false unless array.all? { |v| v.is_a?(Hash) }
-
-    hash_keys = array.flat_map(&:keys).map(&:to_sym)
-    hash_keys.include?(:content_type) && hash_keys.include?(:content)
-  end
-
   def extract_content(array)
-    array = array.map(&:symbolize_keys)
-    array.detect { |h| h[:content_type] == content_type }[:content]
+    array.detect { |h| h[:content_type] == content_type && h[:content] }
   end
 
   attr_accessor :content_type

--- a/spec/presenters/content_type_resolver_spec.rb
+++ b/spec/presenters/content_type_resolver_spec.rb
@@ -106,4 +106,27 @@ RSpec.describe ContentTypeResolver do
       ]
     )
   end
+
+  it "doesn't resolve incomplete multi-type content" do
+    result = subject.resolve(
+      details: {
+        body: {
+          content: [
+            { content: "<p>body</p>" },
+            { content_type: "html" }
+          ]
+        }
+      }
+    )
+    expect(result).to eq(
+      details: {
+        body: {
+          content: [
+            { content: "<p>body</p>" },
+            { content_type: "html" }
+          ]
+        }
+      }
+    )
+  end
 end


### PR DESCRIPTION
https://trello.com/c/vKokCvrb/692-content-store-needs-to-handle-attachments

Adds an additional check to ensure that multi-type content attributes
contain the correct `content_type` (eg text/html) _and_ a corresponding content
value.
Refactored to remove the need to symbolize data keys twice.