### PR TITLE
Stub some router-api requests in the pact tests

### DIFF
--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -34,6 +34,25 @@ Pact.provider_states_for "Publishing API" do
     WebMock.enable!
     WebMock.reset!
     DatabaseCleaner.clean_with :truncation
+
+    escaped_router_api_prefix = Regexp.escape(Plek.find('router-api'))
+    stub_request(
+      :delete,
+      %r(\A#{escaped_router_api_prefix}/routes)
+    ).to_return(
+      status: 404,
+      body: "{}",
+      headers: { "Content-Type" => "application/json" }
+    )
+
+    stub_request(
+      :post,
+      %r(\A#{escaped_router_api_prefix}/routes/commit)
+    ).to_return(
+      status: 200,
+      body: "{}",
+      headers: { "Content-Type" => "application/json" }
+    )
   end
 
   tear_down do


### PR DESCRIPTION
Changing the Content Store to delete routes upon the deletion of the
content means that in the pact tests with the Publishing API, requests
are made to the router-api.

This commit puts in some basic stubs for these requests.