### PR TITLE
Respond with 410 for gone items...

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -17,7 +17,7 @@ class ContentItemsController < ApplicationController
     ) unless item
 
     if item.viewable_by?(authenticated_user_uid)
-      render json: ContentItemPresenter.new(item, api_url_method)
+      render json: ContentItemPresenter.new(item, api_url_method), status: http_status(item)
     else
       render json_forbidden_response
     end
@@ -98,5 +98,10 @@ private
   def max_cache_time(item)
     return unless item.try(:details)
     item.details["max_cache_time"]
+  end
+
+  def http_status(item)
+    return 410 if item.gone?
+    200
   end
 end

--- a/spec/factories/content_item.rb
+++ b/spec/factories/content_item.rb
@@ -40,7 +40,7 @@ FactoryGirl.define do
       format "gone"
     end
 
-    factory :access_limited_content_item do
+    factory :access_limited_content_item, parent: :content_item do
       sequence(:base_path) { |n| "/access-limited-#{n}" }
       access_limited {
         { "users" => ["M6GdNZggrbGiJrLjMSbKqA", "f17250b0-7540-0131-f036-005056030202"] }

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -285,4 +285,24 @@ describe "Fetching content items", type: :request do
       expect(DateTime.iso8601(data["withdrawn_notice"]["withdrawn_at"])).to eq(withdrawn_at)
     end
   end
+
+  context "a gone content item" do
+    let(:gone_item) { FactoryGirl.create(:gone_content_item) }
+
+    before do
+      get_content gone_item
+    end
+
+    it "responds with 410" do
+      expect(response.status).to eq(410)
+    end
+
+    it "sets cache headers to expire in the default TTL" do
+      expect(cache_control["max-age"]).to eq(default_ttl.to_s)
+    end
+
+    it "sets a cache-control directive of public" do
+      expect(cache_control["public"]).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
Part of https://trello.com/c/od05JtVL/732-unpublishing-return-404-or-410-not-200-medium

The content store should return a response status code consistent with the router entry for this content. For 'gone' items this will be 410.