### PR TITLE
Sort the array of links

### DIFF
--- a/lib/compare_links.rb
+++ b/lib/compare_links.rb
@@ -38,9 +38,15 @@ private
 
   def sort(links)
     links.each_with_object({}) do |(k, v), h|
-      h[k] = v.map do |value|
+      v = v.map do |value|
         Hash[value.except(*known_exceptions).sort]
       end
+
+      v = v.sort do |a, b|
+        a['base_path'] <=> b['base_path']
+      end
+
+      h[k] = v
     end
   end
 


### PR DESCRIPTION
This removes noise from the diff, where its just the position of the element in
the array that differs.

The ordering of the elements is non-deterministic in the content store and
publishing API, as far as I can tell.