### PR TITLE
Always register routes, even if the route set is unchanged

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -14,7 +14,7 @@ class ContentItem
     item.assign_attributes(attributes)
 
     if item.upsert
-      item.register_routes(previous_item: previous_item)
+      item.register_routes
     else
       result = false
     end
@@ -138,7 +138,7 @@ class ContentItem
     fact_check_ids.include?(fact_check_id)
   end
 
-  def register_routes(previous_item: nil)
+  def register_routes
     return if self.schema_name.start_with?("placeholder")
     self.route_set.register!
   end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -140,7 +140,6 @@ class ContentItem
 
   def register_routes(previous_item: nil)
     return if self.schema_name.start_with?("placeholder")
-    return if previous_item && previous_item.route_set == self.route_set
     self.route_set.register!
   end
 

--- a/spec/integration/submitting_content_item_spec.rb
+++ b/spec/integration/submitting_content_item_spec.rb
@@ -136,12 +136,7 @@ describe "content item write API", type: :request do
       expect(@item.details).to eq("body" => "<p>Some body text</p>\n")
     end
 
-    it "does not register routes when they haven't changed" do
-      put_json "/content/vat-rates", @data
-      refute_routes_registered("frontend", [['/vat-rates', 'exact']])
-    end
-
-    it "registers routes for the content item when they have changed" do
+    it "registers routes for the content item" do
       @data["routes"] << { "path" => "/vat-rates.json", "type" => 'exact' }
       put_json "/content/vat-rates", @data
       assert_routes_registered("frontend", [['/vat-rates', 'exact'], ['/vat-rates.json', 'exact']])

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -118,53 +118,6 @@ describe ContentItem, type: :model do
         ['/a-path/subpath', 'prefix']
       ])
     end
-
-    context "with a previous item" do
-      before :each do
-        # dup the routes so they can be modified without affecting @item
-        previous_routes = @routes.map(&:dup)
-        @previous_item = build(:content_item, base_path: '/a-path', rendering_app: 'an-app', routes: previous_routes)
-      end
-
-      it 'does not register the routes when they are unchanged' do
-        @item.register_routes(previous_item: @previous_item)
-        refute_routes_registered('an-app', [
-          ['/a-path', 'exact'],
-          ['/a-path.json', 'exact'],
-          ['/a-path/subpath', 'prefix']
-        ])
-      end
-
-      it 'registers routes when the routes are different' do
-        @previous_item.routes[1]['type'] = 'prefix'
-        @item.register_routes(previous_item: @previous_item)
-        assert_routes_registered('an-app', [
-          ['/a-path', 'exact'],
-          ['/a-path.json', 'exact'],
-          ['/a-path/subpath', 'prefix']
-        ])
-      end
-
-      it 'registers routes when the redirects are different' do
-        @previous_item.redirects << { 'path' => '/a-path/old-part', 'type' => 'exact', 'destination' => '/somewhere' }
-        @item.register_routes(previous_item: @previous_item)
-        assert_routes_registered('an-app', [
-          ['/a-path', 'exact'],
-          ['/a-path.json', 'exact'],
-          ['/a-path/subpath', 'prefix']
-        ])
-      end
-
-      it 'registers routes when the rendering_app is different' do
-        @previous_item.rendering_app = 'another-app'
-        @item.register_routes(previous_item: @previous_item)
-        assert_routes_registered('an-app', [
-          ['/a-path', 'exact'],
-          ['/a-path.json', 'exact'],
-          ['/a-path/subpath', 'prefix']
-        ])
-      end
-    end
   end
 
   context 'when loaded from the content store' do

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -73,6 +73,8 @@ Pact.provider_states_for "Publishing API" do
 
   provider_state "a content item exists with base_path /vat-rates and payload_version 0" do
     set_up do
+      stub_request(:any, Regexp.new(Plek.find("router-api")))
+
       FactoryGirl.create(:content_item, base_path: "/vat-rates", payload_version: 0)
     end
   end


### PR DESCRIPTION
Conditionally registering the routes could lead to routes not being
registered entirely for some content. Consider the following scenario:

 - Start with an empty content store
 - update request made
 - No previous item
 - Item saved to the database
 - Route registration fails
 - Content Store returns error status to client

 - update request retried by client
 - previous_item exists
 - route registration skips, as route_set matches that of the previous
   item
 - Content Store returns success status to client

Even though the 2nd request is "successful", the routes have not been
registered. This can also happen if the item exists in the content
store, but the update has different routes.

Always registering the route seems preferable, as the code is simpler
compared to manually rolling back the creation or update of the local
database, however implementing rollback manually in the code would be
a possible alternative, and this change will result in some additional
redundant requests to the router-api.

[Trello](https://trello.com/c/un4CpSs4/670-figure-out-why-check-tenant-right-to-rent-documents-and-postgraduate-loan-are-not-previewable)