### PR TITLE
Allow `gone` items to be returned with 200

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -121,7 +121,13 @@ class ContentItem
   end
 
   def gone?
-    self.schema_name == "gone"
+    #we've overloaded gone a bit by adding explanation and alternative
+    #url to the schema to support Whitehall unpublishing. We need to consider
+    #things with an explanation as only being a bit gone and not return 410 from
+    #content store or register a gone route. This is a fix until we implement an
+    #alternative type of unpublishing through the stack as it is causing issues
+    #in production
+    self.schema_name == "gone" && self.details.empty?
   end
 
   # Return a Hash of link types to lists of related items

--- a/spec/factories/content_item.rb
+++ b/spec/factories/content_item.rb
@@ -40,6 +40,17 @@ FactoryGirl.define do
       format "gone"
     end
 
+    factory :gone_content_item_with_details do
+      sequence(:base_path) { |n| "/messy-language-stuff-#{n}" }
+      format "gone"
+      details {
+        {
+          explanation: "<div class=\"govspeak\"><p>Explanation…</p> </div>",
+          alternative_path: "/example"
+        }
+      }
+    end
+
     factory :access_limited_content_item, parent: :content_item do
       sequence(:base_path) { |n| "/access-limited-#{n}" }
       access_limited {

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -304,4 +304,22 @@ describe "Fetching content items", type: :request do
       expect(cache_control["public"]).to eq(true)
     end
   end
+
+  context "a gone content item with an explantion and alternative_path" do
+    let(:gone_item) { FactoryGirl.create(:gone_content_item_with_details) }
+
+    before do
+      get_content gone_item
+    end
+
+    it "responds with 200" do
+      expect(response.status).to eq(200)
+    end
+
+    it "includes the details" do
+      details = JSON.parse(response.body)["details"]
+      expect(details["explanation"]).to eq("<div class=\"govspeak\"><p>Explanation…</p> </div>")
+      expect(details["alternative_path"]).to eq("/example")
+    end
+  end
 end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -590,4 +590,16 @@ describe ContentItem, type: :model do
       expect(content_item["description"]).to eq("value" => "foo")
     end
   end
+
+  describe "gone?" do
+    it "returns true for schema_name 'gone' with empty details" do
+      gone_item = build(:gone_content_item)
+      expect(gone_item.gone?).to be(true)
+    end
+
+    it "returns true for schema_name 'gone' with empty details" do
+      gone_item = build(:gone_content_item_with_details)
+      expect(gone_item.gone?).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
Currently sending a `gone` item through the `/unpublish` endpoint of Publishing API always creates a `gone` route in the router and causes Content Store to also return a 410 status.

Due to the vagueries of Whitehall 'unpublishing' we need a way to unpublish but still render an explanation and optional alternative url. This can't be done with a 410 route in the router.

We need to address this properly but for now this change should allow the item to be rendered correctly and fix the issues we have in production.