### PR TITLE
Remove obselete content items index

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'rails', '5.1.1'
 
 gem 'mongoid', '6.1.0'
-gem 'mongoid_rails_migrations', '1.0.1'
+gem "mongoid_rails_migrations", git: "https://github.com/alphagov/mongoid_rails_migrations", branch: "avoid-calling-bundler-require-in-library-code-v1.1.0-plus-mongoid-v5-fix"
 
 gem 'logstasher', '0.5.0'
 gem 'airbrake', '~> 5.4'
@@ -29,7 +29,7 @@ gem 'uuidtools', '2.1.5'
 
 group :development, :test do
   gem 'rspec-rails', '~> 3.0'
-  gem 'database_cleaner', '~> 1.5.3'
+  gem 'database_cleaner', '~> 1.6.1'
   gem 'factory_girl', '~> 4.4'
   gem 'webmock', '2.1.0', require: false
   gem 'timecop', '0.7.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,15 @@
+GIT
+  remote: https://github.com/alphagov/mongoid_rails_migrations
+  revision: 7dc2c19549698f5666d2a91e89a9845480e852c4
+  branch: avoid-calling-bundler-require-in-library-code-v1.1.0-plus-mongoid-v5-fix
+  specs:
+    mongoid_rails_migrations (1.1.0)
+      activesupport (>= 4.2.0)
+      bundler (>= 1.0.0)
+      mongoid (>= 4.0.0)
+      rails (>= 4.2.0)
+      railties (>= 4.2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -59,7 +71,7 @@ GEM
     concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    database_cleaner (1.5.3)
+    database_cleaner (1.6.1)
     diff-lcs (1.3)
     docile (1.1.5)
     domain_name (0.5.20170223)
@@ -111,11 +123,6 @@ GEM
     mongoid (6.1.0)
       activemodel (~> 5.0)
       mongo (>= 2.4.1, < 3.0.0)
-    mongoid_rails_migrations (1.0.1)
-      activesupport (>= 3.2.0)
-      bundler (>= 1.0.0)
-      rails (>= 3.2.0)
-      railties (>= 3.2.0)
     multi_json (1.12.1)
     netrc (0.11.0)
     nio4r (2.0.0)
@@ -282,7 +289,7 @@ DEPENDENCIES
   airbrake (~> 5.4)
   airbrake-ruby (= 1.5)
   ci_reporter_rspec (~> 1.0.0)
-  database_cleaner (~> 1.5.3)
+  database_cleaner (~> 1.6.1)
   factory_girl (~> 4.4)
   gds-api-adapters (~> 41.0)
   govuk-content-schema-test-helpers (~> 1.4)
@@ -290,7 +297,7 @@ DEPENDENCIES
   hashdiff
   logstasher (= 0.5.0)
   mongoid (= 6.1.0)
-  mongoid_rails_migrations (= 1.0.1)
+  mongoid_rails_migrations!
   pact
   plek (~> 1.9)
   pry-byebug

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -86,13 +86,6 @@ class ContentItem
   # The updated_at field isn't set on upsert - https://jira.mongodb.org/browse/MONGOID-3716
   before_upsert :set_updated_at
 
-  # We want to look up related items by their content ID, excluding those that
-  # are redirects; when multiple items exist, we take the most recent one, and
-  # we need its base_path and its title. By indexing all these fields, we can
-  # get hold of these related items purely from the index, without having to go
-  # and fetch the entire document.
-  index(content_id: 1, locale: 1, format: 1, updated_at: -1, title: 1, _id: 1)
-
   # We want to look up content items by whether they match a route and the type
   # of route.
   index("routes.path" => 1, "routes.type" => 1)

--- a/db/migrate/20170822104138_remove_obselete_content_items_index.rb
+++ b/db/migrate/20170822104138_remove_obselete_content_items_index.rb
@@ -1,0 +1,20 @@
+class RemoveObseleteContentItemsIndex < Mongoid::Migration
+  def self.up
+    collection.indexes.drop_one(key)
+  end
+
+  def self.down
+    collection.indexes.create_one(key)
+  end
+
+private
+
+  def self.key
+    { content_id: 1, locale: 1, format: 1, updated_at: -1, title: 1, _id: 1 }
+  end
+
+  def self.collection
+    db = connection.database
+    db.collection(:content_items)
+  end
+end


### PR DESCRIPTION
https://trello.com/c/g4UUDLjs/1009-5-remove-long-content-store-index

Removes the mongodb index `content_id_1_locale_1_format_1_updated_at_-1_title_1__id_1` on the content items collection. The name is too long to allow upgrade to mongodb 2.6 and the index is not required by this app.

It was necessary to upgrade the `mongoid_rails_migrations` gem in order to get around the removal of the `alias_method_chain` method in Rails 5. The maintainers haven't yet accepted a fix for this so we're using the same branch as detailed in [this commit](https://github.com/alphagov/manuals-publisher/commit/598f6692a0e805dbc0625a5bf4329a298c728d42).