### PR TITLE
Send an Airbrake error when inconsistent content items are found

### DIFF
--- a/app/models/content_consistency_checker.rb
+++ b/app/models/content_consistency_checker.rb
@@ -1,15 +1,18 @@
 require 'gds_api/router'
 
 class ContentConsistencyChecker
-  attr_reader :base_path
+  attr_reader :base_path, :ignore_recent
 
-  def initialize(base_path)
+  def initialize(base_path, ignore_recent = false)
     @base_path = base_path
+    @ignore_recent = ignore_recent
     @errors = []
   end
 
   def call
     return @errors unless content_item
+
+    return @errors if ignore_recent && content_item.updated_at < 1.day.ago
 
     redirects.each do |redirect|
       check_redirect(redirect)

--- a/lib/tasks/check_content_consistency.rake
+++ b/lib/tasks/check_content_consistency.rake
@@ -1,6 +1,6 @@
 namespace :check_content_consistency do
-  def check_content(base_path)
-    checker = ContentConsistencyChecker.new(base_path)
+  def check_content(base_path, ignore_recent = false)
+    checker = ContentConsistencyChecker.new(base_path, ignore_recent)
     errors = checker.call
 
     if errors.any?
@@ -18,11 +18,14 @@ namespace :check_content_consistency do
   end
 
   desc "Check all the items for consistency with the router-api"
-  task all: :environment do
+  task :all, [:ignore_recent] => [:environment] do |_, args|
     items = ContentItem.pluck(:base_path)
     failures = items.reject do |base_path|
-      check_content(base_path)
+      check_content(
+        base_path,
+        args.fetch(:ignore_recent, false) == "true"
+      )
     end
-    puts "Results: #{failures.count} failures out of #{docs.count}."
+    puts "Results: #{failures.count} failures out of #{items.count}."
   end
 end

--- a/lib/tasks/check_content_consistency.rake
+++ b/lib/tasks/check_content_consistency.rake
@@ -4,8 +4,13 @@ namespace :check_content_consistency do
     errors = checker.call
 
     if errors.any?
-      puts "#{base_path} 😱"
-      puts errors
+      Airbrake.notify(
+        "Found an inconsistent content item: #{base_path} 😱",
+        parameters: {
+          base_path: base_path,
+          errors: errors,
+        }
+      )
     end
 
     errors.none?


### PR DESCRIPTION
This will allow the task to run automatically and send us an alert when inconsistent documents are found.
