### PR TITLE
Add "links.documents" index to content_items

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -79,6 +79,11 @@ class ContentItem
   # and fetch the entire document.
   index(content_id: 1, locale: 1, format: 1, updated_at: -1, title: 1, _id: 1)
 
+  # Add an index to speed up calls from [incoming links](https://github.com/alphagov/content-store/blob/d066a40489c731d2dc835968750b92c8dd992f5c/app/models/content_item.rb#L122-L126).
+  # TODO: This will go away once dependency resolution moves to publishing api from content store,
+  # at which point this index can be removed again.
+  index("links.documents" => 1)
+
   # We want to force the JSON representation to use "base_path" instead of
   # "_id" to prevent "_id" being exposed outside of the model.
   def as_json(options = nil)


### PR DESCRIPTION
The `content-store` queries for this field when searching for detailed guides (and presumably other documents). Queries run in about 4-5 seconds, i.e.

```bash
$ mongo content_store_development
> db.content_items.find({ "links.documents": { "$in": ["5f1856a9-7631-11e4-a3cb-005056011aef"] } })
```

Adding an index appears to fix it.

The indexes will be [created automatically on deployment](https://github.com/alphagov/govuk-app-deployment/blob/master/content-store/config/deploy.rb#L21), but if you want to test this locally you can manually create them using:

```
bundle exec rake db:mongoid:create_indexes
```