### PR TITLE
Reliably register routes

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -2,6 +2,11 @@ class ContentItem
   include Mongoid::Document
   include Mongoid::Timestamps::Updated
 
+  def self.revert(previous_item:, item:)
+    item.remove unless previous_item
+    previous_item&.upsert
+  end
+
   def self.create_or_replace(base_path, attributes)
     previous_item = ContentItem.where(base_path: base_path).first
     lock = UpdateLock.new(previous_item)
@@ -15,7 +20,14 @@ class ContentItem
     item.assign_attributes(attributes)
 
     if item.upsert
-      item.register_routes(previous_item: previous_item)
+      begin
+        item.register_routes(previous_item: previous_item)
+      rescue => e
+        revert(previous_item: previous_item, item: item)
+        raise unless e.is_a?(GdsApi::BaseError)
+        item.errors.add(:routes, "Could not communicated with router.")
+        result = false
+      end
     else
       result = false
     end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -152,8 +152,7 @@ class ContentItem
   end
 
   def register_routes(previous_item: nil)
-    return if self.schema_name.start_with?("placeholder")
-    return if previous_item && previous_item.route_set == self.route_set
+    return unless should_register_routes?(previous_item: previous_item)
     self.route_set.register!
   end
 
@@ -168,6 +167,12 @@ protected
   end
 
 private
+
+  def should_register_routes?(previous_item: nil)
+    return false if self.schema_name.start_with?("placeholder")
+    return false if previous_item && previous_item.route_set == self.route_set
+    true
+  end
 
   def authorised_user_uids
     access_limited.fetch('users', [])

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -153,7 +153,14 @@ class ContentItem
 
   def register_routes(previous_item: nil)
     return unless should_register_routes?(previous_item: previous_item)
-    self.route_set.register!
+
+    tries = Rails.application.config.register_router_retries
+    begin
+      route_set.register!
+    rescue GdsApi::BaseError
+      tries -= 1
+      tries.positive? ? retry : raise
+    end
   end
 
   def base_path_without_root

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,6 +38,8 @@ module ContentStore
 
     config.paths["log"] = ENV["LOG_PATH"] if ENV["LOG_PATH"]
 
+    config.register_router_retries = 3
+
     def router_api
       @router_api ||= GdsApi::Router.new(Plek.current.find('router-api'))
     end


### PR DESCRIPTION
Register routes more reliably by trying multiple times and rolling back the content item if it eventually fails.

[Trello Card](https://trello.com/c/1M8bgdQ0/928-ensure-the-content-store-reliably-updates-the-router-api-3)