### PR TITLE
Add public_updated_at to linked item presenter

### DIFF
--- a/app/presenters/linked_item_presenter.rb
+++ b/app/presenters/linked_item_presenter.rb
@@ -16,6 +16,7 @@ class LinkedItemPresenter
       "api_url" => api_url(linked_item),
       "web_url" => web_url(linked_item),
       "locale" => linked_item.locale,
+      "public_updated_at" => linked_item.public_updated_at,
       "schema_name" => linked_item.schema_name,
       "document_type" => linked_item.document_type
     }

--- a/spec/factories/content_item.rb
+++ b/spec/factories/content_item.rb
@@ -23,7 +23,7 @@ FactoryGirl.define do
       format "answer"
       title "Test content"
       rendering_app 'frontend'
-      public_updated_at Time.now
+      public_updated_at { Time.now }
     end
 
     factory :content_item_with_content_id, traits: [:with_content_id]

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -171,6 +171,7 @@ describe "Fetching content items", type: :request do
         title
         description
         locale
+        public_updated_at
         api_url
         web_url
         links
@@ -229,6 +230,7 @@ describe "Fetching content items", type: :request do
           title
           description
           locale
+          public_updated_at
           api_url
           web_url
           schema_name

--- a/spec/integration/fetching_linked_items_spec.rb
+++ b/spec/integration/fetching_linked_items_spec.rb
@@ -3,40 +3,44 @@ require 'rails_helper'
 describe "Fetching linked items", type: :request do
   describe "GET /incoming-links/:base_path_without_root" do
     it "returns the items linked to an item" do
-      item = create(:content_item, :with_content_id)
-      create(:content_item, content_id: 'ID-1', base_path: '/a', title: "A", links: { "parent" => [item.content_id] })
-      create(:content_item, content_id: 'ID-2', base_path: '/b', title: "B", links: { "parent" => [item.content_id] })
+      Timecop.freeze do
+        item = create(:content_item, :with_content_id)
+        create(:content_item, content_id: 'ID-1', base_path: '/a', title: "A", links: { "parent" => [item.content_id] })
+        create(:content_item, content_id: 'ID-2', base_path: '/b', title: "B", links: { "parent" => [item.content_id] })
 
-      get "/incoming-links#{item.base_path}?types[]=parent&types[]=topics"
+        get "/incoming-links#{item.base_path}?types[]=parent&types[]=topics"
 
-      expect(parsed_response["parent"]).to eql([
-        {
-          "content_id" => "ID-1",
-          "title" => "A",
-          "base_path" => "/a",
-          "description" => nil,
-          "api_url" => "http://www.example.com/content/a",
-          "web_url" => "https://www.test.gov.uk/a",
-          "locale" => "en",
-          "links" => { "parent" => [item.content_id] },
-          "schema_name" => "answer",
-          "document_type" => "answer",
-        },
-        {
-          "content_id" => "ID-2",
-          "title" => "B",
-          "base_path" => "/b",
-          "description" => nil,
-          "api_url" => "http://www.example.com/content/b",
-          "web_url" => "https://www.test.gov.uk/b",
-          "locale" => "en",
-          "links" => { "parent" => [item.content_id] },
-          "schema_name" => "answer",
-          "document_type" => "answer",
-        },
-      ])
+        expect(parsed_response["parent"]).to eql([
+          {
+            "content_id" => "ID-1",
+            "title" => "A",
+            "base_path" => "/a",
+            "description" => nil,
+            "api_url" => "http://www.example.com/content/a",
+            "web_url" => "https://www.test.gov.uk/a",
+            "locale" => "en",
+            "links" => { "parent" => [item.content_id] },
+            "public_updated_at" => Time.now.as_json,
+            "schema_name" => "answer",
+            "document_type" => "answer",
+          },
+          {
+            "content_id" => "ID-2",
+            "title" => "B",
+            "base_path" => "/b",
+            "description" => nil,
+            "api_url" => "http://www.example.com/content/b",
+            "web_url" => "https://www.test.gov.uk/b",
+            "locale" => "en",
+            "links" => { "parent" => [item.content_id] },
+            "public_updated_at" => Time.now.as_json,
+            "schema_name" => "answer",
+            "document_type" => "answer",
+          },
+        ])
 
-      expect(parsed_response["topics"]).to eql([])
+        expect(parsed_response["topics"]).to eql([])
+      end
     end
   end
 
@@ -52,6 +56,6 @@ describe "Fetching linked items", type: :request do
   end
 
   def parsed_response
-    @parsed_response ||= JSON.parse(response.body)
+    JSON.parse(response.body)
   end
 end

--- a/spec/presenters/linked_item_presenter_spec.rb
+++ b/spec/presenters/linked_item_presenter_spec.rb
@@ -17,6 +17,7 @@ describe LinkedItemPresenter do
                 { content_type: "text/html", content: "<p>A HTML description.</p>" },
                 { content_type: "text/plain", content: "Short description." },
               ],
+              public_updated_at: '2015-11-25T00:00:00.000+00:00'
            )
     end
 
@@ -34,6 +35,7 @@ describe LinkedItemPresenter do
         "web_url" => "https://www.test.gov.uk/my-page",
         "locale" => "en",
         "links" => {},
+        "public_updated_at": '2015-11-25T00:00:00.000+00:00',
         "schema_name" => "publication",
         "document_type" => "policy_paper"
       )

--- a/spec/presenters/linked_item_presenter_spec.rb
+++ b/spec/presenters/linked_item_presenter_spec.rb
@@ -17,7 +17,7 @@ describe LinkedItemPresenter do
                 { content_type: "text/html", content: "<p>A HTML description.</p>" },
                 { content_type: "text/plain", content: "Short description." },
               ],
-              public_updated_at: '2015-11-25T00:00:00.000+00:00'
+              public_updated_at: Time.new(2016, 1, 1)
            )
     end
 
@@ -35,7 +35,7 @@ describe LinkedItemPresenter do
         "web_url" => "https://www.test.gov.uk/my-page",
         "locale" => "en",
         "links" => {},
-        "public_updated_at": '2015-11-25T00:00:00.000+00:00',
+        "public_updated_at" => DateTime.new(2016, 1, 1),
         "schema_name" => "publication",
         "document_type" => "policy_paper"
       )


### PR DESCRIPTION
Relies on https://github.com/alphagov/publishing-api/pull/343

As part of https://trello.com/c/ZWU9N8Bc/414-add-missing-details-to-document-list-for-document-collection-format-medium