### PR TITLE
Revert "Don't expose `format`"

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -12,6 +12,7 @@ class ContentItemPresenter
     content_id
     document_type
     first_published_at
+    format
     locale
     need_ids
     phase

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -40,6 +40,7 @@ describe "Fetching content items", type: :request do
         content_id
         title
         description
+        format
         schema_name
         document_type
         need_ids
@@ -61,6 +62,7 @@ describe "Fetching content items", type: :request do
         "content_id" => content_item.content_id,
         "title" => "VAT rates",
         "description" => "Current VAT rates",
+        "format" => "publication",
         "schema_name" => "publication",
         "document_type" => "travel_advice",
         "need_ids" => ["100136"],


### PR DESCRIPTION
Reverts alphagov/content-store#250.

There are some errors on multipage-frontend related to this. We'll solve those before proceeding with this.