### PR TITLE
Add new content purpose supergroup and subgroup

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -61,6 +61,8 @@ class ContentItem
   field :format, type: String
   field :document_type, type: String
   field :content_purpose_document_supertype, type: String, default: ''
+  field :content_purpose_subgroup, type: String, default: ''
+  field :content_purpose_supergroup, type: String, default: ''
   field :email_document_supertype, type: String, default: ''
   field :government_document_supertype, type: String, default: ''
   field :navigation_document_supertype, type: String, default: ''

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -11,6 +11,8 @@ class ContentItemPresenter
     base_path
     content_id
     content_purpose_document_supertype
+    content_purpose_supergroup
+    content_purpose_subgroup
     document_type
     email_document_supertype
     first_published_at

--- a/spec/integration/end_to_end_spec.rb
+++ b/spec/integration/end_to_end_spec.rb
@@ -17,6 +17,8 @@ describe "End-to-end behaviour", type: :request do
     "search_user_need_document_supertype" => "core",
     "user_journey_document_supertype" => "finding",
     "user_need_document_supertype" => "guidance",
+    "content_purpose_supergroup" => "guidance_and_regulation",
+    "content_purpose_subgroup" => "guidance",
     "publishing_app" => "publisher",
     "rendering_app" => "frontend",
     "routes" => [

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -48,6 +48,8 @@ describe "Fetching content items", type: :request do
         navigation_document_supertype
         search_user_need_document_supertype
         user_journey_document_supertype
+        content_purpose_supergroup
+        content_purpose_subgroup
         need_ids
         locale
         analytics_identifier


### PR DESCRIPTION
We have added `content_purpose_supergroup` and `content_purpose_subgroup` to govuk-document-types https://github.com/alphagov/govuk_document_types/pull/36. We need to update content-store with this change.

**Note: The tests will fail until https://github.com/alphagov/govuk-content-schemas/pull/722 is deployed.**