### PR TITLE
Redirect prefix content items for redirect types

### DIFF
--- a/lib/find_by_path.rb
+++ b/lib/find_by_path.rb
@@ -1,6 +1,7 @@
-# This class is designed to work with a Mongoid model that has base_path and
-# routes fields (where the routes field matches the govuk schema of an array
-# of objects with path and type fields)
+# This class is designed to work with a Mongoid model that has base_path,
+# routes and (optionally) redirect fields (where the routes and redirects
+# field matches the govuk schema of an array of objects with path and type
+# fields)
 #
 # It is designed to make it easy to find an item that matches a particular
 # path that may exist as a base_path or within routes
@@ -22,7 +23,9 @@ private
     model_class
       .or(base_path: path)
       .or(routes: { "$elemMatch" => { path: path, type: "exact" } })
+      .or(redirects: { "$elemMatch" => { path: path, type: "exact" } })
       .or(routes: { "$elemMatch" => { :path.in => potential_prefixes(path), type: "prefix" } })
+      .or(redirects: { "$elemMatch" => { :path.in => potential_prefixes(path), type: "prefix" } })
       .entries
   end
 
@@ -43,14 +46,16 @@ private
 
   def exact_route_match(matches, path)
     matches.detect do |item|
-      item.routes.any? { |route| route["path"] == path && route["type"] == "exact" }
+      routes_and_redirects(item).any? do |route|
+        route["path"] == path && route["type"] == "exact"
+      end
     end
   end
 
   def best_prefix_match(matches, path)
     prefixes = potential_prefixes(path)
     sorted = matches.sort_by do |item|
-      best_match = item.routes
+      best_match = routes_and_redirects(item)
         .select { |route| route["type"] == "prefix" && prefixes.include?(route["path"]) }
         .sort_by { |route| -route["path"].length }
         .first
@@ -58,5 +63,9 @@ private
       -best_match["path"].length
     end
     sorted.first
+  end
+
+  def routes_and_redirects(item)
+    item.routes + (item.respond_to?(:redirects) ? item.redirects : [])
   end
 end

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -210,17 +210,7 @@ describe "Fetching content items", type: :request do
     end
   end
 
-  context "when requesting a prefix route within a base_path" do
-    let!(:content_item) do
-      FactoryBot.create(
-        :content_item,
-        base_path: "/base-path",
-        content_id: SecureRandom.uuid,
-        routes: [
-          { path: "/base-path/prefix", type: "prefix" },
-        ],
-      )
-    end
+  shared_examples "redirecting prefix routes" do
     let(:requested_path) { "/base-path/prefix" }
 
     before do
@@ -242,6 +232,36 @@ describe "Fetching content items", type: :request do
         expect(response).to redirect_to("/content/base-path")
       end
     end
+  end
+
+  context "when requesting a prefix route within a base_path" do
+    before do
+      FactoryBot.create(
+        :content_item,
+        base_path: "/base-path",
+        content_id: SecureRandom.uuid,
+        routes: [
+          { path: "/base-path/prefix", type: "prefix" },
+        ],
+      )
+    end
+
+    include_examples "redirecting prefix routes"
+  end
+
+  context "when requesting a prefix redirect within a base_path" do
+    before do
+      FactoryBot.create(
+        :redirect_content_item,
+        base_path: "/base-path",
+        content_id: SecureRandom.uuid,
+        redirects: [
+          { path: "/base-path/prefix", type: "prefix", "destination" => "/somewhere" },
+        ],
+      )
+    end
+
+    include_examples "redirecting prefix routes"
   end
 
   context "a withdrawn content item" do

--- a/spec/lib/find_by_path_spec.rb
+++ b/spec/lib/find_by_path_spec.rb
@@ -7,6 +7,7 @@ describe FindByPath do
     include Mongoid::Document
     field :base_path, type: String
     field :routes, type: Array, default: []
+    field :redirects, type: Array, default: []
   end
 
   FactoryBot.define do
@@ -53,6 +54,22 @@ describe FindByPath do
 
         it { is_expected.to eq superseding_instance }
       end
+    end
+
+    context "when there is a redirect exact match for the path" do
+      let(:exact_route_path) { "/base-path/exact-route" }
+      let(:path) { exact_route_path }
+      let!(:instance) do
+        create(
+          :compatible_model,
+          routes: [],
+          redirects: [
+            { path: exact_route_path, type: "exact", destination: "/somewhere" }
+          ]
+        )
+      end
+
+      it { is_expected.to eq instance }
     end
 
     context "when there is a route with a prefix match" do


### PR DESCRIPTION
This is related to the work in https://github.com/alphagov/content-store/pull/269 but extends this for redirects which were missed and are now a somewhat bizarre inconsistency.
