### PR TITLE
Configurable log path

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,8 @@ module ContentStore
     config.default_ttl = ENV.fetch('DEFAULT_TTL', 30.minutes).to_i.seconds
     config.minimum_ttl = [config.default_ttl, 5.seconds].min
 
+    config.paths["log"] = ENV["LOG_PATH"] if ENV["LOG_PATH"]
+
     def router_api
       @router_api ||= GdsApi::Router.new(Plek.current.find('router-api'))
     end


### PR DESCRIPTION
This makes it relatively easy to have a differently name draft log file for
when two instances of this app are running in docker containers.