### PR TITLE
Report scheduled publishing delays to graphite

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -9,3 +9,7 @@ job_type :rake, "cd :path && govuk_setenv content-store bundle exec rake :task :
 every 1.day, at: "2:00 am" do
   rake "housekeeping:cleanup_publish_intents"
 end
+
+every 1.day, at: "2:15 am" do
+  rake "publishing_delay_report:report_delays"
+end

--- a/lib/tasks/data_hygiene/publishing_delay_report.rake
+++ b/lib/tasks/data_hygiene/publishing_delay_report.rake
@@ -1,0 +1,8 @@
+require "tasks/data_hygiene/publishing_delay_reporter"
+
+namespace :publishing_delay_report do
+  desc "Report on the delay between scheduled and actual publication times"
+  task report_delays: :environment do
+    Tasks::DataHygiene::PublishingDelayReporter.new.report
+  end
+end

--- a/lib/tasks/data_hygiene/publishing_delay_reporter.rb
+++ b/lib/tasks/data_hygiene/publishing_delay_reporter.rb
@@ -1,0 +1,18 @@
+class Tasks::DataHygiene::PublishingDelayReporter
+  def report
+    now = Time.zone.now
+
+    log_entries = ScheduledPublishingLogEntry.where(created_at: (now - 1.day)..now)
+    delays = log_entries.map(&:delay_in_milliseconds)
+
+    unless delays.empty?
+      GovukStatsd.gauge("scheduled_publishing.aggregate.mean_ms", mean(delays))
+    end
+  end
+
+private
+
+  def mean(delays)
+    delays.sum / delays.size.to_f
+  end
+end

--- a/lib/tasks/data_hygiene/publishing_delay_reporter.rb
+++ b/lib/tasks/data_hygiene/publishing_delay_reporter.rb
@@ -6,13 +6,24 @@ class Tasks::DataHygiene::PublishingDelayReporter
     delays = log_entries.map(&:delay_in_milliseconds)
 
     unless delays.empty?
-      GovukStatsd.gauge("scheduled_publishing.aggregate.mean_ms", mean(delays))
+      GovukStatsd.gauge("scheduled_publishing.aggregate.mean_ms", Stats.mean(delays))
+      GovukStatsd.gauge("scheduled_publishing.aggregate.95_percentile_ms", Stats.percentile(delays, 95))
     end
   end
+end
 
-private
+class Tasks::DataHygiene::PublishingDelayReporter::Stats
+  def self.mean(values)
+    raise ArgumentError.new("Cannot calculate the mean of an empty array") if values.empty?
 
-  def mean(delays)
-    delays.sum / delays.size.to_f
+    values.sum / values.size.to_f
+  end
+
+  def self.percentile(values, percentile)
+    raise ArgumentError.new("Cannot calculate percentile #{percentile} of an empty array") if values.empty?
+
+    ordinal = (values.length * percentile.to_f / 100).ceil
+    index = [0, ordinal - 1].max
+    values.sort[index]
   end
 end

--- a/spec/lib/tasks/data_hygiene/publishing_delay_reporter_spec.rb
+++ b/spec/lib/tasks/data_hygiene/publishing_delay_reporter_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+require "tasks/data_hygiene/publishing_delay_reporter"
+
+describe Tasks::DataHygiene::PublishingDelayReporter do
+  it "reports nothing if no documents have been published recently" do
+    expect(GovukStatsd).not_to receive(:gauge)
+
+    described_class.new.report
+  end
+
+  it "reports publishing delays for recent scheduled publishings" do
+    Timecop.freeze(Time.new(2018, 3, 1, 9, 32)) do
+      ScheduledPublishingLogEntry.create(scheduled_publication_time: Time.new(2018, 3, 1, 9, 30))
+    end
+
+    Timecop.freeze(Time.new(2018, 3, 1, 11, 4)) do
+      ScheduledPublishingLogEntry.create(scheduled_publication_time: Time.new(2018, 3, 1, 11, 0))
+    end
+
+    expected_mean_delay_ms = 180_000 # Mean of 2 and 4 minutes = 180,000 ms
+    expect(GovukStatsd).to receive(:gauge).with("scheduled_publishing.aggregate.mean_ms", expected_mean_delay_ms)
+
+    Timecop.freeze(Time.new(2018, 3, 1, 12, 0)) do
+      described_class.new.report
+    end
+  end
+
+  it "limits report to documents published in the past 24 hours" do
+    old_scheduled_publishing = Time.new(2018, 3, 1, 12, 30)
+    Timecop.freeze(old_scheduled_publishing + 15.minutes) do
+      ScheduledPublishingLogEntry.create(scheduled_publication_time: old_scheduled_publishing)
+    end
+
+    recent_scheduled_publishing = Time.new(2018, 3, 5, 9, 30)
+    recent_publishing_delay = 1.hour
+    Timecop.freeze(recent_scheduled_publishing + recent_publishing_delay) do
+      ScheduledPublishingLogEntry.create(scheduled_publication_time: recent_scheduled_publishing)
+    end
+
+    expect(GovukStatsd).to receive(:gauge).with("scheduled_publishing.aggregate.mean_ms", recent_publishing_delay.in_milliseconds)
+
+    Timecop.freeze(Time.new(2018, 3, 6, 9, 45)) do
+      described_class.new.report
+    end
+  end
+end


### PR DESCRIPTION
Add a cron job which runs a rake task every night to send publishing delay stats to graphite.

Calculate the stats directly rather than using a stats gem because the available gems weren't very suitable:

- descriptive-statistics (https://github.com/jtescher/descriptive-statistics) doesn't calculate percentiles in the expected way: it returns nil rather than the maximum value if the percentile requested is larger than the data set, e.g. the 95th percentile of a data set with less than 20 values.
- SciRuby statsample (https://github.com/sciruby/statsample) is too large for what we need: it adds dependencies like a PDF writer and a visualisation toolkit.

https://trello.com/c/pMHR10Rv/85-2-scheduled-publication-reporting