### PR TITLE
Add support for supertypes to content item

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -46,8 +46,8 @@ class ContentItem
   field :description, type: Hash, default: { "value" => nil }
   field :format, type: String
   field :document_type, type: String
-  field :navigation_document_supertype, type: String
-  field :user_journey_document_supertype, type: String
+  field :navigation_document_supertype, type: String, default: ''
+  field :user_journey_document_supertype, type: String, default: ''
   field :schema_name, type: String
   field :locale, type: String, default: I18n.default_locale.to_s
   field :need_ids, type: Array, default: []

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -46,6 +46,8 @@ class ContentItem
   field :description, type: Hash, default: { "value" => nil }
   field :format, type: String
   field :document_type, type: String
+  field :navigation_document_supertype, type: String
+  field :user_journey_document_supertype, type: String
   field :schema_name, type: String
   field :locale, type: String, default: I18n.default_locale.to_s
   field :need_ids, type: Array, default: []

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -14,6 +14,7 @@ class ContentItemPresenter
     first_published_at
     format
     locale
+    navigation_document_supertype
     need_ids
     phase
     public_updated_at
@@ -22,6 +23,7 @@ class ContentItemPresenter
     schema_name
     title
     updated_at
+    user_journey_document_supertype
     withdrawn_notice
   ).freeze
 

--- a/spec/integration/end_to_end_spec.rb
+++ b/spec/integration/end_to_end_spec.rb
@@ -10,6 +10,8 @@ describe "End-to-end behaviour", type: :request do
     "format" => "answer",
     "schema_name" => "answer",
     "document_type" => "travel_advice",
+    "navigation_document_supertype" => "guidance",
+    "user_journey_document_supertype" => "finding",
     "publishing_app" => "publisher",
     "rendering_app" => "frontend",
     "routes" => [

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -43,6 +43,8 @@ describe "Fetching content items", type: :request do
         format
         schema_name
         document_type
+        navigation_document_supertype
+        user_journey_document_supertype
         need_ids
         locale
         analytics_identifier


### PR DESCRIPTION
These were added in https://github.com/alphagov/publishing-api/pull/805.

Somehow our testing system didn't pick up that content store would reject these requests. I'm planning to look into getting that fixed.

https://trello.com/c/07lAcDtC