### PR TITLE
Remove force_http when registering a backend

### DIFF
--- a/app/models/route_set.rb
+++ b/app/models/route_set.rb
@@ -84,7 +84,7 @@ class RouteSet < OpenStruct
 private
 
   def register_rendering_app
-    Rails.application.router_api.add_backend(rendering_app, Plek.find(rendering_app, force_http: true) + "/")
+    Rails.application.router_api.add_backend(rendering_app, Plek.find(rendering_app) + "/")
   end
 
   def register_redirect(route)

--- a/spec/support/router_helpers.rb
+++ b/spec/support/router_helpers.rb
@@ -6,7 +6,7 @@ module RouterHelpers
   def assert_routes_registered(rendering_app, routes)
     # Note: WebMock stubs allow you to assert against already executed requests.
 
-    be_signature = stub_router_backend_registration(rendering_app, "http://#{rendering_app}.test.gov.uk/")
+    be_signature = stub_router_backend_registration(rendering_app, "https://#{rendering_app}.test.gov.uk/")
     assert_requested(be_signature, times: 1)
 
     routes.each do |(path, type)|


### PR DESCRIPTION
@jennyd pointed this out last week - I think this exists from a time when the router couldn't handle HTTPS backends. It can now because we do HTTPS to Trade Tariff and Licensing.

https://github.com/alphagov/router/commit/7e72e8b073bedb05866a0bd68e76ffdac2af7f1e

This will cause new registrations to use the HTTPS backend which will encrypt traffic in our network.