### PR TITLE
Remove Land Registry Corporate Information Page

### DIFF
--- a/db/migrate/20170328121315_remove_land_registry.rb
+++ b/db/migrate/20170328121315_remove_land_registry.rb
@@ -1,0 +1,10 @@
+class RemoveLandRegistry < Mongoid::Migration
+  def self.up
+    content_items = ContentItem.where(content_id: "5fe3c59c-7631-11e4-a3cb-005056011aef")
+    content_items.destroy_all
+  end
+
+  def self.down
+    raise "non-reversible migration"
+  end
+end


### PR DESCRIPTION
Adds a migration to remove Land Registry Corporate Information Page.
There are two content ids associated with the same base path, so these are both removed. When Whitehall republishes the document, it should push everything through correctly.

Corresponding PRs in 

* Publishing Api: https://github.com/alphagov/publishing-api/pull/869
* Whitehall: https://github.com/alphagov/whitehall/pull/3145