### PR TITLE
Ignore api_url and web_url

### DIFF
--- a/lib/compare_links.rb
+++ b/lib/compare_links.rb
@@ -12,7 +12,14 @@ class CompareLink
 
   def compare
     puts "DIFF #{content_item.content_id} #{'*' * 20}"
-    pp HashDiff.diff(sort(old), sort(new))
+    pp HashDiff.best_diff(sort(old), sort(new))
+  end
+
+  def show
+    puts "LINKS #{content_item.content_id} #{'*' * 20}"
+    pp sort(old)
+    puts "EXPANDED LINKS #{content_item.content_id} #{'*' * 20}"
+    pp sort(new)
   end
 
 private
@@ -26,7 +33,7 @@ private
   end
 
   def api_url_method
-    lambda { |a| Plek.current.website_root + "/api/content/" + a }
+    lambda { |path| Plek.current.website_root + "/api/content/" + path }
   end
 
   def sort(links)
@@ -39,11 +46,13 @@ private
 
   def known_exceptions
     %w(
+      api_url
       document_type
       expanded_links
       links
       public_updated_at
       schema_name
+      web_url
     )
   end
 end

--- a/lib/tasks/compare.rake
+++ b/lib/tasks/compare.rake
@@ -19,6 +19,8 @@ namespace :compare do
   task :content_item, [:content_item] => :environment do |_t, args|
     content_item = args[:content_item]
     content_item = ContentItem.find_by(content_id: content_item)
-    CompareLink.new(content_item).compare
+    compare_link = CompareLink.new(content_item)
+    compare_link.show
+    compare_link.compare
   end
 end


### PR DESCRIPTION
These (api_url and web_url) fail on integration since the copy of the DB is from production
with production URLs.

Add show method to more easily compare links with expanded links

Change to HashDiff#best_diff which shows more precise differences with nested arrays of hashes 