### PR TITLE
Update publishingE2ETests option name in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,5 +2,5 @@
 
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
-  govuk.buildProject(publishingE2eTests: true)
+  govuk.buildProject(publishingE2ETests: true)
 }


### PR DESCRIPTION
The `publishingE2eTests` option name has changed to `publishingE2ETests` in
Puppet, so we update it here to make it compatible with the change.