### PR TITLE
Do not present links when they have already been expanded

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -121,7 +121,14 @@ class ContentItem
 
   # Return a Hash of link types to lists of related items
   def linked_items
+    return links if already_expanded_links?
     LinkedItemsQuery.new(self).call
+  end
+
+  def already_expanded_links?
+    return false if links.empty?
+    expanded = links.flat_map { |_, value| value }
+    expanded.all? { |value| value.is_a?(Hash) && value.has_key?(:web_url) }
   end
 
   def incoming_links(link_type, linking_document_type: nil)

--- a/app/presenters/linked_item_presenter.rb
+++ b/app/presenters/linked_item_presenter.rb
@@ -8,13 +8,14 @@ class LinkedItemPresenter
   end
 
   def present
+    return linked_item if already_expanded?
     presented = {
       "content_id" => linked_item.content_id,
       "title" => linked_item.title,
       "base_path" => linked_item.base_path,
       "description" => ContentItemPresenter::RESOLVER.resolve(linked_item.description),
-      "api_url" => api_url(linked_item),
-      "web_url" => web_url(linked_item),
+      "api_url" => api_url,
+      "web_url" => web_url,
       "locale" => linked_item.locale,
       "public_updated_at" => linked_item.public_updated_at,
       "schema_name" => linked_item.schema_name,
@@ -39,15 +40,19 @@ class LinkedItemPresenter
 
 private
 
-  def api_url(item)
-    return nil unless item.base_path
-
-    @api_url_method.call(item.base_path_without_root)
+  def already_expanded?
+    !linked_item.is_a?(ContentItem)
   end
 
-  def web_url(item)
-    return nil unless item.base_path
+  def api_url
+    return unless linked_item.base_path
 
-    Plek.current.website_root + item.base_path
+    @api_url_method.call(linked_item.base_path_without_root)
+  end
+
+  def web_url
+    return unless linked_item.base_path
+
+    Plek.current.website_root + linked_item.base_path
   end
 end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -389,6 +389,17 @@ describe ContentItem, type: :model do
       end
     end
 
+    context "when a link hash has already been expanded" do
+      let(:expanded_link) { [{ web_url: "test" }] }
+      let!(:content_item) do
+        create(:content_item, links: { parent: expanded_link })
+      end
+
+      it "does not create new ContentItems" do
+        expect(content_item.linked_items[:parent]).to eq(expanded_link)
+      end
+    end
+
     context "if a link hash is provided for pass-through" do
       let(:passthrough_link_hash) {
         {

--- a/spec/presenters/linked_item_presenter_spec.rb
+++ b/spec/presenters/linked_item_presenter_spec.rb
@@ -77,6 +77,14 @@ describe LinkedItemPresenter do
       end
     end
 
+    context "a content item has already been expanded" do
+      let(:content_item) { { web_url: "/test" } }
+      let(:presenter) { LinkedItemPresenter.new(content_item, api_url_method) }
+      it "returns the content_item" do
+        expect(presenter.present). to eq(content_item)
+      end
+    end
+
     context "with a topical_event link" do
       let(:content_item) do
         build(:content_item, document_type: "topical_event", details: {


### PR DESCRIPTION
Links are expanded in the publishing API, so there is no need to
expand them in the content store.