### PR TITLE
Don't expose `format`

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -13,7 +13,6 @@ class ContentItemPresenter
     document_type
     email_document_supertype
     first_published_at
-    format
     government_document_supertype
     locale
     navigation_document_supertype

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -40,7 +40,6 @@ describe "Fetching content items", type: :request do
         content_id
         title
         description
-        format
         schema_name
         document_type
         email_document_supertype
@@ -66,7 +65,6 @@ describe "Fetching content items", type: :request do
         "content_id" => content_item.content_id,
         "title" => "VAT rates",
         "description" => "Current VAT rates",
-        "format" => "publication",
         "schema_name" => "publication",
         "document_type" => "travel_advice",
         "need_ids" => ["100136"],


### PR DESCRIPTION
This attribute is deprecated in favour of `schema_name` and `document_type`.