### PR TITLE
Store and present ContentItem#withdrawn_notice

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -65,6 +65,7 @@ class ContentItem
   field :analytics_identifier, type: String
   field :transmitted_at, type: String
   field :payload_version, type: Integer
+  field :withdrawn_notice, type: Hash, default: {}
 
   scope :renderable_content, -> { where(:schema_name.nin => NON_RENDERABLE_FORMATS) }
 

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -23,6 +23,7 @@ class ContentItemPresenter
     schema_name
     title
     updated_at
+    withdrawn_notice
   ).freeze
 
   def initialize(item, api_url_method)

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -55,6 +55,7 @@ describe "Fetching content items", type: :request do
         details
         links
         expanded_links
+        withdrawn_notice
       ])
 
       expect(data).to include(
@@ -258,6 +259,28 @@ describe "Fetching content items", type: :request do
         "schema_name" => nil,
         "document_type" => nil,
       )
+    end
+  end
+
+  context "a withdrawn content item" do
+    let(:withdrawn_at) { DateTime.parse("2016-05-17 11:20") }
+    let(:withdrawn_item) do
+      FactoryGirl.create(
+        :content_item,
+        withdrawn_notice: {
+          explanation: "This is no longer true",
+          withdrawn_at: withdrawn_at,
+        }
+      )
+    end
+
+    it "displays the withdrawal explanation and time" do
+      get_content withdrawn_item
+
+      data = JSON.parse(response.body)
+
+      expect(data["withdrawn_notice"]["explanation"]).to eq("This is no longer true")
+      expect(DateTime.iso8601(data["withdrawn_notice"]["withdrawn_at"])).to eq(withdrawn_at)
     end
   end
 end


### PR DESCRIPTION
Withdrawing content in a publishing application should mean the content store presents the explanation and time of the withdrawal.

Part of https://trello.com/c/78Q9mrDe/708-make-whitehall-use-unpublishing-endpoint-medium