### PR TITLE
Log the delay in scheduled publishing

### DIFF
--- a/spec/integration/submitting_content_item_spec.rb
+++ b/spec/integration/submitting_content_item_spec.rb
@@ -89,6 +89,26 @@ describe "content item write API", type: :request do
         ]
       end
     end
+
+    context "with a publish intent in the past" do
+      before do
+        create(:publish_intent, base_path: @data["base_path"], publish_time: 10.seconds.ago)
+      end
+
+      it "deletes the publish intent" do
+        put_json "/content/vat-rates", @data
+        expect(PublishIntent.count).to eq(0)
+      end
+
+      it "logs the latency from the expected publish time" do
+        allow(Rails.application.statsd).to receive(:timing)
+        expect(Rails.application.statsd).to receive(:timing).with("scheduled_publishing_delay.answer", kind_of(Numeric))
+        expect(Rails.application.statsd).to receive(:timing) do |key, ms|
+          expect(ms).to be_within(1000).of(10000) if key == "scheduled_publishing_delay.answer"
+        end
+        put_json "/content/vat-rates", @data
+      end
+    end
   end
 
   describe "creating a non-English content item" do

--- a/spec/integration/submitting_content_item_spec.rb
+++ b/spec/integration/submitting_content_item_spec.rb
@@ -109,6 +109,23 @@ describe "content item write API", type: :request do
         put_json "/content/vat-rates", @data
       end
     end
+
+    context "with a publish intent in the future" do
+      let!(:publish_intent) do
+        create(:publish_intent, base_path: @data["base_path"], publish_time: 1.hour.from_now)
+      end
+
+      it "doesn't delete the publish intent" do
+        put_json "/content/vat-rates", @data
+        expect(PublishIntent.first).to eq(publish_intent)
+      end
+
+      it "doesn't log the latency from the expected publish time" do
+        allow(Rails.application.statsd).to receive(:timing)
+        expect(Rails.application.statsd).to_not receive(:timing).with("scheduled_publishing_delay.answer", kind_of(Numeric))
+        put_json "/content/vat-rates", @data
+      end
+    end
   end
 
   describe "creating a non-English content item" do


### PR DESCRIPTION
We need data on the time it takes for scheduled publications to reach
the frontend to ensure that we are publishing sufficiently quickly to
meet statuatory requirements.

This PR records the difference between intended publish time and the
actual time that content arrives at content store to statsd.

In order to only log the latency for content submissions that relate to
a PublishIntent, we also delete the PublishIntent if we match one. This
prevents unscheduled submissions later in the day from also recording a
latency. This would give us incorrect data as the latency could be as
long as hours.
