### PR TITLE
Delete fact_check_ids

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -57,8 +57,8 @@ private
   end
 
   def can_view(item)
-    if id_header.present?
-      item.includes_auth_bypass_id_or_fact_check_id?(id_header)
+    if auth_bypass_id_header.present?
+      item.includes_auth_bypass_id?(auth_bypass_id_header)
     else
       !invalid_user_id? && item.viewable_by?(authenticated_user_uid)
     end
@@ -70,14 +70,6 @@ private
 
   def auth_bypass_id_header
     request.headers['Govuk-Auth-Bypass-Id']
-  end
-
-  def fact_check_id_header
-    request.headers['Govuk-Fact-Check-Id']
-  end
-
-  def id_header
-    @_id_header ||= auth_bypass_id_header || fact_check_id_header
   end
 
   def invalid_user_id?
@@ -103,7 +95,7 @@ private
 
     if intent && !intent.past?
       cache_time = (intent.publish_time.to_i - Time.zone.now.to_i)
-    elsif item && (id_header.present? || item.access_limited?)
+    elsif item && (auth_bypass_id_header.present? || item.access_limited?)
       cache_time = config.minimum_ttl
       is_public = false
     elsif item && max_cache_time(item)

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -146,8 +146,8 @@ class ContentItem
     authorised_user_uids.empty? || authorised_user_uids.include?(user_uid)
   end
 
-  def includes_auth_bypass_id_or_fact_check_id?(auth_bypass_id)
-    auth_bypass_ids_or_fact_check_ids.include?(auth_bypass_id)
+  def includes_auth_bypass_id?(auth_bypass_id)
+    auth_bypass_ids.include?(auth_bypass_id)
   end
 
   def register_routes(previous_item: nil)
@@ -172,12 +172,8 @@ private
     access_limited.fetch('users', [])
   end
 
-  def auth_bypass_ids_or_fact_check_ids
-    access_limited.fetch('auth_bypass_ids', fact_check_ids)
-  end
-
-  def fact_check_ids
-    access_limited.fetch('fact_check_ids', [])
+  def auth_bypass_ids
+    access_limited.fetch('auth_bypass_ids', [])
   end
 
   def details_is_empty?

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -225,11 +225,11 @@ describe ContentItem, type: :model do
       end
 
       it "includes a valid auth_bypass_id" do
-        expect(content_item.includes_auth_bypass_id_or_fact_check_id?(auth_bypass_id)).to be(true)
+        expect(content_item.includes_auth_bypass_id?(auth_bypass_id)).to be(true)
       end
 
       it "does not include a valid auth bypass token when the id is invalid" do
-        expect(content_item.includes_auth_bypass_id_or_fact_check_id?("foo")).to be(false)
+        expect(content_item.includes_auth_bypass_id?("foo")).to be(false)
       end
 
       it 'is viewable by an authenticated user' do


### PR DESCRIPTION
Fact_check_ids have now been replaced by auth_bypass_ids.

[DO NOT MERGE] Do not merge until https://github.com/alphagov/content-store/pull/271 and associated PRs have been deployed.

https://trello.com/c/7oRBYwnn/690-rename-fact-check-id-to-auth-bypass-id