### PR TITLE
Add a content tag to the API endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13,6 +13,8 @@ paths:
     get:
       summary: Access a content item by path
       description: The primary means to access content that is hosted on GOV.UK.
+      tags:
+        - Content
       responses:
         200:
           description: A content item is available at that path.


### PR DESCRIPTION
This means it will grouped under that name instead of 'Default'.

[Trello Card](https://trello.com/c/zO3C0fqR/1053-2-look-into-how-we-can-present-the-reference-documentation-clearer)