### PR TITLE
Make naming GOV.UK Content API consistent

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,12 +3,12 @@ openapi: '3.0.0'
 info:
   title: GOV.UK Content API
   description: |
-    The GOV.UK Content API provides a simple and consistent way to request
+    GOV.UK Content API provides a simple and consistent way to request
     [GOV.UK](https://www.gov.uk) content as structured data in a predictable
     format. It is used within the GOV.UK website as the means for applications
     to lookup content in order to render it.
 
-    The API accepts HTTP requests and responds with
+    This API accepts HTTP requests and responds with
     [JSON](https://en.wikipedia.org/wiki/JSON) data containing the same
     published content as is presented on GOV.UK.
 


### PR DESCRIPTION
We've decided to refer to this API as GOV.UK Content API and this updates
all references to it to be consistent with this name.

https://trello.com/c/dKWWoydb/1104-consistent-naming-of-govuk-content-api-in-documentation