### PR TITLE
Move "secret" unicorn config into application

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,0 +1,6 @@
+def load_file_if_exists(config, file)
+  config.instance_eval(File.read(file)) if File.exist?(file)
+end
+load_file_if_exists(self, "/etc/govuk/unicorn.rb")
+
+worker_processes 6


### PR DESCRIPTION
This was deployed as a secret, but doesn’t contain any credentials.
Moving it into the application itself allows us to remove app-specific
config from `alphagov-deployment`