### PR TITLE
Keep the govuk prefix when using logstasher

### DIFF
--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -4,6 +4,6 @@ if Object.const_defined?('LogStasher') && LogStasher.enabled
     fields[:request] = "#{request.request_method} #{request.fullpath} #{request.headers['SERVER_PROTOCOL']}"
     # Pass request Id to logging
     fields[:govuk_request_id] = request.headers['GOVUK-Request-Id']
-    fields[:dependency_resolution_source_content_id] = request.headers['GOVUK-Dependency-Resolution-Source-Content-Id']
+    fields[:govuk_dependency_resolution_source_content_id] = request.headers['GOVUK-Dependency-Resolution-Source-Content-Id']
   end
 end


### PR DESCRIPTION
This comes from the discussion regarding the
GOVUK-Dependency-Resolution-Source-Content-Id header at the Publishing
API Cross Team Architecture Chat meeting, in which it was mentioned that
keeping the GOV.UK specific data prefixed would be helpful when using
Kibana.