### PR TITLE
Log Publishing-Source-Dependent-Content-Id header

### DIFF
--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -4,5 +4,6 @@ if Object.const_defined?('LogStasher') && LogStasher.enabled
     fields[:request] = "#{request.request_method} #{request.fullpath} #{request.headers['SERVER_PROTOCOL']}"
     # Pass request Id to logging
     fields[:govuk_request_id] = request.headers['GOVUK-Request-Id']
+    fields[:dependency_resolution_source_content_id] = request.headers['GOVUK-Dependency-Resolution-Source-Content-Id']
   end
 end


### PR DESCRIPTION
The presence of a value for this can be used to distinguish requests
that are a product of dependency resolution in the Publishing API, and
those that are not.

The value indicates the content id of the source of the dependency
resolution activity.