### PR TITLE
Allow fact check access via header

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -60,11 +60,15 @@ private
     request.headers['Govuk-Fact-Check-Id']
   end
 
+  def invalid_user_id?
+    authenticated_user_uid == 'invalid'
+  end
+
   def can_view(item)
     if fact_check_id_header.present?
       item.fact_checkable_with?(fact_check_id_header)
     else
-      item.viewable_by?(authenticated_user_uid)
+      !invalid_user_id? && item.viewable_by?(authenticated_user_uid)
     end
   end
 

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -16,7 +16,7 @@ class ContentItemsController < ApplicationController
       ContentItem, base_path: encoded_base_path
     ) unless item
 
-    if item.viewable_by?(authenticated_user_uid)
+    if can_view(item)
       render json: ContentItemPresenter.new(item, api_url_method), status: http_status(item)
     else
       render json_forbidden_response
@@ -56,6 +56,18 @@ private
     request.headers['X-Govuk-Authenticated-User']
   end
 
+  def fact_check_id_header
+    request.headers['Govuk-Fact-Check-Id']
+  end
+
+  def can_view(item)
+    if fact_check_id_header.present?
+      item.fact_checkable_with?(fact_check_id_header)
+    else
+      item.viewable_by?(authenticated_user_uid)
+    end
+  end
+
   def json_forbidden_response
     {
       json: {
@@ -75,7 +87,7 @@ private
 
     if intent && !intent.past?
       cache_time = (intent.publish_time.to_i - Time.zone.now.to_i)
-    elsif item && item.access_limited?
+    elsif item && (fact_check_id_header.present? || item.access_limited?)
       cache_time = config.minimum_ttl
       is_public = false
     elsif item && max_cache_time(item)

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -120,6 +120,10 @@ class ContentItem
     !access_limited? || authorised_user_uids.include?(user_uid)
   end
 
+  def fact_checkable_with?(fact_check_id)
+    fact_check_ids.include?(fact_check_id)
+  end
+
   def register_routes(previous_item: nil)
     return if self.schema_name.start_with?("placeholder")
     return if previous_item && previous_item.route_set == self.route_set
@@ -142,6 +146,10 @@ private
 
   def authorised_user_uids
     access_limited['users']
+  end
+
+  def fact_check_ids
+    access_limited.fetch('fact_check_ids', [])
   end
 
   def details_is_empty?

--- a/spec/factories/content_item.rb
+++ b/spec/factories/content_item.rb
@@ -66,7 +66,10 @@ FactoryGirl.define do
     factory :access_limited_content_item, parent: :content_item do
       sequence(:base_path) { |n| "/access-limited-#{n}" }
       access_limited {
-        { "users" => ["M6GdNZggrbGiJrLjMSbKqA", "f17250b0-7540-0131-f036-005056030202"] }
+        {
+          "users" => ["M6GdNZggrbGiJrLjMSbKqA", "f17250b0-7540-0131-f036-005056030202"],
+          "fact_check_ids" => ["85aa9fd5-c514-4964-b931-5b597e4ec668"]
+        }
       }
     end
   end

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -117,7 +117,6 @@ describe "Fetching content items", type: :request do
     end
   end
 
-
   context "a content item with a non-ASCII base_path" do
     let(:content_item) { create(:content_item, base_path: URI.encode('/news/בוט לאינד')) }
 
@@ -133,6 +132,18 @@ describe "Fetching content items", type: :request do
     end
   end
 
+  context "when the authenticated_user_uid header is invalid" do
+    let(:content_item) { create(:content_item) }
+
+    before do
+      get "/content/#{content_item.base_path}", params: {},
+        headers: { 'X-Govuk-Authenticated-User' => "invalid" }
+    end
+
+    it "returns a 403 Forbidden response" do
+      expect(response.status).to eq(403)
+    end
+  end
 
   context "a non-existent content item" do
     before(:each) { get "/content/does/not/exist" }


### PR DESCRIPTION
If a valid JWT token is passed to authenticating-proxy it will extract
the value to the Govuk-Fact-Check-Id header, which is passed downstream
by gds-api-adapters.

This change then checks that the header value matches a value in the
fact_check_id array within the access_limited hash of the item being
requested and returns it if so, otherwise sends a 403.

Note that the presence of the header means the user has bypassed
normal authentication, so we need to verify that they've specifically
requested the item with that fact_check_id, and not fall through to
the auth check.

As with a normal access-limited item, we send a cache-control: private
header when the request contains the content-id header.