### PR TITLE
Log expired publishing intents to Sentry

### DIFF
--- a/app/models/publish_intent.rb
+++ b/app/models/publish_intent.rb
@@ -55,7 +55,17 @@ class PublishIntent
 
   # Called nightly from a cron job
   def self.cleanup_expired
-    where(:publish_time.lt => PUBLISH_TIME_LEEWAY.ago).delete_all
+    expired = where(:publish_time.lt => PUBLISH_TIME_LEEWAY.ago)
+
+    expired.each do |intent|
+      GovukError.notify(
+        "Publish intent has expired",
+        level: "warning",
+        extra: { base_path: intent.base_path, scheduled_publish_time: intent.publish_time }
+      )
+    end
+
+    expired.delete_all
   end
 
   def base_path_without_root


### PR DESCRIPTION
Log a warning when the housekeeping job cleans up any expired publishing intents.

This cleanup job used to be necesssary to delete expired intents, but intents are now deleted when the document is published so there should no longer be any expired intents.

If this doesn't log any warnings in the next few weeks, it should be safe to remove the housekeeping task altogether.

https://trello.com/c/pMHR10Rv/85-2-scheduled-publication-reporting