### PR TITLE
Require Pretty-printer

### DIFF
--- a/lib/compare_links.rb
+++ b/lib/compare_links.rb
@@ -1,4 +1,5 @@
 require "hashdiff"
+require "pp"
 
 class CompareLink
   attr_reader :new, :content_item


### PR DESCRIPTION
It is not loaded when running a rake task to compare links