### PR TITLE
Increase publish intent cache leeway

### DIFF
--- a/app/models/publish_intent.rb
+++ b/app/models/publish_intent.rb
@@ -21,7 +21,7 @@ class PublishIntent
     ::FindByPath.new(self).find(path)
   end
 
-  PUBLISH_TIME_LEEWAY = 1.minute
+  PUBLISH_TIME_LEEWAY = 5.minutes
 
   field :_id, as: :base_path, type: String, overwrite: true
   field :publish_time, type: DateTime

--- a/spec/models/publish_intent_spec.rb
+++ b/spec/models/publish_intent_spec.rb
@@ -114,10 +114,17 @@ describe PublishIntent, type: :model do
       end
     end
 
-    it "is true for an intent in the past" do
-      intent.publish_time = 5.minutes.ago
-      expect(intent.past?).to eq(true)
+    it "is false for an intent within the leeway period" do
+      intent.publish_time = 4.minutes.ago
+      expect(intent.past?).to eq(false)
+    end
 
+    it "is true for an intent past the leeway period" do
+      intent.publish_time = 6.minutes.ago
+      expect(intent.past?).to eq(true)
+    end
+
+    it "is true for an intent in the past" do
       intent.publish_time = 5.months.ago
       expect(intent.past?).to eq(true)
     end


### PR DESCRIPTION
This commit increases the cache leeway for `PublishIntent` to 5 minutes. This has the effect of setting the max-age headers to 0 for content that has a publish intent for responses to requests received for up to 5 minutes after the scheduled publication time.

This change is being made following a perceived delay in the publishing of a statistics publication from Whitehall. Examination of the logs show that the publish request was initially sent from Whitehall within 15 seconds of the scheduled publication time but was held up, probably due
to a backlog of sidekiq jobs in the downstream queue at publishing api, and didn't arrive at content-store until over 2 minutes after the scheduled time. This caused users that tried to access the content during that time to be served the default 30 minute max-age and the publication of the content to appear to have been delayed for 30 minutes. 

This will be part of further mitigating changes that may include creating a higher priority queue for scheduled publishing. 

[Trello](https://trello.com/c/xfIvn3Pv/133-statistics-announced-in-advance-don-t-always-display-on-time)