### PR TITLE
Store the GOVUK-Request-ID header in the content item

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -81,6 +81,7 @@ class ContentItem
   field :analytics_identifier, type: String
   field :payload_version, type: Integer
   field :withdrawn_notice, type: Hash, default: {}
+  field :publishing_request_id, type: String, default: nil
 
   # The updated_at field isn't set on upsert - https://jira.mongodb.org/browse/MONGOID-3716
   before_upsert :set_updated_at

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -27,6 +27,7 @@ class ContentItemPresenter
     updated_at
     user_journey_document_supertype
     withdrawn_notice
+    publishing_request_id
   ).freeze
 
   def initialize(item, api_url_method)

--- a/spec/factories/content_item.rb
+++ b/spec/factories/content_item.rb
@@ -10,6 +10,7 @@ FactoryGirl.define do
     routes { [{ 'path' => base_path, 'type' => 'exact' }] }
     payload_version 0
     first_published_at { Time.now }
+    publishing_request_id { "432.432523.233242" }
 
     trait :with_content_id do
       content_id { SecureRandom.uuid }

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -59,6 +59,7 @@ describe "Fetching content items", type: :request do
         details
         links
         withdrawn_notice
+        publishing_request_id
       ])
 
       expect(data).to include(

--- a/spec/integration/submitting_content_item_spec.rb
+++ b/spec/integration/submitting_content_item_spec.rb
@@ -23,6 +23,7 @@ describe "content item write API", type: :request do
       "routes" => [
         { "path" => "/vat-rates", "type" => 'exact' }
       ],
+      "publishing_request_id" => "test test test",
     }
   end
 
@@ -45,6 +46,7 @@ describe "content item write API", type: :request do
       expect(item.public_updated_at).to match_datetime("2014-05-14T13:00:06Z")
       expect(item.updated_at).to be_within(10.seconds).of(Time.zone.now)
       expect(item.details).to eq("body" => "<p>Some body text</p>\n")
+      expect(item.publishing_request_id).to eq("test test test")
     end
 
     it "responds with an empty JSON document in the body" do


### PR DESCRIPTION
This will be sent by the Publishing API.

[Trello Card](https://trello.com/c/JZ5Zabe9/702-remove-publishing-request-id-from-travel-advice-publisher-details-hash-2)