### PR TITLE
Don't expose `format`

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -12,7 +12,6 @@ class ContentItemPresenter
     content_id
     document_type
     first_published_at
-    format
     locale
     need_ids
     phase

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -40,7 +40,6 @@ describe "Fetching content items", type: :request do
         content_id
         title
         description
-        format
         schema_name
         document_type
         need_ids
@@ -62,7 +61,6 @@ describe "Fetching content items", type: :request do
         "content_id" => content_item.content_id,
         "title" => "VAT rates",
         "description" => "Current VAT rates",
-        "format" => "publication",
         "schema_name" => "publication",
         "document_type" => "travel_advice",
         "need_ids" => ["100136"],


### PR DESCRIPTION
This stops content store from exposing `format` to users. This attribute is deprecated in favour of `schema_name` and `document_type`.

Removing the attribute from the database is out of scope for this PR.

https://github.com/alphagov/govuk-content-schemas/pull/444 removes the attribute from the frontend schemas.

https://trello.com/c/C8A9bnuO

cc @danielroseman is this sensible?
