### PR TITLE
Delete stale placeholder policies

### DIFF
--- a/db/migrate/20160609155601_remove_policy_placeholders.rb
+++ b/db/migrate/20160609155601_remove_policy_placeholders.rb
@@ -1,0 +1,8 @@
+class RemovePolicyPlaceholders < Mongoid::Migration
+  def self.up
+    ids_to_delete = %w(12a4eb7a-6037-4cc0-aa58-0a4f2fbc5e7f e0deb0ec-e9fc-4308-b8c0-eba4dc92aa83 f656d065-43aa-4ab0-91f7-a6809ce5b68b)
+    ids_to_delete.each do |id|
+      ContentItem.find_by(content_id: id).destroy
+    end
+  end
+end


### PR DESCRIPTION
There are a few placeholder policies which the policy-publisher
doesn't know about.

This is because those policies were renamed at some point before
the migration to publishing-api was completed.

We should delete these manually.
We already introduced another PR to deal with publishing-api.

See
https://trello.com/c/xARBi6HF
and
https://github.com/alphagov/publishing-api/pull/356