### PR TITLE
Revert using foreman in dev environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM ruby:2.4.2
 RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential && apt-get clean
+RUN gem install foreman
 
 ENV GOVUK_APP_NAME content-store
 ENV GOVUK_CONTENT_SCHEMAS_PATH /govuk-content-schemas
@@ -15,4 +16,4 @@ ADD Gemfile* $APP_HOME/
 RUN bundle install
 ADD . $APP_HOME
 
-CMD bundle exec foreman run web
+CMD foreman run web

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gem 'mongo', '2.4.3'
 gem 'mongoid', '6.2.1'
 gem "mongoid_rails_migrations", git: "https://github.com/alphagov/mongoid_rails_migrations", branch: "avoid-calling-bundler-require-in-library-code-v1.1.0-plus-mongoid-v5-fix"
 
-gem 'foreman', '~> 0.84'
 gem 'hashdiff', require: false
 gem 'uuidtools', '2.1.5'
 gem 'whenever', '~> 0.10.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,8 +83,6 @@ GEM
     ffi (1.9.18)
     filelock (1.1.1)
     find_a_port (1.0.1)
-    foreman (0.84.0)
-      thor (~> 0.19.1)
     gds-api-adapters (51.2.0)
       addressable
       link_header
@@ -287,7 +285,7 @@ GEM
     statsd-ruby (1.4.0)
     term-ansicolor (1.6.0)
       tins (~> 1.0)
-    thor (0.19.4)
+    thor (0.20.0)
     thread_safe (0.3.6)
     timecop (0.9.1)
     tins (1.16.3)
@@ -319,7 +317,6 @@ DEPENDENCIES
   ci_reporter_rspec (~> 1.0.0)
   database_cleaner (~> 1.6.1)
   factory_bot (~> 4.8)
-  foreman (~> 0.84)
   gds-api-adapters (~> 51.2.0)
   govuk-content-schema-test-helpers (~> 1.6)
   govuk-lint

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 bundle install
-bundle exec foreman run web
+bundle exec rails s -p 3068


### PR DESCRIPTION
Wider context: https://github.com/alphagov/publishing-e2e-tests/pull/202

This removes foreman from the Gemfile and from the startup.sh usage and
instead installs foreman separately via `gem install` in the Dockerfile
so that it can be used in the docker environment.

The reason for this is that running everything via unicorn in dev can
cause some wtfs (such as breaking better_errors) and installing foreman
via Gemfile does contradict some contenious advice given by the foreman
gem maintainer.