### PR TITLE
Remove special case for pact version

### DIFF
--- a/lib/tasks/pact.rake
+++ b/lib/tasks/pact.rake
@@ -22,7 +22,7 @@ unless Rails.env.production?
   task "pact:verify:branch", [:branch_name] do |t, args|
     abort "Please provide a branch name. eg rake #{t.name}[my_feature_branch]" unless args[:branch_name]
 
-    pact_version = args[:branch_name] == "master" ? args[:branch_name] : "branch-#{args[:branch_name]}"
+    pact_version = "branch-#{args[:branch_name]}"
 
     require 'pact/tasks/task_helper'
 


### PR DESCRIPTION
This has been changed in the Publishing API in b29dc4d1 and this is the
coresponding change in the content-store where the pact with the
Publishing API is verified.