### PR TITLE
Add a task to validate against frontend schemas

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,13 @@
+Style/BracesAroundHashParameters:
+  EnforcedStyle: context_dependent
+  SupportedStyles:
+    # The `braces` style enforces braces around all method parameters that are
+    # hashes.
+    - braces
+    # The `no_braces` style checks that the last parameter doesn't have braces
+    # around it.
+    - no_braces
+    # The `context_dependent` style checks that the last parameter doesn't have
+    # braces around it, but requires braces if the second to last parameter is
+    # also a hash literal.
+    - context_dependent

--- a/lib/tasks/data_hygiene/schema_validation.rake
+++ b/lib/tasks/data_hygiene/schema_validation.rake
@@ -1,0 +1,9 @@
+require "tasks/data_hygiene/schema_validator"
+
+namespace :schema_validation do
+  desc "validates all content items for a given format producing a report of errors"
+  task :errors_for_format, [:schema_name] => :environment do |_t, args|
+    schema_name = args[:schema_name]
+    DataHygiene::SchemaValidator.new(schema_name).report_errors
+  end
+end

--- a/lib/tasks/data_hygiene/schema_validator.rb
+++ b/lib/tasks/data_hygiene/schema_validator.rb
@@ -1,0 +1,63 @@
+module DataHygiene
+  class SchemaValidator
+    def initialize(schema_name, log = STDOUT)
+      @schema_name = schema_name
+      @log = log
+    end
+
+    def report_errors
+      error_count = 0
+      log.puts "Validating #{criteria.count} items with format '#{schema_name}'\n\n"
+
+      File.open(report_path, "w") do |file|
+        criteria.each do |item|
+          validation_errors = validate(payload(item))
+          if validation_errors.any?
+            log.print "E"
+            csv_row = [item.base_path, validation_errors].flatten.join(",")
+            file.write(csv_row + " \n")
+            error_count += 1
+          else
+            log.print "."
+          end
+        end
+      end
+
+      log.puts "\n\n#{error_count} errors written to #{report_path}"
+    end
+
+  private
+
+    attr_reader :schema_name, :log
+
+    def criteria
+      ContentItem.any_of(
+        { schema_name: schema_name },
+        { document_type: schema_name },
+        { format: schema_name },
+      )
+    end
+
+    def validate(payload)
+      JSON::Validator.fully_validate(
+        schema,
+        payload,
+      )
+    end
+
+    def payload(item)
+      api_url_method = Rails.application.routes.url_helpers.method(:content_item_path)
+      ContentItemPresenter.new(item, api_url_method).to_json
+    end
+
+    def schema
+      prefix_path = Rails.env.development? ? "../govuk-content-schemas/dist" : "govuk-content-schemas"
+      schema_path = "#{prefix_path}/formats/#{schema_name}/frontend/schema.json"
+      @schema ||= JSON.load(File.read(schema_path))
+    end
+
+    def report_path
+      Rails.root.join("tmp", "#{schema_name}-validation-errors.csv")
+    end
+  end
+end

--- a/spec/integration/access_limited_spec.rb
+++ b/spec/integration/access_limited_spec.rb
@@ -19,7 +19,7 @@ describe "Fetching an access-limited content item", type: :request do
   context "request with an authorised user ID specified in the header" do
     before do
       get "/content/#{access_limited_content_item.base_path}",
-        {}, 'X-Govuk-Authenticated-User' => authorised_user_uid
+        {}, { 'X-Govuk-Authenticated-User' => authorised_user_uid }
     end
 
     it "returns the details for the requested item" do
@@ -38,7 +38,7 @@ describe "Fetching an access-limited content item", type: :request do
   context "request with an unauthorised user ID specified in the header" do
     it "returns a 403 (Forbidden) response" do
       get "/content/#{access_limited_content_item.base_path}",
-        {}, 'X-Govuk-Authenticated-User' => 'unauthorised-user'
+        {}, { 'X-Govuk-Authenticated-User' => 'unauthorised-user' }
 
       json = JSON.parse(response.body)
 


### PR DESCRIPTION
Adds a task which will validate all content items of a given `format`/`schema_name`/`document_type` against the relevant frontend schema.
This task reports errors for a content item `base_path` in csv format, written to the application tmp dir.