### PR TITLE
Remove sorting results during verification task

### DIFF
--- a/lib/tasks/check_content_items_against_schema.rake
+++ b/lib/tasks/check_content_items_against_schema.rake
@@ -26,7 +26,7 @@ task :check_content_items_against_schema, [:format_names] => :environment do |_t
   invalid_content_items = []
 
   puts "Validating #{validatable_content_items.count} content items"
-  validatable_content_items.order_by([:format, :asc], [:_id, :asc]).each do |content_item|
+  validatable_content_items.each do |content_item|
     presenter = ContentItemPresenter.new(content_item, api_url_callable)
     validator = GovukContentSchemaTestHelpers::Validator.new(content_item.format, presenter.to_json)
     if validator.valid?


### PR DESCRIPTION
There's too many resuts to continue sorting them.

This commit aims to solve the following error message:

> Mongo::Error::OperationFailure: too much data for sort() with no index.
add an index or specify a smaller limit (10128)