### PR TITLE
Switch to using present? to add a nil check

### DIFF
--- a/lib/route_consistency_checker.rb
+++ b/lib/route_consistency_checker.rb
@@ -131,7 +131,7 @@ private
   end
 
   def should_check_backend_id(route)
-    route.handler == "backend" || !route.backend_id.empty?
+    route.handler == "backend" || route.backend_id.present?
   end
 
   def expected_handler(content_item)


### PR DESCRIPTION
Previously when 'route.backend_id' was nil, it was raising a NoMethodError.

[Trello card](https://trello.com/c/0uqM1YHL/899-create-alert-for-new-inconsistent-documents-3)