### PR TITLE
Support base_path less content

### DIFF
--- a/app/presenters/expanded_links_presenter.rb
+++ b/app/presenters/expanded_links_presenter.rb
@@ -14,7 +14,7 @@ class ExpandedLinksPresenter
           api_url: api_url(link),
           web_url: web_url(link),
           links: link[:links].present? ? self.class.new(link[:links]).present : {}
-        )
+        ).compact
       end
     end
   end

--- a/spec/presenters/expanded_links_presenter_spec.rb
+++ b/spec/presenters/expanded_links_presenter_spec.rb
@@ -112,6 +112,28 @@ RSpec.describe ExpandedLinksPresenter do
       end
     end
 
+    context "link without base_path" do
+      let(:links) do
+        {
+          link_group: [{}]
+        }
+      end
+
+      let(:expected_links) do
+        {
+          link_group: [
+            {
+              links: {}
+            }
+          ]
+        }
+      end
+
+      it "does not include api_path, api_url or web_url" do
+        is_expected.to match expected_links
+      end
+    end
+
     context "link with children" do
       let(:links) do
         { group: [{ base_path: "/grand-parent", links: parent }] }


### PR DESCRIPTION
Some link types are base_path less e.g. contact, government and world_location. Presenting `null` `api_path`, `web_url` and `api_url` for these formats makes them invalid with the frontend schemas.

This commit removes those fields when their value is null.