### PR TITLE
[Do not merge] Downgrade Airbrake gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,7 @@ gem 'mongoid', '6.1.0'
 gem 'mongoid_rails_migrations', '1.0.1'
 
 gem 'logstasher', '0.5.0'
-gem 'airbrake', '~> 5.4'
-gem 'airbrake-ruby', '1.5'
+gem 'airbrake', github: 'alphagov/airbrake', branch: 'silence-dep-warnings-for-rails-5'
 
 gem 'unicorn', '4.8.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: git://github.com/alphagov/airbrake.git
+  revision: ad9c926a56535c48f95c33824a76e10bc8f91179
+  branch: silence-dep-warnings-for-rails-5
+  specs:
+    airbrake (4.3.8)
+      builder
+      multi_json
+      rails (>= 5.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -40,9 +50,6 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.3.8)
-    airbrake (5.5.0)
-      airbrake-ruby (~> 1.5)
-    airbrake-ruby (1.5.0)
     arel (8.0.0)
     ast (2.3.0)
     awesome_print (1.7.0)
@@ -279,8 +286,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  airbrake (~> 5.4)
-  airbrake-ruby (= 1.5)
+  airbrake!
   ci_reporter_rspec (~> 1.0.0)
   database_cleaner (~> 1.5.3)
   factory_girl (~> 4.4)

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -2,10 +2,10 @@ if ENV['ERRBIT_API_KEY'].present?
   errbit_uri = Plek.find_uri('errbit')
 
   Airbrake.configure do |config|
-    config.project_key = ENV['ERRBIT_API_KEY']
-    config.project_id = 1 # dummy, not used in Errbit
-    config.host = errbit_uri.to_s
-    config.environment = ENV['ERRBIT_ENVIRONMENT_NAME']
+    config.api_key = ENV["ERRBIT_API_KEY"]
+    config.host = errbit_uri.host
+    config.secure = errbit_uri.scheme == "https"
+    config.environment_name = ENV["ERRBIT_ENVIRONMENT_NAME"]
   end
 end
 #


### PR DESCRIPTION
Trello card: https://trello.com/c/wg6F6Gk3

The inconsistent document checker task is no longer sending an error report to Errbit. 
This seems to have started happening when the app was upgraded to Rails 5. As it's known that version 5 of Airbrake is not compatible with Rails 5, the hope is that simply changing the version of Airbrake used to the alphagov fork will fix the problem.