### PR TITLE
Validate against frontend schemas

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,14 +1,14 @@
 class ApplicationController < ActionController::API
   rescue_from Mongoid::Errors::DocumentNotFound, with: :error_404
 
+  def config
+    @config ||= ContentStore::Application.config
+  end
+
 private
 
   def error_404
     head :not_found
-  end
-
-  def config
-    @config ||= ContentStore::Application.config
   end
 
   def parse_json_request

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -17,7 +17,9 @@ class ContentItemsController < ApplicationController
     ) unless item
 
     if item.viewable_by?(authenticated_user_uid)
-      render json: ContentItemPresenter.new(item, api_url_method), status: http_status(item)
+      json = ContentItemPresenter.new(item, api_url_method).as_json
+      validate_schema(json)
+      render json: json, status: http_status(item)
     else
       render json_forbidden_response
     end
@@ -103,5 +105,9 @@ private
   def http_status(item)
     return 410 if item.gone?
     200
+  end
+
+  def validate_schema(json)
+    SchemaValidator.new(type: :schema).validate(json.except("content_id"))
   end
 end

--- a/app/validators/schema_validator.rb
+++ b/app/validators/schema_validator.rb
@@ -1,0 +1,74 @@
+require "json-schema"
+
+class SchemaValidator
+  def initialize(type:, schema_name: nil, schema: nil)
+    @type = type
+    @schema = schema
+    @schema_name = schema_name
+  end
+
+  def validate(payload)
+    @payload = payload
+
+    return true if schema_name_exception?
+
+    errors = JSON::Validator.fully_validate(
+      schema,
+      payload,
+      errors_as_objects: true,
+    )
+
+    return true if errors.empty?
+
+    errors = Hash[errors.map.with_index { |e, i| [i, present_error(e)] }]
+
+    Airbrake.notify_or_ignore(
+      {
+        error_class: "SchemaValidationError",
+        error_message: "Error validating payload against schema"
+      },
+      parameters: {
+        errors: errors,
+        message_data: payload
+      }
+    )
+    false
+  end
+
+private
+
+  attr_reader :payload, :type
+
+  def present_error(error_hash)
+    # The schema key just contains an addressable, which is not informative as
+    # the schema in use should be clear from the error class and message
+    error_hash = error_hash.reject { |k, _| k == :schema }
+
+    if error_hash.has_key?(:errors)
+      error_hash[:errors] = Hash[
+        error_hash[:errors].map do |k, errors|
+          [k, Hash[errors.map.with_index { |e, i| [i, present_error(e)] }]]
+        end
+      ]
+    end
+
+    error_hash
+  end
+
+  def schema
+    @schema || JSON.load(File.read("../govuk-content-schemas/dist/formats/#{schema_name}/frontend/#{type}.json"))
+  rescue Errno::ENOENT => error
+    Airbrake.notify_or_ignore(error, parameters: {
+      explanation: "#{payload} is missing schema_name #{schema_name} or type #{type}"
+    })
+    {}
+  end
+
+  def schema_name
+    @schema_name || payload["schema_name"] || payload["format"]
+  end
+
+  def schema_name_exception?
+    schema_name.to_s.match(/placeholder_/)
+  end
+end

--- a/spec/controllers/content_items_controller_spec.rb
+++ b/spec/controllers/content_items_controller_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe ContentItemsController, type: :controller do
+  describe "show" do
+    let(:validator) { double(:validator) }
+
+    before do
+      FactoryGirl.create(:content_item, base_path: "/vat-rates")
+    end
+
+    it "validates against frontend schemas" do
+      expect(SchemaValidator).to receive(:new)
+        .with(type: :schema).and_return(validator)
+      expect(validator).to receive(:validate)
+        .with(hash_including("base_path" => "/vat-rates"))
+
+      get :show, base_path_without_root: "vat-rates"
+    end
+  end
+end

--- a/spec/validators/schema_validator_spec.rb
+++ b/spec/validators/schema_validator_spec.rb
@@ -1,0 +1,170 @@
+require "rails_helper"
+
+RSpec.describe SchemaValidator do
+  let(:schema) do
+    {
+      "type" => "object",
+      "required" => ["a"],
+      "properties" => {
+        "a" => { "type" => "integer" }
+      }
+    }
+  end
+
+  subject(:validator) do
+    SchemaValidator.new(type: :schema, schema: schema)
+  end
+
+  context "schema" do
+    let(:schema) { nil }
+    let(:payload) { { schema_name: 'test' } }
+
+    it "logs to airbrake with an unknown schema_name" do
+      expect(Airbrake).to receive(:notify_or_ignore)
+        .with(an_instance_of(Errno::ENOENT), a_hash_including(:parameters))
+      validator.validate(payload)
+    end
+  end
+
+  context "valid payload" do
+    let(:payload) { { "a" => 1 } }
+
+    it "does not report to airbrake" do
+      expect(Airbrake).to_not receive(:notify_or_ignore)
+      validator.validate(payload)
+    end
+
+    it "logs to airbrake when the payload is invalid" do
+      expect(validator.validate(payload)).to be true
+    end
+  end
+
+  context "invalid payload" do
+    let(:payload) { { "b" => 1 } }
+
+    it "reports to airbrake" do
+      expect(Airbrake).to receive(:notify_or_ignore)
+      validator.validate(payload)
+    end
+
+    it "logs to airbrake when the payload is invalid" do
+      expect(validator.validate(payload)).to be false
+    end
+  end
+
+  context "exceptions" do
+    let(:payload) { { "schema_name" => "placeholder_test" } }
+
+    it "does not report to airbrake" do
+      expect(Airbrake).to_not receive(:notify_or_ignore)
+      validator.validate(payload)
+    end
+  end
+
+  context "schema with format/schema_name alternatives" do
+    let(:schema) {
+      {
+        "oneOf" => [
+          {
+            "properties" => {
+              "format" => { "type" => "string" },
+              "title" => { "type" => "string" },
+            },
+            "additionalProperties" => false,
+            "required" => %w{format title},
+          },
+          {
+            "properties" => {
+              "schema_name" => { "type" => "string" },
+              "document_type" => { "type" => "string" },
+            },
+            "additionalProperties" => false,
+            "required" => %w{schema_name document_type format}
+          }
+        ]
+      }
+    }
+
+    context "when schema_name is provided" do
+      let(:payload) {
+        { schema_name: "foo" }
+      }
+      it "reports useful validation errors" do
+        expect(Airbrake).to receive(:notify_or_ignore) do |_, opts|
+          expect(opts[:parameters][:errors][0]).to match(
+            a_hash_including(
+              message: a_string_starting_with("The property '#/' of type Hash did not match"),
+              failed_attribute: "OneOf",
+              errors: {
+                oneof_0: {
+                  0 => a_hash_including(
+                    message: a_string_starting_with("The property '#/' did not contain a required property of 'title'"),
+                    failed_attribute: "Required",
+                  ),
+                  1 => a_hash_including(
+                    message: a_string_starting_with("The property '#/' did not contain a required property of 'format'"),
+                    failed_attribute: "Required",
+                  ),
+                  2 => a_hash_including(
+                    message: a_string_starting_with("The property '#/' contains additional properties [\"schema_name\"] outside of the schema when none are allowed"),
+                    failed_attribute: "AdditionalProperties"
+                  )
+                },
+                oneof_1: {
+                  0 => a_hash_including(
+                    message: a_string_starting_with("The property '#/' did not contain a required property of 'format'"),
+                    failed_attribute: "Required",
+                  ),
+                  1 => a_hash_including(
+                    message: a_string_starting_with("The property '#/' did not contain a required property of 'document_type'"),
+                    failed_attribute: "Required",
+                  ),
+                }
+              }
+            )
+          )
+        end
+        validator.validate(payload)
+      end
+    end
+
+    context "when format is provided" do
+      let(:payload) {
+        { format: "foo" }
+      }
+      it "reports useful validation errors" do
+        expect(Airbrake).to receive(:notify_or_ignore) do |_, opts|
+          expect(opts[:parameters][:errors][0]).to match(
+            a_hash_including(
+              message: a_string_starting_with("The property '#/' of type Hash did not match"),
+              failed_attribute: "OneOf",
+              errors: {
+                oneof_0: {
+                  0 => a_hash_including(
+                    message: a_string_starting_with("The property '#/' did not contain a required property of 'title'"),
+                    failed_attribute: "Required",
+                  ),
+                },
+                oneof_1: {
+                  0 => a_hash_including(
+                    message: a_string_starting_with("The property '#/' did not contain a required property of 'document_type'"),
+                    failed_attribute: "Required",
+                  ),
+                  1 => a_hash_including(
+                    message: a_string_starting_with("The property '#/' did not contain a required property of 'schema_name'"),
+                    failed_attribute: "Required",
+                  ),
+                  2 => a_hash_including(
+                    message: a_string_starting_with("The property '#/' contains additional properties [\"format\"] outside of the schema when none are allowed"),
+                    failed_attribute: "AdditionalProperties"
+                  ),
+                }
+              }
+            )
+          )
+        end
+        validator.validate(payload)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/qegWyQTI/725-content-store-validation-against-front-end-schemas

Validates the outgoing presentation of a content item against the relevant frontend schema.
Validation errors are reported via Airbrake.
This should go out with https://github.gds/gds/alphagov-deployment/pull/1204 in order to take Airbrake notification out of the request process.