### PR TITLE
Consider `gone` items with no explanation/alternative_url as 'gone'

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -127,7 +127,7 @@ class ContentItem
     #content store or register a gone route. This is a fix until we implement an
     #alternative type of unpublishing through the stack as it is causing issues
     #in production
-    self.schema_name == "gone" && self.details.empty?
+    schema_name == "gone" && details_is_empty?
   end
 
   # Return a Hash of link types to lists of related items
@@ -174,5 +174,9 @@ private
 
   def authorised_user_uids
     access_limited['users']
+  end
+
+  def details_is_empty?
+    details.nil? || details.values.reject(&:blank?).empty?
   end
 end

--- a/spec/factories/content_item.rb
+++ b/spec/factories/content_item.rb
@@ -51,6 +51,17 @@ FactoryGirl.define do
       }
     end
 
+    factory :gone_content_time_with_empty_details_fields do
+      sequence(:base_path) { |n| "/more-gone-than-the-other-gone-#{n}" }
+      format "gone"
+      details {
+        {
+          explanation: "",
+          alternative_path: ""
+        }
+      }
+    end
+
     factory :access_limited_content_item, parent: :content_item do
       sequence(:base_path) { |n| "/access-limited-#{n}" }
       access_limited {

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -592,14 +592,19 @@ describe ContentItem, type: :model do
   end
 
   describe "gone?" do
-    it "returns true for schema_name 'gone' with empty details" do
+    it "returns true for schema_name 'gone' with no details" do
       gone_item = build(:gone_content_item)
       expect(gone_item.gone?).to be(true)
     end
 
-    it "returns true for schema_name 'gone' with empty details" do
+    it "returns false for schema_name 'gone' with details" do
       gone_item = build(:gone_content_item_with_details)
       expect(gone_item.gone?).to be(false)
+    end
+
+    it "returns true for schema_name 'gone' with empty details fields" do
+      gone_item = build(:gone_content_time_with_empty_details_fields)
+      expect(gone_item.gone?).to be(true)
     end
   end
 end


### PR DESCRIPTION
A previous PR added a check for the absence of the `details` field on a `gone` content item and used that to determine whether to consider the item actually 'gone' (return 410) or gone with content (and return 200).

This PR adds further logic to that to check that there is a `details` field and that there are values within it. If there are no values we return 410 even if there are keys but they are empty.

\cc: @tuzz 