### PR TITLE
Remove explicitly setting unicorn worker processes

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,4 +1,2 @@
 require "govuk_app_config"
 GovukUnicorn.configure(self)
-
-worker_processes Integer(ENV.fetch("UNICORN_WORKER_PROCESSES", 6))


### PR DESCRIPTION
This is now managed via an env var from puppet.

This should be merged once: https://github.com/alphagov/govuk-puppet/pull/7212 is deployed to prod.