### PR TITLE
Revert "Add scheduled publication time to content item response"

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -10,20 +10,13 @@ class ContentItemsController < ApplicationController
       PublishIntent.find_by_path(encoded_request_path)
     end
 
-    scheduled_publishing_log = GovukStatsd.time('show.find_scheduled_publishing_log_entry') do
-      ScheduledPublishingLogEntry.latest_with_path(encoded_request_path)
-    end
-
     set_cache_headers(item, intent)
 
     return error_404 unless item
     return redirect_canonical(item) if item.base_path != encoded_request_path
 
     if can_view(item)
-      render(
-        json: ContentItemPresenter.new(item, api_url_method, scheduled_publishing: scheduled_publishing_log),
-        status: http_status(item)
-      )
+      render json: ContentItemPresenter.new(item, api_url_method), status: http_status(item)
     else
       render json_forbidden_response
     end

--- a/app/models/scheduled_publishing_log_entry.rb
+++ b/app/models/scheduled_publishing_log_entry.rb
@@ -10,12 +10,6 @@ class ScheduledPublishingLogEntry
     document.delay_in_milliseconds = set_delay_in_milliseconds
   end
 
-  def self.latest_with_path(base_path)
-    ScheduledPublishingLogEntry.where(base_path: base_path)
-      .order_by(scheduled_publication_time: "desc")
-      .first
-  end
-
 private
 
   def set_delay_in_milliseconds

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -33,10 +33,9 @@ class ContentItemPresenter
     publishing_request_id
   ).freeze
 
-  def initialize(item, api_url_method, scheduled_publishing: nil)
+  def initialize(item, api_url_method)
     @item = item
     @api_url_method = api_url_method
-    @scheduled_publishing = scheduled_publishing
   end
 
   def as_json(options = nil)
@@ -46,13 +45,12 @@ class ContentItemPresenter
       "details" => RESOLVER.resolve(item.details),
     ).tap do |i|
       i["redirects"] = item["redirects"] if i["schema_name"] == "redirect"
-      i["publishing_scheduled_at"] = scheduled_publishing.scheduled_publication_time if scheduled_publishing
     end
   end
 
 private
 
-  attr_reader :item, :api_url_method, :scheduled_publishing
+  attr_reader :item, :api_url_method
 
   def links
     ExpandedLinksPresenter.new(item.expanded_links).present

--- a/spec/factories/scheduled_publishing_log_entry.rb
+++ b/spec/factories/scheduled_publishing_log_entry.rb
@@ -1,5 +1,0 @@
-FactoryBot.define do
-  factory :scheduled_publishing_log_entry, class: ScheduledPublishingLogEntry do
-    scheduled_publication_time Time.new(2018, 1, 1)
-  end
-end

--- a/spec/models/scheduled_publishing_log_entry_spec.rb
+++ b/spec/models/scheduled_publishing_log_entry_spec.rb
@@ -15,37 +15,4 @@ describe ScheduledPublishingLogEntry do
       expect(log_entry.delay_in_milliseconds).to be_within(1).of(20000)
     end
   end
-
-  describe "find latest by path" do
-    it "returns nil if there are no log entries for the given path" do
-      log_entry = ScheduledPublishingLogEntry.latest_with_path("/some_page")
-      expect(log_entry).to be_nil
-    end
-
-    it "returns a single log entry" do
-      expected_log_entry = ScheduledPublishingLogEntry.create(
-        base_path: "/a_scheduled_page",
-        scheduled_publication_time: Time.now,
-      )
-      log_entry = ScheduledPublishingLogEntry.latest_with_path("/a_scheduled_page")
-      expect(log_entry).to eq(expected_log_entry)
-    end
-
-    it "returns the log entry for the most recent publishing" do
-      ScheduledPublishingLogEntry.create(
-        base_path: "/some_path",
-        scheduled_publication_time: Time.new(2015, 5, 1),
-      )
-      ScheduledPublishingLogEntry.create(
-        base_path: "/some_path",
-        scheduled_publication_time: Time.new(2018, 3, 20),
-      )
-      ScheduledPublishingLogEntry.create(
-        base_path: "/some_path",
-        scheduled_publication_time: Time.new(2017, 12, 31),
-      )
-      log_entry = ScheduledPublishingLogEntry.latest_with_path("/some_path")
-      expect(log_entry.scheduled_publication_time).to eq(Time.new(2018, 3, 20))
-    end
-  end
 end

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -83,28 +83,4 @@ describe ContentItemPresenter do
       expect(presented.keys).to include("redirects")
     end
   end
-
-  context "when the document was not published by the scheduler" do
-    it "does not include a scheduled publication date" do
-      content_item = create(:content_item)
-      presented = ContentItemPresenter.new(content_item, api_url_method).as_json
-      expect(presented["publishing_scheduled_at"]).to be_nil
-    end
-  end
-
-  context "when the document was published by the scheduler" do
-    it "includes scheduled publication date" do
-      content_item = create(:content_item)
-      scheduled_publishing = create(:scheduled_publishing_log_entry)
-      presented = ContentItemPresenter.new(content_item, api_url_method, scheduled_publishing: scheduled_publishing).as_json
-      expect(presented["publishing_scheduled_at"]).to eq(scheduled_publishing.scheduled_publication_time)
-    end
-
-    it "validates against the schema" do
-      content_item = create(:content_item, :with_content_id, schema_name: "generic")
-      scheduled_publishing = create(:scheduled_publishing_log_entry)
-      presented = ContentItemPresenter.new(content_item, api_url_method, scheduled_publishing: scheduled_publishing).as_json
-      expect(presented.to_json).to be_valid_against_schema("generic")
-    end
-  end
 end


### PR DESCRIPTION
This reverts commit cf1747115f9f00e3586c067fe014f6207ca91da5 (PR #391).

This increased the response times by around 50% on staging, so revert this while we consider how to improve this, e.g. by adding an index to ScheduledPublishingLogEntry.

Response times are 150-200 ms on integration, so the extra query didn't make requests noticeably slower.  But on staging, where response times are around 10 ms, the extra query made a significant difference (the red line marks the deployment to staging):

<img width="1416" alt="screen shot 2018-03-01 at 14 55 03" src="https://user-images.githubusercontent.com/754712/36851587-6f9ac64e-1d61-11e8-842e-7d2d99608d20.png">

Responses are still fast, but since this is the content-store I'd like to at least investigate adding an index to avoid a 50% increase in response times.

https://trello.com/c/pMHR10Rv/85-2-scheduled-publication-reporting