### PR TITLE
Update webrick due to security vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,7 +301,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    webrick (1.3.1)
+    webrick (1.4.2)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)


### PR DESCRIPTION
Github is notifying us that Webrick <= 1.3.1 has a security vulnerability so it seems like a good idea to upgrade it.