### PR TITLE
Add scheduled publishing delay to the content item response

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -46,7 +46,10 @@ class ContentItemPresenter
       "details" => RESOLVER.resolve(item.details),
     ).tap do |i|
       i["redirects"] = item["redirects"] if i["schema_name"] == "redirect"
-      i["publishing_scheduled_at"] = scheduled_publishing.scheduled_publication_time if scheduled_publishing
+      if scheduled_publishing
+        i["publishing_scheduled_at"] = scheduled_publishing.scheduled_publication_time
+        i["scheduled_publishing_delay_seconds"] = scheduled_publishing.delay_in_milliseconds / 1000
+      end
     end
   end
 

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -93,11 +93,17 @@ describe ContentItemPresenter do
   end
 
   context "when the document was published by the scheduler" do
-    it "includes scheduled publication date" do
+    it "includes scheduled publication date and delay" do
       content_item = create(:content_item)
-      scheduled_publishing = create(:scheduled_publishing_log_entry)
+      scheduled_publishing = Timecop.freeze(Time.new(2018, 3, 1, 9, 32)) do
+        create(:scheduled_publishing_log_entry,
+          scheduled_publication_time: Time.new(2018, 3, 1, 9, 30))
+      end
+
       presented = ContentItemPresenter.new(content_item, api_url_method, scheduled_publishing: scheduled_publishing).as_json
+
       expect(presented["publishing_scheduled_at"]).to eq(scheduled_publishing.scheduled_publication_time)
+      expect(presented["scheduled_publishing_delay_seconds"]).to eq(120)
     end
 
     it "validates against the schema" do


### PR DESCRIPTION
This allows publishers to check the delay without having to compare it to the updated time, which may be misleading if the document has been manually published after the scheduled publishing.

The tests will fail until the new field is added to the content schemas (alphagov/govuk-content-schemas#726).

https://trello.com/c/pMHR10Rv/85-2-scheduled-publication-reporting