### PR TITLE
Add register_backends rake task

### DIFF
--- a/lib/tasks/register_backends.rake
+++ b/lib/tasks/register_backends.rake
@@ -1,0 +1,11 @@
+desc "
+  Register backends with the router-api for all rendering apps in the
+  database.
+"
+task register_backends: :environment do
+  ContentItem.distinct(:rendering_app).compact.each do |rendering_app|
+    backend = "#{Plek.find(rendering_app)}/"
+    puts "Adding backend #{backend} for #{rendering_app}"
+    Rails.application.router_api.add_backend(rendering_app, backend)
+  end
+end


### PR DESCRIPTION
This provides a convinient way to set backends in the Router API, for
all the content in the Content Store.

This can be useful for a few reasons:
 - You have changed the configuration of the
content store with respect to the backends it generates, and want to
update the Router API.
 - The data in the Router API doesn't match, as you have loaded the
database from another a deployment of these applications with
different configuration.