### PR TITLE
Fix a test in the fetching linked items spec

### DIFF
--- a/spec/integration/fetching_linked_items_spec.rb
+++ b/spec/integration/fetching_linked_items_spec.rb
@@ -1,46 +1,47 @@
 require 'rails_helper'
+include ActiveSupport::Testing::TimeHelpers
 
 describe "Fetching linked items", type: :request do
   describe "GET /incoming-links/:base_path_without_root" do
     it "returns the items linked to an item" do
-      Timecop.freeze do
-        item = create(:content_item, :with_content_id, document_type: "travel_advice")
-        create(:content_item, content_id: 'ID-1', base_path: '/a', title: "A", links: { "parent" => [item.content_id] })
-        create(:content_item, content_id: 'ID-2', base_path: '/b', title: "B", links: { "parent" => [item.content_id] })
+      item = create(:content_item, :with_content_id, document_type: "travel_advice")
+      id_1 = create(:content_item, content_id: 'ID-1', base_path: '/a', title: "A", links: { "parent" => [item.content_id] })
+      id_1.reload
+      id_2 = create(:content_item, content_id: 'ID-2', base_path: '/b', title: "B", links: { "parent" => [item.content_id] })
+      id_2.reload
 
-        get "/incoming-links#{item.base_path}?types[]=parent&types[]=topics"
+      get "/incoming-links#{item.base_path}?types[]=parent&types[]=topics"
 
-        expect(parsed_response["parent"]).to eql([
-          {
-            "content_id" => "ID-1",
-            "title" => "A",
-            "base_path" => "/a",
-            "description" => nil,
-            "api_url" => "http://www.example.com/content/a",
-            "web_url" => "https://www.test.gov.uk/a",
-            "locale" => "en",
-            "public_updated_at" => Time.now.as_json,
-            "schema_name" => "answer",
-            "document_type" => "answer",
-            "links" => { "parent" => [item.content_id] },
-          },
-          {
-            "content_id" => "ID-2",
-            "title" => "B",
-            "base_path" => "/b",
-            "description" => nil,
-            "api_url" => "http://www.example.com/content/b",
-            "web_url" => "https://www.test.gov.uk/b",
-            "locale" => "en",
-            "public_updated_at" => Time.now.as_json,
-            "schema_name" => "answer",
-            "document_type" => "answer",
-            "links" => { "parent" => [item.content_id] },
-          },
-        ])
+      expect(parsed_response["parent"]).to eql([
+        {
+          "content_id" => "ID-1",
+          "title" => "A",
+          "base_path" => "/a",
+          "description" => nil,
+          "api_url" => "http://www.example.com/content/a",
+          "web_url" => "https://www.test.gov.uk/a",
+          "locale" => "en",
+          "public_updated_at" => id_1.public_updated_at.as_json,
+          "schema_name" => "answer",
+          "document_type" => "answer",
+          "links" => { "parent" => [item.content_id] },
+        },
+        {
+          "content_id" => "ID-2",
+          "title" => "B",
+          "base_path" => "/b",
+          "description" => nil,
+          "api_url" => "http://www.example.com/content/b",
+          "web_url" => "https://www.test.gov.uk/b",
+          "locale" => "en",
+          "public_updated_at" => id_2.public_updated_at.as_json,
+          "schema_name" => "answer",
+          "document_type" => "answer",
+          "links" => { "parent" => [item.content_id] },
+        },
+      ])
 
-        expect(parsed_response["topics"]).to eql([])
-      end
+      expect(parsed_response["topics"]).to eql([])
     end
   end
 


### PR DESCRIPTION
Initially it appeared that my local timezone was leaking in to the test,
and causing the public_updated_at values to differ by an hour in the
actual and expected response. I tried quite a few different ways of
resolving this, and some worked, but led to the times sometimes being a
millisecond apart.

Changing to using travel_to (instead of Timecop) and comparing against
the values from the created objects was the only way I could get the
test to pass reliably.

I was expecting that just comparing against the values on the objects
would resolve any issues, but, the rendering of the time differed. I
think the value of public_updated_at used to construct the request body
in the presenter may come directly from the factory, but in the test,
the value comes from the database, which is leading to a disparity.