### PR TITLE
Allow authorised users to view fact-check limited content

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -117,7 +117,7 @@ class ContentItem
   end
 
   def viewable_by?(user_uid)
-    !access_limited? || authorised_user_uids.include?(user_uid)
+    authorised_user_uids.empty? || authorised_user_uids.include?(user_uid)
   end
 
   def fact_checkable_with?(fact_check_id)
@@ -145,7 +145,7 @@ protected
 private
 
   def authorised_user_uids
-    access_limited['users']
+    access_limited.fetch('users', [])
   end
 
   def fact_check_ids

--- a/spec/factories/content_item.rb
+++ b/spec/factories/content_item.rb
@@ -65,12 +65,22 @@ FactoryGirl.define do
 
     factory :access_limited_content_item, parent: :content_item do
       sequence(:base_path) { |n| "/access-limited-#{n}" }
-      access_limited {
-        {
-          "users" => ["M6GdNZggrbGiJrLjMSbKqA", "f17250b0-7540-0131-f036-005056030202"],
-          "fact_check_ids" => ["85aa9fd5-c514-4964-b931-5b597e4ec668"]
+
+      trait :by_user_id do
+        access_limited {
+          {
+            "users" => ["M6GdNZggrbGiJrLjMSbKqA", "f17250b0-7540-0131-f036-005056030202"],
+          }
         }
-      }
+      end
+
+      trait :by_fact_check_id do
+        access_limited {
+          {
+            "fact_check_ids" => ["85aa9fd5-c514-4964-b931-5b597e4ec668"]
+          }
+        }
+      end
     end
   end
 end

--- a/spec/integration/access_limited_spec.rb
+++ b/spec/integration/access_limited_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-describe "Fetching an access-limited content item", type: :request do
-  let(:access_limited_content_item) { create(:access_limited_content_item) }
+describe "Fetching an access-limited by user-id content item", type: :request do
+  let(:access_limited_content_item) { create(:access_limited_content_item, :by_user_id) }
   let(:authorised_user_uid) { access_limited_content_item.access_limited['users'].first }
 
   context "request without an authentication header" do
@@ -49,7 +49,9 @@ describe "Fetching an access-limited content item", type: :request do
   end
 
   context "with a fact check ID specified in the header" do
+    let(:access_limited_content_item) { create(:access_limited_content_item, :by_fact_check_id) }
     let(:fact_check_id) { access_limited_content_item.access_limited["fact_check_ids"].first }
+
     before do
       get "/content/#{access_limited_content_item.base_path}",
         params: {}, headers: { 'Govuk-Fact-Check-Id' => fact_check_id }

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -192,8 +192,8 @@ describe ContentItem, type: :model do
       end
     end
 
-    context 'an access-limited content item' do
-      let!(:content_item) { create(:access_limited_content_item) }
+    context 'an access-limited by user-id content item' do
+      let!(:content_item) { create(:access_limited_content_item, :by_user_id) }
       let(:authorised_user_uid) { content_item.access_limited['users'].first }
 
       it 'is access limited' do
@@ -207,6 +207,28 @@ describe ContentItem, type: :model do
       it 'is not viewable by an unauthorised user' do
         expect(content_item.viewable_by?('unauthorised-user')).to be(false)
         expect(content_item.viewable_by?(nil)).to be(false)
+      end
+    end
+
+    context "an access-limited by fact_check_id content item" do
+      let!(:content_item) { create(:access_limited_content_item, :by_fact_check_id) }
+      let(:fact_check_id) { content_item.access_limited['fact_check_ids'].first }
+      let(:logged_in_user) { 'authenticated_user_uid' }
+
+      it "is access limited" do
+        expect(content_item.access_limited?).to be(true)
+      end
+
+      it "is fact_checkable_with a valid fact_check_id" do
+        expect(content_item.fact_checkable_with?(fact_check_id)).to be(true)
+      end
+
+      it "is not fact_checkable_with an invalid fact check token" do
+        expect(content_item.fact_checkable_with?("foo")).to be(false)
+      end
+
+      it 'is viewable by an authenticated user' do
+        expect(content_item.viewable_by?(logged_in_user)).to be(true)
       end
     end
   end


### PR DESCRIPTION
Fixes an edge case around the viewing of fact-check access-limited
content items. Authenticated users were prevented from viewing
documents when a fact-check-id was set in the access-limited hash.