### PR TITLE
Handle deleting routes when deleting content items

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -55,7 +55,11 @@ class ContentItemsController < ApplicationController
   end
 
   def destroy
-    ContentItem.find_by(base_path: encoded_base_path).destroy
+    content_item = ContentItem.find_by(base_path: encoded_base_path)
+
+    content_item.delete_routes
+    content_item.destroy
+
     render status: :ok
   end
 

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -170,6 +170,12 @@ class ContentItem
     end
   end
 
+  def delete_routes
+    return unless should_register_routes?
+
+    route_set.delete!
+  end
+
   def base_path_without_root
     base_path&.sub(%r{^/}, "")
   end

--- a/app/models/route_set.rb
+++ b/app/models/route_set.rb
@@ -81,6 +81,21 @@ class RouteSet < OpenStruct
     commit_routes
   end
 
+  def delete!
+    return unless any_routes?
+
+    paths.each do |path|
+      begin
+        Rails.application.router_api.delete_route(path)
+      rescue GdsApi::HTTPNotFound
+        # Ignore this, as this path could have already been deleted
+        next
+      end
+    end
+
+    commit_routes
+  end
+
 private
 
   def register_rendering_app
@@ -114,6 +129,12 @@ private
 
   def commit_routes
     Rails.application.router_api.commit_routes
+  end
+
+  def paths
+    (routes + gone_routes + redirects).map do |hash|
+      hash[:path]
+    end
   end
 
   def any_routes?

--- a/app/models/route_set.rb
+++ b/app/models/route_set.rb
@@ -86,7 +86,7 @@ class RouteSet < OpenStruct
 
     paths.each do |path|
       begin
-        Rails.application.router_api.delete_route(path)
+        router_api.delete_route(path)
       rescue GdsApi::HTTPNotFound
         # Ignore this, as this path could have already been deleted
         next
@@ -99,11 +99,11 @@ class RouteSet < OpenStruct
 private
 
   def register_rendering_app
-    Rails.application.router_api.add_backend(rendering_app, Plek.find(rendering_app) + "/")
+    router_api.add_backend(rendering_app, Plek.find(rendering_app) + "/")
   end
 
   def register_redirect(route)
-    Rails.application.router_api.add_redirect_route(
+    router_api.add_redirect_route(
       route.fetch(:path),
       route.fetch(:type),
       route.fetch(:destination),
@@ -113,14 +113,14 @@ private
   end
 
   def register_gone_route(route)
-    Rails.application.router_api.add_gone_route(
+    router_api.add_gone_route(
       route.fetch(:path),
       route.fetch(:type),
     )
   end
 
   def register_route(route, rendering_app)
-    Rails.application.router_api.add_route(
+    router_api.add_route(
       route.fetch(:path),
       route.fetch(:type),
       rendering_app,
@@ -128,7 +128,11 @@ private
   end
 
   def commit_routes
-    Rails.application.router_api.commit_routes
+    router_api.commit_routes
+  end
+
+  def router_api
+    Rails.application.router_api
   end
 
   def paths

--- a/spec/integration/deleting_a_content_item_spec.rb
+++ b/spec/integration/deleting_a_content_item_spec.rb
@@ -6,12 +6,25 @@ RSpec.describe "Deleting a content item", type: :request do
   context "when the content item exists" do
     before do
       FactoryGirl.create(:content_item, base_path: base_path)
+
+      @delete_stubs = ContentItem.find_by(
+        base_path: base_path
+      ).routes.map do |route|
+        stub_route_deleted(route["path"])
+      end
     end
 
     it "deletes the content item" do
       delete "/content/vat-rates"
 
       expect(ContentItem.where(base_path: base_path).count).to eq(0)
+    end
+
+    it "deletes the routes" do
+      delete "/content/vat-rates"
+
+      @delete_stubs.each { |stub| assert_requested(stub, times: 1) }
+      assert_requested(stub_router_commit, times: 1)
     end
 
     it "returns a 200" do

--- a/spec/support/router_helpers.rb
+++ b/spec/support/router_helpers.rb
@@ -52,6 +52,13 @@ module RouterHelpers
       with(body: { "route" => hash_including("incoming_path" => path) })
     assert_not_requested(route_stub)
   end
+
+  def stub_route_deleted(path)
+    stub_http_request(
+      :delete,
+      "#{ROUTER_API_ENDPOINT}/routes?incoming_path=#{CGI.escape(path)}"
+    ).to_return(status: 200)
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
Copied from the last commit:

This change provides a means to delete routes, from the Publishing
API, via the Content Store.

On an architectural level, the Publishing API doesn't directly talk to
the Router API, all communication goes through the Content Store. The
Publishing API can delete content items from the Content Store,
e.g. if you unpublish some content with a vanish type.

This change means that deletions from the Content Store will mean that
the Content Store will delete the relevant routes from the router.

One practical issue which this helps with is removing content/routes
when they are no longer wanted. This is tricky with content with
prefix routes. Say you have two bits of content, A and B where the
routes are:

  /A (type prefix)
  /A/B

If you wanted to remove B, such that A was responsible for /A/B, then
the vanish unpublishing type, with this change to the Content Store
would be a way of doing that.

This change doesn't address the issue of deleting routes when a
ContentItem no longer specifies that route, which I think is another
somewhat related deficiency.