### PR TITLE
Add a script to check for content consistency with router-api

### DIFF
--- a/app/models/content_consistency_checker.rb
+++ b/app/models/content_consistency_checker.rb
@@ -1,0 +1,106 @@
+require 'gds_api/router'
+
+class ContentConsistencyChecker
+  attr_reader :base_path
+
+  def initialize(base_path)
+    @base_path = base_path
+    @errors = []
+  end
+
+  def call
+    return @errors unless content_item
+
+    redirects.each do |redirect|
+      check_redirect(redirect)
+    end
+
+    routes.each do |route|
+      check_route(route)
+    end
+
+    @errors
+  end
+
+private
+
+  def get_route(path)
+    begin
+      res = JSON.parse(router_api.get_route(path).raw_response_body)
+    rescue GdsApi::HTTPNotFound
+      @errors << "Path (#{path}) was not found!"
+      nil
+    end
+  end
+
+  def check_redirect(redirect)
+    path = redirect[:path]
+
+    res = get_route(path)
+    return unless res
+
+    if res["handler"] != "redirect"
+      @errors << "router-api: Handler is not a redirect for #{path}."
+    end
+
+    if res["redirect_to"] != redirect[:destination]
+      @errors << "router-api: Route destination (#{res['redirect_to']}) " \
+                 "does not match item destination " \
+                 "(#{redirect['destination']})."
+    end
+  end
+
+  def check_route(route)
+    path = route[:path]
+
+    res = get_route(path)
+    return unless res
+
+    if res["handler"] != expected_handler
+      @errors << "Handler (#{res['handler']}) does not match expected item " \
+                 "handler (#{expected_handler})."
+    end
+
+    if res["backend_id"] != rendering_app
+      @errors << "Backend ID (#{res['backend_id']}) does not match item " \
+                 "rendering app (#{rendering_app})."
+    end
+
+    if res["disabled"]
+      @errors << "Route is marked as disabled."
+    end
+  end
+
+  def content_item
+    @content_item ||= ContentItem.find_by!(base_path: base_path)
+  rescue Mongoid::Errors::DocumentNotFound
+    @errors << "Content (#{base_path}) could not be found."
+    @content_item ||= nil
+  end
+
+  def expected_handler
+    if content_item.gone?
+      "gone"
+    elsif content_item.redirect?
+      "redirect"
+    else
+      "backend"
+    end
+  end
+
+  def routes
+    content_item.routes
+  end
+
+  def redirects
+    content_item.redirects
+  end
+
+  def rendering_app
+    content_item.rendering_app
+  end
+
+  def router_api
+    Rails.application.router_api
+  end
+end

--- a/app/models/content_consistency_checker.rb
+++ b/app/models/content_consistency_checker.rb
@@ -26,7 +26,7 @@ private
 
   def get_route(path)
     begin
-      res = JSON.parse(router_api.get_route(path).raw_response_body)
+      JSON.parse(router_api.get_route(path).raw_response_body)
     rescue GdsApi::HTTPNotFound
       @errors << "Path (#{path}) was not found!"
       nil
@@ -66,9 +66,7 @@ private
                  "rendering app (#{rendering_app})."
     end
 
-    if res["disabled"]
-      @errors << "Route is marked as disabled."
-    end
+    @errors << "Route is marked as disabled." if res["disabled"]
   end
 
   def content_item

--- a/lib/tasks/check_content_consistency.rake
+++ b/lib/tasks/check_content_consistency.rake
@@ -1,0 +1,28 @@
+namespace :check_content_consistency do
+  def check_content(base_path)
+    checker = ContentConsistencyChecker.new(base_path)
+    errors = checker.call
+
+    if errors.any?
+      puts "#{base_path} 😱"
+      puts errors
+    end
+
+    errors.none?
+  end
+
+  desc "Check items for consistency with the router-api"
+  task :one, [:base_path] => [:environment] do |_, args|
+    base_path = args[:base_path]
+    check_content(base_path)
+  end
+
+  desc "Check all the items for consistency with the router-api"
+  task all: :environment do
+    items = ContentItem.pluck(:base_path)
+    successes, failures = items.partition do |base_path|
+      check_content(base_path)
+    end
+    puts "Results: #{failures.count} failures out of #{docs.count}."
+  end
+end

--- a/lib/tasks/check_content_consistency.rake
+++ b/lib/tasks/check_content_consistency.rake
@@ -20,7 +20,7 @@ namespace :check_content_consistency do
   desc "Check all the items for consistency with the router-api"
   task all: :environment do
     items = ContentItem.pluck(:base_path)
-    successes, failures = items.partition do |base_path|
+    _, failures = items.partition do |base_path|
       check_content(base_path)
     end
     puts "Results: #{failures.count} failures out of #{docs.count}."

--- a/lib/tasks/check_content_consistency.rake
+++ b/lib/tasks/check_content_consistency.rake
@@ -20,7 +20,7 @@ namespace :check_content_consistency do
   desc "Check all the items for consistency with the router-api"
   task all: :environment do
     items = ContentItem.pluck(:base_path)
-    _, failures = items.partition do |base_path|
+    failures = items.reject do |base_path|
       check_content(base_path)
     end
     puts "Results: #{failures.count} failures out of #{docs.count}."

--- a/spec/models/content_consistency_checker_spec.rb
+++ b/spec/models/content_consistency_checker_spec.rb
@@ -1,0 +1,148 @@
+require "rails_helper"
+
+RSpec.describe ContentConsistencyChecker do
+  describe "#call" do
+    describe "unknown content" do
+      subject { described_class.new("/does-not-exist").call }
+
+      it "should have errors" do
+        expect(subject).not_to be_empty
+      end
+    end
+
+    describe "valid content" do
+      let(:content_item) { FactoryGirl.create(:content_item) }
+
+      subject { described_class.new(content_item.base_path).call }
+
+      it "should not have errors" do
+        stub_router(content_item.base_path)
+        expect(subject).to be_empty
+      end
+    end
+
+    context "has redirects" do
+      let(:content_item) { FactoryGirl.create(:redirect_content_item) }
+
+      subject { described_class.new(content_item.base_path).call }
+
+      context "router API does not have an entry for the item" do
+        before { stub_router(content_item.base_path, {}, 404) }
+
+        it "should produce an error" do
+          expect(subject.first).to match(/not found/)
+        end
+      end
+
+      context "router API handler is not marked as a redirect" do
+        before { stub_router(content_item.base_path) }
+
+        it "should produce an error" do
+          expect(subject.first).to match(/Handler is not a redirect for/)
+        end
+      end
+
+      context "router API redirect destination does not match" do
+        before do
+          stub_router(
+            content_item.base_path,
+            handler: "redirect",
+            redirect_to: "/somewhere-else",
+          )
+        end
+
+        it "should produce an error" do
+          expect(subject.first).to match(/does not match item destination/)
+        end
+      end
+    end
+
+    context "has routes" do
+      let(:content_item) { FactoryGirl.create(:content_item) }
+
+      subject { described_class.new(content_item.base_path).call }
+
+      context "router API does not have an entry for the item" do
+        before do
+          stub_router(content_item.base_path, {}, 404)
+        end
+
+        it "should produce an error" do
+          expect(subject.first).to match(/not found/)
+        end
+      end
+
+      context "router API does not have an entry for the item" do
+        before do
+          stub_router(content_item.base_path, backend_id: "falafel")
+        end
+
+        it "should produce an error" do
+          expect(subject.first).to match(/does not match item rendering app/)
+        end
+      end
+
+      context "router API has item marked as disabled" do
+        before do
+          stub_router(content_item.base_path, disabled: true)
+        end
+
+        it "should produce an error" do
+          expect(subject.first).to match(/is marked as disabled/)
+        end
+      end
+
+      context "router API has a different handler" do
+        before do
+          stub_router(
+            content_item.base_path,
+            handler: "redirect",
+            incoming_path: content_item.base_path,
+          )
+        end
+
+        it "should produce an error" do
+          expect(subject.first).to match(/does not match expected item handler/)
+        end
+      end
+
+      context "router API has a different handler for a gone item" do
+        let(:content_item) { FactoryGirl.create(:gone_content_item) }
+        before do
+          stub_router(
+            content_item.base_path,
+            handler: "backend",
+            incoming_path: content_item.base_path,
+          )
+        end
+
+        it "should produce an error" do
+          expect(subject.first).to match(/does not match expected item handler/)
+        end
+      end
+    end
+  end
+end
+
+def router_api_url
+  Plek.find('router-api')
+end
+
+def default_router_body
+  {
+    backend_id: "frontend",
+    disabled: false,
+    handler: "backend",
+    route_type: "exact",
+  }
+end
+
+def stub_router(path = "/test-redirect", body_args = {}, status = 200)
+  body = default_router_body.merge(incoming_path: path).merge(body_args)
+  stub_request(:get, "#{router_api_url}/routes?incoming_path=#{path}").
+  and_return(
+    status: status,
+    body: body.to_json,
+    headers: { "Content-Type": "application/json" }
+  )
+end

--- a/spec/models/content_consistency_checker_spec.rb
+++ b/spec/models/content_consistency_checker_spec.rb
@@ -140,9 +140,9 @@ end
 def stub_router(path = "/test-redirect", body_args = {}, status = 200)
   body = default_router_body.merge(incoming_path: path).merge(body_args)
   stub_request(:get, "#{router_api_url}/routes?incoming_path=#{path}").
-  and_return(
-    status: status,
-    body: body.to_json,
-    headers: { "Content-Type": "application/json" }
-  )
+    and_return(
+      status: status,
+      body: body.to_json,
+      headers: { "Content-Type": "application/json" }
+    )
 end


### PR DESCRIPTION
This PR adds a script to check for content consistency across the `content-store` and `router-api`.

See alphagov/publishing-api#742 for the equivalent script in the `publishing-api`.