### PR TITLE
Add Mongo SSL config.

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -25,5 +25,8 @@ production:
     default:
       uri: <%= ENV['MONGODB_URI'] %>
       options:
+        ssl: <%= ENV['MONGO_SSL'] || 'false' %>
+        ssl_verify: <%= ENV['MONGO_SSL_VERIFY'] || 'true' %>
+        server_selection_timeout: 5
         write:
           w: majority


### PR DESCRIPTION
Need to add the option for connecting to Mongo via SSL in production in order to test this app in the PaaS environment where Mongo is provided externally and can only be accessed over a TLS connection.