### PR TITLE
Add the "content purpose" supertype

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -60,6 +60,7 @@ class ContentItem
   field :description, type: Hash, default: { "value" => nil }
   field :format, type: String
   field :document_type, type: String
+  field :content_purpose_document_supertype, type: String, default: ''
   field :email_document_supertype, type: String, default: ''
   field :government_document_supertype, type: String, default: ''
   field :navigation_document_supertype, type: String, default: ''

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -66,6 +66,8 @@ class ContentItem
   field :navigation_document_supertype, type: String, default: ''
   field :search_user_need_document_supertype, type: String, default: ''
   field :user_journey_document_supertype, type: String, default: ''
+
+  # TODO: remove after publishing-api no longer sends this
   field :user_need_document_supertype, type: String, default: ''
   field :schema_name, type: String
   field :locale, type: String, default: I18n.default_locale.to_s

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -25,7 +25,6 @@ class ContentItemPresenter
     search_user_need_document_supertype
     title
     updated_at
-    user_need_document_supertype
     user_journey_document_supertype
     withdrawn_notice
     publishing_request_id

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -10,6 +10,7 @@ class ContentItemPresenter
     analytics_identifier
     base_path
     content_id
+    content_purpose_document_supertype
     document_type
     email_document_supertype
     first_published_at

--- a/spec/integration/end_to_end_spec.rb
+++ b/spec/integration/end_to_end_spec.rb
@@ -10,6 +10,7 @@ describe "End-to-end behaviour", type: :request do
     "format" => "answer",
     "schema_name" => "answer",
     "document_type" => "travel_advice",
+    "content_purpose_document_supertype" => "guidance",
     "email_document_supertype" => "publications",
     "government_document_supertype" => "new-stories",
     "navigation_document_supertype" => "guidance",

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -42,6 +42,7 @@ describe "Fetching content items", type: :request do
         description
         schema_name
         document_type
+        content_purpose_document_supertype
         email_document_supertype
         government_document_supertype
         navigation_document_supertype

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -47,7 +47,6 @@ describe "Fetching content items", type: :request do
         navigation_document_supertype
         search_user_need_document_supertype
         user_journey_document_supertype
-        user_need_document_supertype
         need_ids
         locale
         analytics_identifier


### PR DESCRIPTION
https://github.com/alphagov/govuk_document_types/pull/33 replaced `user_need_document_supertype` with `content_purpose_document_supertype`. 

This PR makes sure that the content store can handle being sent both by the publishing-api, and makes sure the app returns the new document type. It will fail until https://github.com/alphagov/govuk-content-schemas/pull/678 is deployed.

https://trello.com/c/PBPo5tmL