### PR TITLE
Remove references to the Content API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ The central storage of *published* content on GOV.UK.
 ## Technical documentation
 
 The content store maps public-facing URLs to published items of content,
-represented as JSON data. It will replace [content API][content-api]
-in time.
+represented as JSON data.
 
 Publishing applications add content to the content store via the Publishing API;
 public-facing applications read content from the content store and render them
@@ -34,5 +33,4 @@ Example API requests and corresponding responses can be found in the
 Detailed technical information can be found in the
 [content store documentation](doc/technical-information.md).
 
-[content-api]: https://github.com/alphagov/govuk_content_api
 [pact-broker-docs]: https://pact-broker.cloudapps.digital/pacts/provider/Content%20Store/consumer/Publishing%20API/latest


### PR DESCRIPTION
The [`content_api`](https://github.com/alphagov/govuk_content_api) has
been retired, and all content has been migrated to the
[`content_store`](https://github.com/alphagov/content-store).

Therefore, we can remove all references to the Content API, and rely
solely on the Content Store.

### Trello

https://trello.com/c/TsUsUwD7/153-remove-documentation-on-content-api