### PR TITLE
Log publishing delay for scheduled publishing

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -30,9 +30,10 @@ class ContentItemsController < ApplicationController
     intent = PublishIntent.find_by_path(encoded_base_path)
     if intent.present? && intent.publish_time.past?
       intent.destroy
-      Rails.application.statsd.timing(
-        "scheduled_publishing_delay.#{item.document_type}",
-        ((item.updated_at.to_time - intent.publish_time.to_time) * 1000).to_i
+      ScheduledPublishingLogEntry.create(
+        base_path: item.base_path,
+        document_type: item.document_type,
+        scheduled_publication_time: intent.publish_time
       )
     end
 

--- a/app/models/scheduled_publishing_log_entry.rb
+++ b/app/models/scheduled_publishing_log_entry.rb
@@ -1,0 +1,18 @@
+class ScheduledPublishingLogEntry
+  include Mongoid::Document
+  include Mongoid::Timestamps::Created
+  field :base_path, type: String
+  field :document_type, type: String
+  field :scheduled_publication_time, type: DateTime
+  field :delay_in_milliseconds
+
+  before_save do |document|
+    document.delay_in_milliseconds = set_delay_in_milliseconds
+  end
+
+private
+
+  def set_delay_in_milliseconds
+    ((Time.now - scheduled_publication_time) * 1000.0).to_i
+  end
+end

--- a/spec/models/scheduled_publishing_log_entry_spec.rb
+++ b/spec/models/scheduled_publishing_log_entry_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+describe ScheduledPublishingLogEntry do
+  describe "when created" do
+    it "sets the delay" do
+      publication_time = Time.now
+      allow(Time).to receive(:now)
+        .and_return(publication_time + 20)
+      log_entry = ScheduledPublishingLogEntry.create(
+        base_path: "/booyah",
+        document_type: "stats",
+        scheduled_publication_time: publication_time
+      )
+
+      expect(log_entry.delay_in_milliseconds).to be_within(1).of(20000)
+    end
+  end
+end


### PR DESCRIPTION
We need to understand how long after the time a scheduled publication is due to be published it is visible to users.

We previously tried to record this delay using statsd but the relatively low frequency of data points makes the data collected with that approach difficult to analyse. It also doesn't give us data on specific content items in the event that there is a delay in publishing and we are required to report on it by the publishers.

This PR removes the statsd logging and replaces it with logging to the database via the `ScheduledPublishingLogEntry` object. This should have a minimal effect on performance as the `update` action is relatively low traffic.

[Trello](https://trello.com/c/up4fXkoi/899-time-to-publish-for-scheduled-publishing-needs-to-be-measured)