### PR TITLE
Test against Publishing API pacts as part of build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,5 +2,20 @@
 
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
-  govuk.buildProject(publishingE2ETests: true)
+  govuk.buildProject(
+    extraParameters: [
+      stringParam(
+        name: "PUBLISHING_API_PACT_BRANCH",
+        defaultValue: "deployed-to-production",
+        description: "The branch of Publishing API pact tests to run against"
+      ),
+    ],
+    beforeTest: {
+      govuk.setEnvar("PACT_BROKER_BASE_URL", "https://pact-broker.cloudapps.digital")
+    },
+    publishingE2ETests: true,
+    afterTest: {
+      govuk.runRakeTask("pact:verify:branch[${env.PUBLISHING_API_PACT_BRANCH}]")
+    }
+  )
 }


### PR DESCRIPTION
Publishing API publishes a suite of pact tests each time it builds on a
branch and tests these against content-store on the deployed to
production branch. However the inverse of this seems to have been
overlooked and it was possible to merge commits into content-store which
broke these pact tests.

Once https://github.com/alphagov/content-store/pull/333 is merged in this should pass :crossed_fingers: 