### PR TITLE
Fix scheduled publishing delays by not deleting the publishing intent

### DIFF
--- a/app/models/publish_intent.rb
+++ b/app/models/publish_intent.rb
@@ -55,17 +55,7 @@ class PublishIntent
 
   # Called nightly from a cron job
   def self.cleanup_expired
-    expired = where(:publish_time.lt => PUBLISH_TIME_LEEWAY.ago)
-
-    expired.each do |intent|
-      GovukError.notify(
-        "Publish intent has expired",
-        level: "warning",
-        extra: { base_path: intent.base_path, scheduled_publish_time: intent.publish_time }
-      )
-    end
-
-    expired.delete_all
+    where(:publish_time.lt => PUBLISH_TIME_LEEWAY.ago).delete_all
   end
 
   def base_path_without_root

--- a/spec/integration/submitting_content_item_spec.rb
+++ b/spec/integration/submitting_content_item_spec.rb
@@ -102,13 +102,10 @@ describe "content item write API", type: :request do
       end
 
       it "logs the latency from the expected publish time" do
-        expect(ScheduledPublishingLogEntry).to receive(:create).with(
-          base_path: @data["base_path"],
-          document_type: @data["document_type"],
-          scheduled_publication_time: publish_time
-        ).and_return(ScheduledPublishingLogEntry.new)
-
         put_json "/content/vat-rates", @data
+
+        log_entry = ScheduledPublishingLogEntry.find_by(base_path: "/vat-rates")
+        expect(log_entry.scheduled_publication_time).to be_within(0.001.seconds).of(publish_time)
       end
     end
 

--- a/spec/integration/submitting_content_item_spec.rb
+++ b/spec/integration/submitting_content_item_spec.rb
@@ -92,13 +92,13 @@ describe "content item write API", type: :request do
 
     context "with a publish intent in the past" do
       let(:publish_time) { 10.seconds.ago.to_datetime }
-      before do
+      let!(:publish_intent) do
         create(:publish_intent, base_path: @data["base_path"], publish_time: publish_time)
       end
 
-      it "deletes the publish intent" do
+      it "doesn't delete the publish intent" do
         put_json "/content/vat-rates", @data
-        expect(PublishIntent.count).to eq(0)
+        expect(PublishIntent.first).to eq(publish_intent)
       end
 
       it "logs the latency from the expected publish time" do
@@ -106,6 +106,40 @@ describe "content item write API", type: :request do
 
         log_entry = ScheduledPublishingLogEntry.find_by(base_path: "/vat-rates")
         expect(log_entry.scheduled_publication_time).to be_within(0.001.seconds).of(publish_time)
+      end
+
+      it "only logs the latency on the first publishing" do
+        put_json "/content/vat-rates", @data
+        expect(ScheduledPublishingLogEntry.where(base_path: "/vat-rates").count).to eq(1)
+
+        put_json "/content/vat-rates", @data
+        expect(ScheduledPublishingLogEntry.where(base_path: "/vat-rates").count).to eq(1)
+      end
+
+      it "does not log latency for 'coming soon' notices" do
+        @data["document_type"] = "coming_soon"
+
+        put_json "/content/vat-rates", @data
+        expect(ScheduledPublishingLogEntry.count).to eq(0)
+      end
+    end
+
+    context "with an earlier scheduled publishing" do
+      it "logs the publishing delays for each scheduled publishing" do
+        first_scheduled_time = 1.day.ago.to_datetime
+        publish_intent = create(:publish_intent, base_path: @data["base_path"], publish_time: first_scheduled_time)
+        put_json "/content/vat-rates", @data
+
+        second_scheduled_time = 1.day.ago.to_datetime
+        publish_intent.publish_time = second_scheduled_time
+        publish_intent.save!
+        put_json "/content/vat-rates", @data
+
+        log_entries = ScheduledPublishingLogEntry.where(base_path: "/vat-rates")
+        expect(log_entries.count).to eq(2)
+
+        expect(log_entries[0].scheduled_publication_time).to be_within(0.001.seconds).of(first_scheduled_time)
+        expect(log_entries[1].scheduled_publication_time).to be_within(0.001.seconds).of(second_scheduled_time)
       end
     end
 


### PR DESCRIPTION
Publishing intents were sometimes being deleted incorrectly.

They were supposed to be deleted when the final version of the document was published by the whitehall scheduler, but they were sometimes being deleted slightly early when the "coming soon" version of the document was republished - this was triggered by the publishing of the document's attachments. When an attachment is published, dependency resolution in the publishing-api triggers a publishing of all the linked documents, including the parent publication.

Deleting the publishing intent early causes a bug, because the publishing intent is used to set a short cache expiry in the run-up to the scheduled publishing. If the intent is deleted a few minutes early, the "coming soon" version is served to users with the default cache expiry (30 minutes) which delays the appearance of the published version.

It's safe to leave publishing intents in the DB because they are cleaned up by the nightly `housekeeping:cleanup_publish_intents` rake task.

https://trello.com/c/5Pj1ixOa/112-publishing-intent-bug-is-delaying-scheduled-publications

cc @kevindew @boffbowsh 