### PR TITLE
Rake task to show unusual link attributes for migration

### DIFF
--- a/lib/link_details.rb
+++ b/lib/link_details.rb
@@ -1,0 +1,89 @@
+class LinkDetails
+  def initialize(scope)
+    @scope = scope
+  end
+
+  def report
+    @report ||= build_report
+  end
+
+  def print_report
+    report.each do |(key, results)|
+      puts "Link Type: #{key}"
+      if results[:attributes].length > 1
+        puts "Multiple attribute types for same link type"
+        results[:attributes].each_index do |index|
+          attributes_report(
+            results[:attributes][index],
+            results[:content_ids][index]
+          )
+        end
+      else
+        attributes_report(results[:attributes][0], results[:content_ids][0])
+      end
+    end
+  end
+
+private
+
+  def attributes_report(attributes, content_ids)
+    unusual_attributes = (attributes || []) - expected_fields
+    content_ids_show = content_ids ? content_ids.sample(4) : 'None'
+    puts "  Unusual Attributes: #{unusual_attributes}"
+    puts "  Example Content Ids: #{content_ids_show}" if unusual_attributes
+  end
+
+  def build_report
+    content_item_links = @scope.each_with_object({}) do |item, memo|
+      memo[item.content_id] = presented_links(item.linked_items)
+    end
+    # This probably should be done better without the 3 embedded loops, left in
+    # while this is just a basic proof of concept
+    content_item_links.each_with_object({}) do |(id, links), memo|
+      links.each do |(type, type_links)|
+        type_sym = type.to_sym
+        memo[type_sym] ||= { attributes: [], content_ids: [] }
+        type_links.each do |link|
+          fields = link.keys
+          index = memo[type_sym][:attributes].find_index(fields)
+          if index
+            memo[type_sym][:content_ids][index] << id
+          else
+            memo[type_sym][:attributes] << fields
+            new_index = memo[type_sym][:attributes].find_index(fields)
+            memo[type_sym][:content_ids][new_index] = [id]
+          end
+        end
+      end
+    end
+  end
+
+  def presented_links(links)
+    links.each_with_object({}) do |(link_type, linked_items), items|
+      items[link_type] = linked_items.map do |i|
+        LinkedItemPresenter.new(i, api_url_method).present
+      end
+    end
+  end
+
+  def api_url_method
+    lambda { |path| Plek.current.website_root + "/api/content/" + path }
+  end
+
+  def expected_fields
+    %w(
+      analytics_identifier
+      api_url
+      base_path
+      content_id
+      description
+      document_type
+      links
+      locale
+      public_updated_at
+      schema_name
+      title
+      web_url
+    )
+  end
+end

--- a/lib/tasks/link_details.rake
+++ b/lib/tasks/link_details.rake
@@ -1,0 +1,32 @@
+require 'link_details'
+
+namespace :link_details do
+  desc """
+  Show attributes that are unusual in links for a particular document type and
+  some sample content ids to find them.
+  Used in the process to migrate link generation from Content Store to
+  Publishing API
+  rake 'link_details:document_type[service_manual_guide]'
+  """
+  task :document_type, [:document_type] => :environment do |_t, args|
+    document_type = args[:document_type]
+    scope = ContentItem.where(document_type: document_type)
+    LinkDetails.new(scope).print_report
+  end
+
+  desc """
+  Show attributes that are unusual in links for all document types.
+  This will take a long time to run.
+  Used in the process to migrate link generation from Content Store to
+  Publishing API
+  rake 'link_details:all'
+  """
+  task all: :environment do
+    document_types = ContentItem.distinct(:document_type)
+    (document_types - ['working_group']).each do |document_type|
+      puts "\nDocument Type: #{document_type}\n"
+      scope = ContentItem.where(document_type: document_type)
+      LinkDetails.new(scope).print_report
+    end
+  end
+end


### PR DESCRIPTION
This task loops through items in the content store to pull out details which can aid us in finding unexpected attributes in link types for migrating to using publishing API to generate them.