### PR TITLE
Improve explanations for openapi.yml

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -81,6 +81,7 @@ components:
         - email_document_supertype
         - first_published_at
         - government_document_supertype
+        - links
         - navigation_document_supertype
         - need_ids
         - phase
@@ -89,7 +90,6 @@ components:
         - schema_name
         - updated_at
         - user_journey_document_supertype
-        - links
       properties:
         analytics_identifier:
           type: integer
@@ -101,6 +101,12 @@ components:
           type: string
           format: uuid
           description: A UUID which represents the public identifier for a piece of content, combined with locale this makes the unique identifier for an individual piece of content. Can be null for redirects / gone content.
+        description:
+          type: string
+          description: A description of the content which can then be displayed publically.
+        details:
+          type: object
+          description: An object representing data that is structured in a format defined by the schema of the edition. This holds the content for the edition, often in a field called body. Can be null for items without content - eg a redirect.
         document_type:
           type: string
           description: A particular type of document, used to differentiate between documents that are of different types but share the same schema.
@@ -114,6 +120,13 @@ components:
         government_document_supertype:
           type: string
           description: Grouping for email subscriptions.
+        links:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              $ref: '#/components/schemas/LinkedContentItem'
+          description: An object that has collections of [LinkedContentItems](#linkedcontentitem) objects in arrays, which are grouped by a link type.
         locale:
           type: string
           description: The language the document is written in. A fixed list of locales is allowed.
@@ -136,6 +149,9 @@ components:
         publishing_app:
           type: string
           description: The application which published the edition.
+        publishing_request_id:
+          type: string
+          description: The GOV.UK Request ID which was used when the content item was published.
         rendering_app:
           type: string
           description: The application which will be used to render the content of the edition.
@@ -155,22 +171,6 @@ components:
         withdrawn_notice:
           $ref: '#/components/schemas/WithdrawnNotice'
           description: If the edition is withdrawn, this will contain the information about when and why it was withdrawn.
-        publishing_request_id:
-          type: string
-          description: The GOV.UK Request ID which was used when the content item was published.
-        links:
-          type: object
-          additionalProperties:
-            type: array
-            items:
-              $ref: '#/components/schemas/LinkedContentItem'
-          description: An object that has collections of [LinkedContentItems](#linkedcontentitem) objects in arrays, which are grouped by a link type.
-        description:
-          type: string
-          description: A description of the content which can then be displayed publically.
-        details:
-          type: object
-          description: An object representing data that is structured in a format defined by the schema of the edition. This holds the content for the edition, often in a field called body. Can be null for items without content - eg a redirect.
       example:
         $ref: '#/components/examples/ContentItemExample'
 
@@ -219,6 +219,13 @@ components:
         document_type:
           type: string
           description: A particular type of document, used to differentiate between documents that are of different types but share the same schema.
+        links:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              $ref: '#/components/schemas/LinkedContentItem'
+          description: An object that has collections of [LinkedContentItems](#linkedcontentitem) objects in arrays, which are grouped by a link type.
         locale:
           type: string
           description: The language the document is written in. A fixed list of locales is allowed.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -264,7 +264,7 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/LinkedContentItem'
-          description: An object containing all the GOV.UK documents that this document links to organised by the link names
+          description: An object that has collections of [LinkedContentItems](#linkedcontentitem) objects in arrays, which are grouped by a link type.
         description:
           type: string
           description: A description of the content which can then be displayed publically.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -69,106 +69,6 @@ paths:
 
 components:
   schemas:
-    WithdrawnNotice:
-      description: |
-        Contains information about why and when a ContentItem was withdrawn.
-      type: object
-      required:
-        - explanation
-        - withdrawn_at
-      properties:
-        explanation:
-          type: string
-          description: An explanation as to why the content was withdrawn.
-        withdrawn_at:
-          type: string
-          format: date-time
-          description: The date when the content was withdrawn.
-      example:
-        explanation: ! '<div class="govspeak"><p>This guidance has been withdrawn from use
-    because the Environment Agency no longer provides best practice guidance. See
-    guidance on <a href="https://www.gov.uk/guidance/prevent-the-spread-of-harmful-invasive-and-non-native-plants">preventing
-    harmful weeds and invasive non-native plants spreading weeds</a> for information
-    on controlling specific plants.</p>
-
-    </div>'
-        withdrawn_at: '2016-07-11T15:08:02Z'
-
-    LinkedContentItem:
-      description: |
-        ContentItems are related to one another via `links`.
-        LinkedContentItems contain the data necessary to describe and render a link to a GOV.UK content item.
-      type: object
-      required:
-        - analytics_identifier
-        - api_path
-        - base_path
-        - content_id
-        - description
-        - document_type
-        - locale
-        - links
-        - public_updated_at
-        - schema_name
-        - title
-        - withdrawn
-      properties:
-        analytics_identifier:
-          type: integer
-          nullable: true
-          description: An identifier which clients of the Publishing API can include with an edition for later use in analytics software.
-        api_path:
-          type: string
-          nullable: true
-          description: The base path of the content item, available from the API.
-        base_path:
-          type: string
-          nullable: true
-          description: The path of the content on GOV.UK - or the shortest one for content that spans multiple sub paths.
-        content_id:
-          type: string
-          format: uuid
-          description: A UUID which represents the public identifier for a piece of content, combined with locale this makes the unique identifier for an individual piece of content. Can be null for redirects / gone content.
-        description:
-          type: string
-          nullable: true
-          description: A description of the content which can then be displayed publically.
-        details:
-          type: object
-          description: An object representing data that is structured in a format defined by the schema of the edition. This holds the content for the edition, often in a field called body. Can be null for items without content - eg a redirect.
-        document_type:
-          type: string
-          description: A particular type of document, used to differentiate between documents that are of different types but share the same schema.
-        locale:
-          type: string
-          description: The language the document is written in. A fixed list of locales is allowed.
-        public_updated_at:
-          type: string
-          format: date-time
-          description: Can be set by publishing application, otherwise set automatically in Publishing API each time an edition is published with a major edition.
-        schema_name:
-          type: string
-          description: The name of the GOV.UK content schema that the request body will be validated against.
-        title:
-          type: string
-          description: The title of the edition, displayed to the user.
-        withdrawn:
-          type: boolean
-          description: Holds whether or not the content has been withdrawn.
-      example:
-        api_path: /api/content/browse/tax/vat
-        base_path: /browse/tax/vat
-        content_id: 895d337a-fa68-4c83-ab79-1c08016afe87
-        description: Includes online returns, rates, charging and record keeping
-        document_type: mainstream_browse_page
-        locale: en
-        public_updated_at: '2015-06-24T13:56:39Z'
-        schema_name: mainstream_browse_page
-        title: VAT
-        withdrawn: false
-        links: {}
-        api_url: https://www.gov.uk/api/content/browse/tax/vat
-        web_url: https://www.gov.uk/browse/tax/vat
 
     ContentItem:
       description: |
@@ -273,6 +173,107 @@ components:
           description: An object representing data that is structured in a format defined by the schema of the edition. This holds the content for the edition, often in a field called body. Can be null for items without content - eg a redirect.
       example:
         $ref: '#/components/examples/ContentItemExample'
+
+    LinkedContentItem:
+      description: |
+        ContentItems are related to one another via `links`.
+        LinkedContentItems contain the data necessary to describe and render a link to a GOV.UK content item.
+      type: object
+      required:
+        - analytics_identifier
+        - api_path
+        - base_path
+        - content_id
+        - description
+        - document_type
+        - locale
+        - links
+        - public_updated_at
+        - schema_name
+        - title
+        - withdrawn
+      properties:
+        analytics_identifier:
+          type: integer
+          nullable: true
+          description: An identifier which clients of the Publishing API can include with an edition for later use in analytics software.
+        api_path:
+          type: string
+          nullable: true
+          description: The base path of the content item, available from the API.
+        base_path:
+          type: string
+          nullable: true
+          description: The path of the content on GOV.UK - or the shortest one for content that spans multiple sub paths.
+        content_id:
+          type: string
+          format: uuid
+          description: A UUID which represents the public identifier for a piece of content, combined with locale this makes the unique identifier for an individual piece of content. Can be null for redirects / gone content.
+        description:
+          type: string
+          nullable: true
+          description: A description of the content which can then be displayed publically.
+        details:
+          type: object
+          description: An object representing data that is structured in a format defined by the schema of the edition. This holds the content for the edition, often in a field called body. Can be null for items without content - eg a redirect.
+        document_type:
+          type: string
+          description: A particular type of document, used to differentiate between documents that are of different types but share the same schema.
+        locale:
+          type: string
+          description: The language the document is written in. A fixed list of locales is allowed.
+        public_updated_at:
+          type: string
+          format: date-time
+          description: Can be set by publishing application, otherwise set automatically in Publishing API each time an edition is published with a major edition.
+        schema_name:
+          type: string
+          description: The name of the GOV.UK content schema that the request body will be validated against.
+        title:
+          type: string
+          description: The title of the edition, displayed to the user.
+        withdrawn:
+          type: boolean
+          description: Holds whether or not the content has been withdrawn.
+      example:
+        api_path: /api/content/browse/tax/vat
+        base_path: /browse/tax/vat
+        content_id: 895d337a-fa68-4c83-ab79-1c08016afe87
+        description: Includes online returns, rates, charging and record keeping
+        document_type: mainstream_browse_page
+        locale: en
+        public_updated_at: '2015-06-24T13:56:39Z'
+        schema_name: mainstream_browse_page
+        title: VAT
+        withdrawn: false
+        links: {}
+        api_url: https://www.gov.uk/api/content/browse/tax/vat
+        web_url: https://www.gov.uk/browse/tax/vat
+
+    WithdrawnNotice:
+      description: |
+        Contains information about why and when a ContentItem was withdrawn.
+      type: object
+      required:
+        - explanation
+        - withdrawn_at
+      properties:
+        explanation:
+          type: string
+          description: An explanation as to why the content was withdrawn.
+        withdrawn_at:
+          type: string
+          format: date-time
+          description: The date when the content was withdrawn.
+      example:
+        explanation: ! '<div class="govspeak"><p>This guidance has been withdrawn from use
+    because the Environment Agency no longer provides best practice guidance. See
+    guidance on <a href="https://www.gov.uk/guidance/prevent-the-spread-of-harmful-invasive-and-non-native-plants">preventing
+    harmful weeds and invasive non-native plants spreading weeds</a> for information
+    on controlling specific plants.</p>
+
+    </div>'
+        withdrawn_at: '2016-07-11T15:08:02Z'
   examples:
     ContentItemExample:
       analytics_identifier:
@@ -520,3 +521,4 @@ components:
           title=\"Value Added Tax\">VAT</abbr> rate businesses charge</a> depends on their
           goods and services.</p>\n\n<p>Check the <a href=\"https://www.gov.uk/rates-of-vat-on-different-goods-and-services\">rates
           of <abbr title=\"Value Added Tax\">VAT</abbr></a> on different goods and services.</p>\n\n"
+

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -57,7 +57,7 @@ paths:
               example:
                 $ref: '#/components/examples/ContentItemExample'
         303:
-          description: The canonical path for this content item is a different path.
+          description: A content item at a different location is responsible for the content at this path.
         404:
           description: No content item is available at that path.
         410:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -72,8 +72,8 @@ components:
 
     ContentItem:
       description: |
-        Resource containing the content, GOV.UK links and metadata for a page on GOV.UK.
-        A ContentItem has fields which describe it, such as when it was last updated, fields containing content text and links to related GOV.UK ContentItems.
+        A resource that represents a piece of content on GOV.UK.
+        It contains metadata that describe common attributes shared between all content, a details for the particular content and a links field to describe relationships with other content.
       type: object
       required:
         - base_path
@@ -176,8 +176,8 @@ components:
 
     LinkedContentItem:
       description: |
-        ContentItems are related to one another via `links`.
-        LinkedContentItems contain the data necessary to describe and render a link to a GOV.UK content item.
+        A LinkedContentItem is an abridged form of ContentItem which is used to represent links between ContentItems.
+        It is embedded within the `links` field that is used within ContentItem and LinkedContentItem.
       type: object
       required:
         - analytics_identifier
@@ -259,7 +259,7 @@ components:
 
     WithdrawnNotice:
       description: |
-        Contains information about why and when a ContentItem was withdrawn.
+        A WithdrawnNotice is an object that can be embedded within a ContentItem and is used to explain the reason a piece of content has been withdrawn.
       type: object
       required:
         - explanation


### PR DESCRIPTION
https://trello.com/c/B62dFYcP/1106-content-fixes-for-documentation

This (hopefully) fulfills the "Explain better" aspect of improving the documentation. I'm hopeful that these sections will also have links to a soon arriving "Getting Started" section which can explain these difficult concepts better.