### PR TITLE
Hard delete routes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'hashdiff', require: false
 if ENV['GDS_API_ADAPTERS_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', "~> 47.9.1"
+  gem 'gds-api-adapters', "~> 50.0.0"
 end
 
 gem 'govuk_app_config', '~> 0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
     find_a_port (1.0.1)
-    gds-api-adapters (47.9.1)
+    gds-api-adapters (50.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -297,7 +297,7 @@ DEPENDENCIES
   ci_reporter_rspec (~> 1.0.0)
   database_cleaner (~> 1.6.1)
   factory_girl (~> 4.4)
-  gds-api-adapters (~> 47.9.1)
+  gds-api-adapters (~> 50.0.0)
   govuk-content-schema-test-helpers (~> 1.4)
   govuk-lint
   govuk_app_config (~> 0.2)

--- a/app/models/route_set.rb
+++ b/app/models/route_set.rb
@@ -86,7 +86,7 @@ class RouteSet < OpenStruct
 
     paths.each do |path|
       begin
-        router_api.delete_route(path)
+        router_api.delete_route(path, hard_delete: true)
       rescue GdsApi::HTTPNotFound
         # Ignore this, as this path could have already been deleted
         next

--- a/spec/integration/deleting_a_content_item_spec.rb
+++ b/spec/integration/deleting_a_content_item_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Deleting a content item", type: :request do
       @delete_stubs = ContentItem.find_by(
         base_path: base_path
       ).routes.map do |route|
-        stub_route_deleted(route["path"])
+        stub_route_deleted(route["path"], hard_delete: true)
       end
     end
 

--- a/spec/support/router_helpers.rb
+++ b/spec/support/router_helpers.rb
@@ -53,11 +53,11 @@ module RouterHelpers
     assert_not_requested(route_stub)
   end
 
-  def stub_route_deleted(path)
-    stub_http_request(
-      :delete,
-      "#{ROUTER_API_ENDPOINT}/routes?incoming_path=#{CGI.escape(path)}"
-    ).to_return(status: 200)
+  def stub_route_deleted(path, hard_delete: false)
+    url = "#{ROUTER_API_ENDPOINT}/routes?incoming_path=#{CGI.escape(path)}"
+    url += "&hard_delete=true" if hard_delete
+
+    stub_http_request(:delete, url).to_return(status: 200)
   end
 end
 


### PR DESCRIPTION
Copied from the third commit:

This avoids the Router API service converting these routes to gone
routes, and gets it to actually delete them.

I think this behaviour is better, it avoids state building up in the
Router API and also means that the unpublishing type of vanish will
work, as the routes will be deleted from the router.