### PR TITLE
Switch from CGI.escape to ERB url_encode

### DIFF
--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -11,14 +11,18 @@ Pact.configure do |config|
   config.include WebMock::Matchers
 end
 
+def url_encode(str)
+  ERB::Util.url_encode(str)
+end
+
 Pact.service_provider "Content Store" do
   honours_pact_with "Publishing API" do
     if ENV['USE_LOCAL_PACT']
       pact_uri ENV.fetch('PUBLISHING_API_PACT_PATH', '../publishing-api/spec/pacts/publishing_api-content_store.json')
     else
       base_url = ENV.fetch("PACT_BROKER_BASE_URL", "https://pact-broker.cloudapps.digital")
-      url = "#{base_url}/pacts/provider/#{CGI.escape(name)}/consumer/#{CGI.escape(consumer_name)}"
-      version_part = ENV['PUBLISHING_API_PACT_VERSION'] ? "versions/#{CGI.escape(ENV['PUBLISHING_API_PACT_VERSION'])}" : 'latest'
+      url = "#{base_url}/pacts/provider/#{url_encode(name)}/consumer/#{url_encode(consumer_name)}"
+      version_part = ENV['PUBLISHING_API_PACT_VERSION'] ? "versions/#{url_encode(ENV['PUBLISHING_API_PACT_VERSION'])}" : 'latest'
 
       pact_uri "#{url}/#{version_part}"
     end


### PR DESCRIPTION
The switch from URI.escape to CGI.escape had the unfortunate side effect
that the URLs broke when they had spaces in them as CGI.escape uses the
"+" encoding of query strings rather than the %20 used in paths. To get
this we have to use a different method and the ERB::Util.url_encode
seems to be the best option in std lib.

It worked this tiem, promise: https://ci.integration.publishing.service.gov.uk/job/publishing-api/job/docs%252Ffix-pact-testing/8/console