### PR TITLE
Fix missing routes from placeholders

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -183,7 +183,10 @@ private
 
   def should_register_routes?(previous_item: nil)
     return false if self.schema_name.start_with?("placeholder")
-    return false if previous_item && previous_item.route_set == self.route_set
+    if previous_item
+      return previous_item.schema_name == "placeholder" ||
+          previous_item.route_set != self.route_set
+    end
     true
   end
 

--- a/spec/integration/submitting_content_item_spec.rb
+++ b/spec/integration/submitting_content_item_spec.rb
@@ -147,12 +147,14 @@ describe "content item write API", type: :request do
   end
 
   describe 'updating an existing content item' do
+    let(:format) { "gone" }
     before(:each) do
       Timecop.travel(30.minutes.ago) do
         @item = create(
           :content_item,
           title: "Original title",
           base_path: "/vat-rates",
+          format: format,
           need_ids: ["100321"],
           public_updated_at: Time.zone.parse("2014-03-12T14:53:54Z"),
           details: { "foo" => "bar" }
@@ -185,6 +187,15 @@ describe "content item write API", type: :request do
       @data["routes"] << { "path" => "/vat-rates.json", "type" => 'exact' }
       put_json "/content/vat-rates", @data
       assert_routes_registered("frontend", [['/vat-rates', 'exact'], ['/vat-rates.json', 'exact']])
+    end
+
+    context "when the original item is a placeholder" do
+      let(:format) { "placeholder" }
+
+      it "registers routes for the content item" do
+        put_json "/content/vat-rates", @data
+        assert_routes_registered("frontend", [['/vat-rates', 'exact']])
+      end
     end
 
     context "when the router-api is unavailable" do

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -168,7 +168,23 @@ describe ContentItem, type: :model do
         ])
       end
     end
+
+    context "when previous item is a placeholder" do
+      before :each do
+        previous_routes = @routes.map(&:dup)
+        @previous_item = build(:content_item, base_path: '/a-path', rendering_app: 'an-app', format: "placeholder", routes: previous_routes)
+      end
+
+      it "registers routes even though they haven't changed" do
+        @item.register_routes(previous_item: @previous_item)
+        assert_routes_registered('an-app', [
+          ['/a-path', 'exact'],
+          ['/a-path.json', 'exact'],
+        ])
+      end
+    end
   end
+
 
   context 'when loaded from the content store' do
     before do


### PR DESCRIPTION
This fixes a situation where routes weren't registered for items that
were once placeholders. When a placeholder was published with a
different format it would not have routes registered as these were the
same as the placeholder - but since the placeholder routes weren't
registered no routes are registered.