### PR TITLE
Include redirects in redirect schema output

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -41,7 +41,9 @@ class ContentItemPresenter
       "links" => links,
       "description" => RESOLVER.resolve(item.description),
       "details" => RESOLVER.resolve(item.details),
-    )
+    ).tap do |i|
+      i["redirects"] = item["redirects"] if i["schema_name"] == "redirect"
+    end
   end
 
 private

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -67,4 +67,20 @@ describe ContentItemPresenter do
 
     expect(presented.to_json).to be_valid_against_schema("generic")
   end
+
+  context "when schema_name is not redirect" do
+    it "doesn't include redirects field" do
+      content_item = create(:content_item)
+      presented = ContentItemPresenter.new(content_item, api_url_method).as_json
+      expect(presented.keys).to_not include("redirects")
+    end
+  end
+
+  context "when schema_name is redirect" do
+    it "includes the redirects field" do
+      content_item = create(:redirect_content_item)
+      presented = ContentItemPresenter.new(content_item, api_url_method).as_json
+      expect(presented.keys).to include("redirects")
+    end
+  end
 end


### PR DESCRIPTION
See: https://github.com/alphagov/gds-api-adapters/pull/805 for context

This is to allow applications other than router the option to know about
which redirects a redirect content item has.

The reason for this is to enable a fallback for the scenario when router
proxies a request to an application but when the application queries the
content store it returns a redirect type which the frontend app has no
option other than return a 500.