### PR TITLE
Check 100 content items per schema

### DIFF
--- a/lib/tasks/validate_content_against_schema.rake
+++ b/lib/tasks/validate_content_against_schema.rake
@@ -26,7 +26,7 @@ def validate_content_for_schema(schema_name)
   api_url_callable = lambda { |base_path| "http://api.example.com/content#{base_path}" }
 
   # content_id ASC makes the sample semi-random
-  items = ContentItem.order(content_id: :asc).where(schema_name: schema_name).limit(10)
+  items = ContentItem.order(content_id: :asc).where(schema_name: schema_name).limit(100)
 
   counts = { checked: 0, okay: 0, fail: 0 }
   errors = []


### PR DESCRIPTION
This increases the number of content items that are checked in the sampled test. The current task finishes in 36 seconds, so this will increase the runtime to around 6 minutes, which is fine.

cc @thomasleese 