### PR TITLE
Add rake task to validate a sample of content

### DIFF
--- a/lib/tasks/validate_content_against_schema.rake
+++ b/lib/tasks/validate_content_against_schema.rake
@@ -1,0 +1,56 @@
+task validate_content_against_schema: :environment do
+  GovukContentSchemaTestHelpers.configure do |config|
+    config.schema_type = 'frontend'
+    config.project_root = Rails.root
+  end
+
+  schema_names = ContentItem.distinct(:schema_name).select(&:present?)
+  puts "Will check #{schema_names}"
+
+  reports = schema_names.map do |schema_name|
+    validate_content_for_schema(schema_name)
+  end
+
+  total_checked = reports.sum { |r| r[:counts][:checked] }
+  total_fail = reports.sum { |r| r[:counts][:fail] }
+  failure_percentage = ((total_fail / total_checked.to_f) * 100).to_i
+
+  Rails.application.statsd.gauge("document_validation.checked", total_checked)
+  Rails.application.statsd.gauge("document_validation.fail", total_fail)
+  Rails.application.statsd.gauge("document_validation.failure_percentage", failure_percentage)
+
+  puts reports.to_yaml
+end
+
+def validate_content_for_schema(schema_name)
+  api_url_callable = lambda { |base_path| "http://api.example.com/content#{base_path}" }
+
+  # content_id ASC makes the sample semi-random
+  items = ContentItem.order(content_id: :asc).where(schema_name: schema_name).limit(10)
+
+  counts = { checked: 0, okay: 0, fail: 0 }
+  errors = []
+
+  items.each do |content_item|
+    print '.'
+
+    counts[:checked] += 1
+
+    begin
+      presenter = ContentItemPresenter.new(content_item, api_url_callable)
+      validator = GovukContentSchemaTestHelpers::Validator.new(content_item.schema_name, "schema", presenter.to_json)
+
+      if validator.valid?
+        counts[:okay] += 1
+      else
+        counts[:fail] += 1
+        errors << [content_item.base_path, validator.errors]
+      end
+    rescue GovukContentSchemaTestHelpers::ImproperlyConfiguredError => e
+      errors << [content_item.base_path, e.message]
+      counts[:fail] += 1
+    end
+  end
+
+  { schema_name: schema_name, counts: counts, errors: errors }
+end


### PR DESCRIPTION
The content-store currently returns a lot of invalid items. Before we start fixing that we need some way to track the number of invalid things.

This commit adds a rake task that is meant to be run periodically. It will take 100 items for each schema and validate those. The result is outputted so that we can see the errors in Jenkins. The overall result is sent to statsd as a gauge. This means we can generate a graph of the (sampled) percentage of content items that are invalid.

Ideally we would check every item in the content-store, but this is prohibitively expensive (it takes about 4 hours). The sample will hopefully give us enough data to start working on improving the state of the data.

https://trello.com/c/FesP8XSc