### PR TITLE
Record publishing delays in graphite

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -30,11 +30,12 @@ class ContentItemsController < ApplicationController
     intent = PublishIntent.find_by_path(encoded_base_path)
     if intent.present? && intent.publish_time.past?
       intent.destroy
-      ScheduledPublishingLogEntry.create(
+      log_entry = ScheduledPublishingLogEntry.create(
         base_path: item.base_path,
         document_type: item.document_type,
         scheduled_publication_time: intent.publish_time
       )
+      GovukStatsd.timing("scheduled_publishing.delay_ms", log_entry.delay_in_milliseconds)
     end
 
     response_body = {}

--- a/spec/integration/submitting_content_item_spec.rb
+++ b/spec/integration/submitting_content_item_spec.rb
@@ -106,7 +106,7 @@ describe "content item write API", type: :request do
           base_path: @data["base_path"],
           document_type: @data["document_type"],
           scheduled_publication_time: publish_time
-        )
+        ).and_return(ScheduledPublishingLogEntry.new)
 
         put_json "/content/vat-rates", @data
       end


### PR DESCRIPTION
Log the difference between the scheduled publishing time and the actual publishing time. Use a Statsd `timing` stat, which automatically calculates other stats like the mean and standard deviation.

It might be more useful to calculate some daily aggregates, but at least this will let us start recording some data about publishing delays.

https://trello.com/c/pMHR10Rv/85-2-scheduled-publication-reporting