### PR TITLE
Remove unused 'user_need_document_supertype' field

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -69,8 +69,6 @@ class ContentItem
   field :search_user_need_document_supertype, type: String, default: ''
   field :user_journey_document_supertype, type: String, default: ''
 
-  # TODO: remove after publishing-api no longer sends this
-  field :user_need_document_supertype, type: String, default: ''
   field :schema_name, type: String
   field :locale, type: String, default: I18n.default_locale.to_s
   field :need_ids, type: Array, default: []

--- a/spec/integration/end_to_end_spec.rb
+++ b/spec/integration/end_to_end_spec.rb
@@ -16,7 +16,6 @@ describe "End-to-end behaviour", type: :request do
     "navigation_document_supertype" => "guidance",
     "search_user_need_document_supertype" => "core",
     "user_journey_document_supertype" => "finding",
-    "user_need_document_supertype" => "guidance",
     "content_purpose_supergroup" => "guidance_and_regulation",
     "content_purpose_subgroup" => "guidance",
     "publishing_app" => "publisher",


### PR DESCRIPTION
This field was removed from govuk_document_types in version 0.2.0: https://github.com/alphagov/govuk_document_types/blob/master/CHANGELOG.md#020

publishing-api is using a later version of this library, so this field is no longer sent to the content-store.