### PR TITLE
Extend the gone but not gone hack

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -116,6 +116,20 @@ class ContentItem
     schema_name == "gone" && details_is_empty?
   end
 
+  def router_rendering_app
+    # This is an extension of the hack in `gone?` method.
+    #
+    # For items that are registered in the content store which are not redirects
+    # or gones we need to have a rendering_app. This is fine for all but the
+    # "gone but not gone" exception defined in `gone?` where rendering_app is
+    # not part of the schema for a gone but it required to register the route.
+    #
+    # This rather nastily fallsback to whitehall frontend for gones that are
+    # not gone and lack a rendering_app
+    return rendering_app if schema_name != "gone" || gone?
+    rendering_app || "whitehall-frontend"
+  end
+
   def viewable_by?(user_uid)
     authorised_user_uids.empty? || authorised_user_uids.include?(user_uid)
   end

--- a/app/models/route_set.rb
+++ b/app/models/route_set.rb
@@ -34,7 +34,7 @@ class RouteSet < OpenStruct
       gone_routes: gone_routes,
       redirects: redirects,
       base_path: item.base_path,
-      rendering_app: item.rendering_app,
+      rendering_app: item.router_rendering_app,
       is_redirect: item.redirect?,
       is_gone: item.gone?,
     )


### PR DESCRIPTION
Yeah... this kinda sucks. Sorry.

In the previous hack to get `gone` working with a rendering application
due to the presence of details there is a problem that the rendering_app
isn't included.

This is a fix for this by implicitly setting this value to
"whitehall-frontend" when we have a gone and a lack of rendering_app.

The alternative approach to this would be to allow the gone schema to
include a rendering_app value and send the rendering_app as part of the
PublishingAPI GonePresenter. This however felt even more wrong than this
hack as we'd have to either do:

a) Include rendering_app in all gone content items even though all
except whitehall-frontend would not be rendered by the app we are
providing (they are handled by the router)

or

b) only include rendering_app for whitehall-frontend and thus duplicate
this whitehall specific knowledge into the PublishingAPI

This therefore is just a stop gap until what should happen with these is
actually worked out.