### PR TITLE
Add a little bit of schema validation for output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ else
   gem 'gds-api-adapters', '36.0.1'
 end
 
-gem 'govuk-content-schema-test-helpers', '1.3.0'
+gem 'govuk-content-schema-test-helpers', '~> 1.4'
 gem 'uuidtools', '2.1.5'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
       rest-client (~> 2.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
-    govuk-content-schema-test-helpers (1.3.0)
+    govuk-content-schema-test-helpers (1.4.0)
       json-schema (~> 2.5.1)
     govuk-lint (0.6.1)
       rubocop (~> 0.35.0)
@@ -91,8 +91,8 @@ GEM
       domain_name (~> 0.5)
     i18n (0.7.0)
     json (2.0.2)
-    json-schema (2.5.1)
-      addressable (~> 2.3.7)
+    json-schema (2.5.2)
+      addressable (~> 2.3.8)
     kgio (2.9.2)
     link_header (0.0.8)
     logstash-event (1.1.5)
@@ -290,7 +290,7 @@ DEPENDENCIES
   database_cleaner (~> 1.5.3)
   factory_girl (~> 4.4.0)
   gds-api-adapters (= 36.0.1)
-  govuk-content-schema-test-helpers (= 1.3.0)
+  govuk-content-schema-test-helpers (~> 1.4)
   govuk-lint
   hashdiff
   logstasher (= 0.5.0)

--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+export REPO_NAME="alphagov/govuk-content-schemas"
+export CONTEXT_MESSAGE="Verify content-store against content schemas"
+
+exec ./jenkins.sh

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -11,5 +11,14 @@ bundle exec govuk-lint-ruby \
   --format clang \
   app config Gemfile lib script spec
 
+# Clone govuk-content-schemas depedency for contract tests
+rm -rf /tmp/govuk-content-schemas
+git clone git@github.com:alphagov/govuk-content-schemas.git /tmp/govuk-content-schemas
+(
+ cd /tmp/govuk-content-schemas
+ git checkout ${SCHEMA_GIT_COMMIT:-"deployed-to-production"}
+)
+export GOVUK_CONTENT_SCHEMAS_PATH=/tmp/govuk-content-schemas
+
 bundle exec rake db:mongoid:drop
 COVERAGE=on bundle exec rake ci:setup:rspec default

--- a/spec/factories/content_item.rb
+++ b/spec/factories/content_item.rb
@@ -10,6 +10,7 @@ FactoryGirl.define do
     routes { [{ 'path' => base_path, 'type' => 'exact' }] }
     transmitted_at "1"
     payload_version 0
+    first_published_at { Time.now }
 
     trait :with_content_id do
       content_id { SecureRandom.uuid }

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -59,4 +59,12 @@ describe ContentItemPresenter do
       expect(presenter.as_json["details"]).to eq(body: "<p>content</p>")
     end
   end
+
+  it "validates against the schema" do
+    content_item = create(:content_item, :with_content_id, schema_name: "generic")
+
+    presented = ContentItemPresenter.new(content_item, api_url_method).as_json
+
+    expect(presented.to_json).to be_valid_against_schema("generic")
+  end
 end

--- a/spec/support/schema_testing.rb
+++ b/spec/support/schema_testing.rb
@@ -1,0 +1,9 @@
+require 'govuk-content-schema-test-helpers'
+
+GovukContentSchemaTestHelpers.configure do |config|
+  config.schema_type = 'frontend'
+  config.project_root = Rails.root
+end
+
+require 'govuk-content-schema-test-helpers/rspec_matchers'
+RSpec.configuration.include GovukContentSchemaTestHelpers::RSpecMatchers


### PR DESCRIPTION
This adds a test that the output of `ContentItemPresenter` is valid against the `generic` schema. This will ensure that the schemas and this app will be kept in sync.

https://trello.com/c/C8A9bnuO