### PR TITLE
Add ENV var to allow setting Mongo write mode

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -29,4 +29,4 @@ production:
         ssl_verify: <%= ENV['MONGO_SSL_VERIFY'] || 'true' %>
         server_selection_timeout: 5
         write:
-          w: majority
+          w: <%= ENV['MONGO_WRITE_CONCERN'] || 'majority' %>


### PR DESCRIPTION
This allows us to run the content store in a production like state without requiring multiple Mongo instances to be present.

This is currently utilised as part of running the E2E tests in production.