### PR TITLE
Rename fact_check_ids to auth_bypass_ids

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'hashdiff', require: false
 if ENV['GDS_API_ADAPTERS_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '36.0.1'
+  gem 'gds-api-adapters', "~> 41.0"
 end
 
 gem 'govuk-content-schema-test-helpers', '~> 1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
     factory_girl (4.8.0)
       activesupport (>= 3.0.0)
     find_a_port (1.0.1)
-    gds-api-adapters (36.0.1)
+    gds-api-adapters (41.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -119,7 +119,7 @@ GEM
     multi_json (1.12.1)
     netrc (0.11.0)
     nio4r (1.2.1)
-    nokogiri (1.7.0.1)
+    nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
     null_logger (0.0.1)
     pact (1.10.0)
@@ -142,7 +142,7 @@ GEM
       term-ansicolor (~> 1.0)
       thor
       webrick
-    pact-support (0.6.0)
+    pact-support (0.6.1)
       awesome_print (~> 1.1)
       find_a_port (~> 1.0.1)
       json
@@ -284,7 +284,7 @@ DEPENDENCIES
   ci_reporter_rspec (~> 1.0.0)
   database_cleaner (~> 1.5.3)
   factory_girl (~> 4.4)
-  gds-api-adapters (= 36.0.1)
+  gds-api-adapters (~> 41.0)
   govuk-content-schema-test-helpers (~> 1.4)
   govuk-lint
   hashdiff
@@ -306,4 +306,4 @@ DEPENDENCIES
   whenever (~> 0.9.4)
 
 BUNDLED WITH
-   1.11.2
+   1.14.5

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -146,8 +146,8 @@ class ContentItem
     authorised_user_uids.empty? || authorised_user_uids.include?(user_uid)
   end
 
-  def fact_checkable_with?(fact_check_id)
-    fact_check_ids.include?(fact_check_id)
+  def includes_auth_bypass_id_or_fact_check_id?(auth_bypass_id)
+    auth_bypass_ids_or_fact_check_ids.include?(auth_bypass_id)
   end
 
   def register_routes(previous_item: nil)
@@ -170,6 +170,10 @@ private
 
   def authorised_user_uids
     access_limited.fetch('users', [])
+  end
+
+  def auth_bypass_ids_or_fact_check_ids
+    access_limited.fetch('auth_bypass_ids', fact_check_ids)
   end
 
   def fact_check_ids

--- a/config/initializers/gds_api_adapters.rb
+++ b/config/initializers/gds_api_adapters.rb
@@ -1,3 +1,0 @@
-GdsApi.configure do |config|
-  config.always_raise_for_not_found = true
-end

--- a/lib/tasks/data_hygiene/inconsistent_redirect_finder.rb
+++ b/lib/tasks/data_hygiene/inconsistent_redirect_finder.rb
@@ -14,7 +14,7 @@ class InconsistentRedirectFinder
       rescue GdsApi::HTTPNotFound
         next
       end
-      route && route.handler == "redirect"
+      route && route["handler"] == "redirect"
     end
   end
 end

--- a/spec/factories/content_item.rb
+++ b/spec/factories/content_item.rb
@@ -74,10 +74,10 @@ FactoryGirl.define do
         }
       end
 
-      trait :by_fact_check_id do
+      trait :by_auth_bypass_id do
         access_limited {
           {
-            "fact_check_ids" => ["85aa9fd5-c514-4964-b931-5b597e4ec668"]
+            "auth_bypass_ids" => ["85aa9fd5-c514-4964-b931-5b597e4ec668"]
           }
         }
       end

--- a/spec/integration/access_limited_spec.rb
+++ b/spec/integration/access_limited_spec.rb
@@ -48,20 +48,20 @@ describe "Fetching an access-limited by user-id content item", type: :request do
     end
   end
 
-  context "with a fact check ID specified in the header" do
-    let(:access_limited_content_item) { create(:access_limited_content_item, :by_fact_check_id) }
-    let(:fact_check_id) { access_limited_content_item.access_limited["fact_check_ids"].first }
+  context "with a auth bypass ID specified in the header" do
+    let(:access_limited_content_item) { create(:access_limited_content_item, :by_auth_bypass_id) }
+    let(:auth_bypass_id) { access_limited_content_item.access_limited["auth_bypass_ids"].first }
 
     before do
       get "/content/#{access_limited_content_item.base_path}",
-        params: {}, headers: { 'Govuk-Fact-Check-Id' => fact_check_id }
+        params: {}, headers: { 'Govuk-Auth-Bypass-Id' => auth_bypass_id }
     end
 
     it "marks the cache-control as private" do
       expect(cache_control["private"]).to eq(true)
     end
 
-    context "if the fact check ID matches" do
+    context "if the auth bypass ID matches" do
       it "returns the requested item" do
         expect(response.status).to eq(200)
         expect(response.content_type).to eq("application/json")
@@ -71,8 +71,8 @@ describe "Fetching an access-limited by user-id content item", type: :request do
       end
     end
 
-    context "if the fact check ID does not match" do
-      let(:fact_check_id) { SecureRandom.uuid }
+    context "if the auth bypass ID does not match" do
+      let(:auth_bypass_id) { SecureRandom.uuid }
       it "returns a 403 Forbidden response" do
         json = JSON.parse(response.body)
 

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -215,21 +215,21 @@ describe ContentItem, type: :model do
       end
     end
 
-    context "an access-limited by fact_check_id content item" do
-      let!(:content_item) { create(:access_limited_content_item, :by_fact_check_id) }
-      let(:fact_check_id) { content_item.access_limited['fact_check_ids'].first }
+    context "an access-limited by auth_bypass_id content item" do
+      let!(:content_item) { create(:access_limited_content_item, :by_auth_bypass_id) }
+      let(:auth_bypass_id) { content_item.access_limited['auth_bypass_ids'].first }
       let(:logged_in_user) { 'authenticated_user_uid' }
 
       it "is access limited" do
         expect(content_item.access_limited?).to be(true)
       end
 
-      it "is fact_checkable_with a valid fact_check_id" do
-        expect(content_item.fact_checkable_with?(fact_check_id)).to be(true)
+      it "includes a valid auth_bypass_id" do
+        expect(content_item.includes_auth_bypass_id_or_fact_check_id?(auth_bypass_id)).to be(true)
       end
 
-      it "is not fact_checkable_with an invalid fact check token" do
-        expect(content_item.fact_checkable_with?("foo")).to be(false)
+      it "does not include a valid auth bypass token when the id is invalid" do
+        expect(content_item.includes_auth_bypass_id_or_fact_check_id?("foo")).to be(false)
       end
 
       it 'is viewable by an authenticated user' do


### PR DESCRIPTION
Content needs to be previewable by users without signon accounts in most stages of a publishers workflow, not just during fact check.

https://trello.com/c/7oRBYwnn/690-rename-fact-check-id-to-auth-bypass-id