### PR TITLE
Plek based link urls

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -43,6 +43,6 @@ private
   attr_reader :item, :api_url_method
 
   def links
-    item.expanded_links
+    ExpandedLinksPresenter.new(item.expanded_links).present
   end
 end

--- a/app/presenters/expanded_links_presenter.rb
+++ b/app/presenters/expanded_links_presenter.rb
@@ -1,0 +1,37 @@
+class ExpandedLinksPresenter
+  attr_reader :expanded_links
+
+  def initialize(expanded_links)
+    @expanded_links = expanded_links
+  end
+
+  def present
+    expanded_links.each_with_object({}) do |(type, links), memo|
+      links = Array.wrap(links)
+      memo[type] = links.map do |link|
+        link.dup.merge(
+          api_path: api_path(link),
+          api_url: api_url(link),
+          web_url: web_url(link),
+          links: link[:links].present? ? self.class.new(link[:links]).present : {}
+        )
+      end
+    end
+  end
+
+private
+
+  def api_path(link)
+    return link[:api_path] if link[:api_path]
+    "/api/content" + link[:base_path] if link[:base_path]
+  end
+
+  def api_url(link)
+    api_path = api_path(link)
+    Plek.current.website_root + api_path if api_path
+  end
+
+  def web_url(link)
+    Plek.current.website_root + link[:base_path] if link[:base_path]
+  end
+end


### PR DESCRIPTION
We have a problem that due to data syncing the values of `web_url` and `api_url` in the expanded links of a content item reference the production environment. This causes problems for links in the staging and integration environment.

The ideal way forward is for rendering applications to no longer use urls and instead use the absolute paths of base_path and api_path, therefore we plan to deprecate these fields from the content store.

In the meantime though this dynamically sets web_url and api_url based off Plek to be relevant to the environment the content store is running within.