### PR TITLE
Add search_user_need_document_supertype

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -63,6 +63,7 @@ class ContentItem
   field :email_document_supertype, type: String, default: ''
   field :government_document_supertype, type: String, default: ''
   field :navigation_document_supertype, type: String, default: ''
+  field :search_user_need_document_supertype, type: String, default: ''
   field :user_journey_document_supertype, type: String, default: ''
   field :schema_name, type: String
   field :locale, type: String, default: I18n.default_locale.to_s

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -22,6 +22,7 @@ class ContentItemPresenter
     publishing_app
     rendering_app
     schema_name
+    search_user_need_document_supertype
     title
     updated_at
     user_journey_document_supertype

--- a/spec/integration/end_to_end_spec.rb
+++ b/spec/integration/end_to_end_spec.rb
@@ -13,6 +13,7 @@ describe "End-to-end behaviour", type: :request do
     "email_document_supertype" => "publications",
     "government_document_supertype" => "new-stories",
     "navigation_document_supertype" => "guidance",
+    "search_user_need_document_supertype" => "core",
     "user_journey_document_supertype" => "finding",
     "publishing_app" => "publisher",
     "rendering_app" => "frontend",

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -45,6 +45,7 @@ describe "Fetching content items", type: :request do
         email_document_supertype
         government_document_supertype
         navigation_document_supertype
+        search_user_need_document_supertype
         user_journey_document_supertype
         need_ids
         locale


### PR DESCRIPTION
This is for grouping documents by core or government. In the short term this will be used in an A/B test to boost core (sometimes referred to as 'mainstream') documents in search results.

https://trello.com/c/z9wtoGTV