### PR TITLE
Add "email" and "government" supertypes

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -50,6 +50,8 @@ class ContentItem
   field :description, type: Hash, default: { "value" => nil }
   field :format, type: String
   field :document_type, type: String
+  field :email_document_supertype, type: String, default: ''
+  field :government_document_supertype, type: String, default: ''
   field :navigation_document_supertype, type: String, default: ''
   field :user_journey_document_supertype, type: String, default: ''
   field :schema_name, type: String

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -11,8 +11,10 @@ class ContentItemPresenter
     base_path
     content_id
     document_type
+    email_document_supertype
     first_published_at
     format
+    government_document_supertype
     locale
     navigation_document_supertype
     need_ids

--- a/spec/integration/end_to_end_spec.rb
+++ b/spec/integration/end_to_end_spec.rb
@@ -10,6 +10,8 @@ describe "End-to-end behaviour", type: :request do
     "format" => "answer",
     "schema_name" => "answer",
     "document_type" => "travel_advice",
+    "email_document_supertype" => "publications",
+    "government_document_supertype" => "new-stories",
     "navigation_document_supertype" => "guidance",
     "user_journey_document_supertype" => "finding",
     "publishing_app" => "publisher",

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -43,6 +43,8 @@ describe "Fetching content items", type: :request do
         format
         schema_name
         document_type
+        email_document_supertype
+        government_document_supertype
         navigation_document_supertype
         user_journey_document_supertype
         need_ids


### PR DESCRIPTION
These are required to enabled the migration of email
subscriptions to email_alert_api.