### PR TITLE
Use Airbrake.notify_sync instead of Airbrake.notify

### DIFF
--- a/lib/tasks/check_route_consistency.rake
+++ b/lib/tasks/check_route_consistency.rake
@@ -1,7 +1,7 @@
 require "route_consistency_checker"
 
 def report_errors(errors)
-  Airbrake.notify(
+  Airbrake.notify_sync(
     "Inconsistent routes",
     parameters: {
       errors: errors,


### PR DESCRIPTION
When running in a rake task, Airbrake.notify doesn't properly
finish triggering before the rake task ends and therefore the
message never makes it to Airbrake.

[Trello Card](https://trello.com/c/wg6F6Gk3/947-3-investigate-why-the-inconsistent-checker-is-not-working-all-the-time)