### PR TITLE
Rake task to compare links with expanded links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'plek', '~> 1.9'
 gem 'statsd-ruby', '~> 1.2.1'
 
 gem 'whenever', '~> 0.9.4', require: false
+gem 'hashdiff', require: false
 
 if ENV['GDS_API_ADAPTERS_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
     govuk-lint (0.6.1)
       rubocop (~> 0.35.0)
       scss_lint (~> 0.44.0)
+    hashdiff (0.3.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
@@ -288,6 +289,7 @@ DEPENDENCIES
   gds-api-adapters (= 20.1.1)
   govuk-content-schema-test-helpers (= 1.3.0)
   govuk-lint
+  hashdiff
   logstasher (= 0.5.0)
   mongoid (= 5.1.3)
   mongoid_rails_migrations (= 1.0.1)

--- a/lib/compare_links.rb
+++ b/lib/compare_links.rb
@@ -1,0 +1,48 @@
+require "hashdiff"
+
+class CompareLink
+  attr_reader :new, :content_item
+
+  def initialize(content_item)
+    @content_item = content_item
+    @old = content_item.linked_items
+    @new = content_item.expanded_links
+  end
+
+  def compare
+    puts "DIFF #{content_item.content_id} #{'*' * 20}"
+    pp HashDiff.diff(sort(old), sort(new))
+  end
+
+private
+
+  def old
+    @old.each_with_object({}) do |(link_type, linked_items), items|
+      items[link_type] = linked_items.map do |i|
+        LinkedItemPresenter.new(i, api_url_method).present
+      end
+    end
+  end
+
+  def api_url_method
+    lambda { |a| Plek.current.website_root + "/api/content/" + a }
+  end
+
+  def sort(links)
+    links.each_with_object({}) do |(k, v), h|
+      h[k] = v.map do |value|
+        Hash[value.except(*known_exceptions).sort]
+      end
+    end
+  end
+
+  def known_exceptions
+    %w(
+      document_type
+      expanded_links
+      links
+      public_updated_at
+      schema_name
+    )
+  end
+end

--- a/lib/tasks/compare.rake
+++ b/lib/tasks/compare.rake
@@ -1,0 +1,24 @@
+require 'compare_links'
+
+namespace :compare do
+  desc """
+  Compare expanded links with links for migration for a schema_name
+  rake 'compare:links[service_manual_guide]'
+  """
+  task :schema_name, [:schema_name] => :environment do |_t, args|
+    schema_name = args[:schema_name]
+    ContentItem.where(schema_name: schema_name).each do |item|
+      CompareLink.new(item).compare
+    end
+  end
+
+  desc """
+  Compare expanded links with links for migration for a content item
+  rake 'compare:content_item[5cb79345-4832-4f75-a48e-1d0118636a7d]'
+  """
+  task :content_item, [:content_item] => :environment do |_t, args|
+    content_item = args[:content_item]
+    content_item = ContentItem.find_by(content_id: content_item)
+    CompareLink.new(content_item).compare
+  end
+end


### PR DESCRIPTION
Uses HashDiff to print out the differences of links and expanded_links
to ensure there are no breaking changes