### PR TITLE
Add "links.working_groups" index to content_items

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -84,6 +84,11 @@ class ContentItem
   # at which point this index can be removed again.
   index("links.documents" => 1)
 
+  # Add an index to speed up calls from working groups.
+  # TODO: This will go away once dependency resolution moves to publishing api from content store,
+  # at which point this index can be removed again.
+  index("links.working_groups" => 1)
+
   # We want to force the JSON representation to use "base_path" instead of
   # "_id" to prevent "_id" being exposed outside of the model.
   def as_json(options = nil)


### PR DESCRIPTION
The `content-store` queries for this field when searching for guides. Queries run slowly, here's an example:

```bash
$ mongo content_store_development
> db.content_items.find({ "links.working_groups": { "$in": ["f3a2c385-2a22-47db-a532-0c343315caa3"] } })
```

Adding an index appears to fix it. Dependency resolution will also fix this, after which we may remove it.

The indexes will be [created automatically on deployment](https://github.com/alphagov/govuk-app-deployment/blob/master/content-store/config/deploy.rb#L21), but if you want to test this locally you can manually create them using:

```
bundle exec rake db:mongoid:create_indexes
```

Prior art: https://github.com/alphagov/content-store/pull/215