### PR TITLE
Make publishing time a DB field and add publishing delay

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -140,14 +140,12 @@ private
       .first
 
     if new_scheduled_publishing?(intent, document_type, latest_log_entry)
-      log_entry = ScheduledPublishingLogEntry.create(
+      latest_log_entry = ScheduledPublishingLogEntry.create(
         base_path: base_path,
         document_type: document_type,
         scheduled_publication_time: intent.publish_time,
       )
-      GovukStatsd.timing("scheduled_publishing.delay_ms", log_entry.delay_in_milliseconds)
-
-      log_entry
+      GovukStatsd.timing("scheduled_publishing.delay_ms", latest_log_entry.delay_in_milliseconds)
     end
 
     latest_log_entry

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -10,20 +10,13 @@ class ContentItemsController < ApplicationController
       PublishIntent.find_by_path(encoded_request_path)
     end
 
-    scheduled_publishing_log = GovukStatsd.time('show.find_scheduled_publishing_log_entry') do
-      ScheduledPublishingLogEntry.latest_with_path(encoded_request_path)
-    end
-
     set_cache_headers(item, intent)
 
     return error_404 unless item
     return redirect_canonical(item) if item.base_path != encoded_request_path
 
     if can_view(item)
-      render(
-        json: ContentItemPresenter.new(item, api_url_method, scheduled_publishing: scheduled_publishing_log),
-        status: http_status(item)
-      )
+      render json: ContentItemPresenter.new(item, api_url_method), status: http_status(item)
     else
       render json_forbidden_response
     end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -18,13 +18,7 @@ class ContentItem
 
     item = ContentItem.new(base_path: base_path)
 
-    publishing_scheduled_at = if log_entry
-      log_entry.scheduled_publication_time
-    else
-      nil
-    end
-
-    item.assign_attributes(attributes.merge(publishing_scheduled_at: publishing_scheduled_at))
+    item.assign_attributes(attributes.merge(scheduled_publication_details(log_entry)))
 
     if item.upsert
       begin
@@ -82,6 +76,7 @@ class ContentItem
   field :first_published_at, type: DateTime
   field :public_updated_at, type: DateTime
   field :publishing_scheduled_at, type: DateTime
+  field :scheduled_publishing_delay_seconds, type: Integer
   field :details, type: Hash, default: {}
   field :publishing_app, type: String
   field :rendering_app, type: String
@@ -220,4 +215,15 @@ private
   def details_is_empty?
     details.nil? || details.values.reject(&:blank?).empty?
   end
+
+  def self.scheduled_publication_details(log_entry)
+    return {} unless log_entry
+
+    {
+      publishing_scheduled_at: log_entry.scheduled_publication_time,
+      scheduled_publishing_delay_seconds: log_entry.delay_in_milliseconds / 1000
+    }
+  end
+
+  private_class_method :scheduled_publication_details
 end

--- a/app/models/scheduled_publishing_log_entry.rb
+++ b/app/models/scheduled_publishing_log_entry.rb
@@ -12,12 +12,6 @@ class ScheduledPublishingLogEntry
     document.delay_in_milliseconds = set_delay_in_milliseconds
   end
 
-  def self.latest_with_path(base_path)
-    ScheduledPublishingLogEntry.where(base_path: base_path)
-      .order_by(scheduled_publication_time: "desc")
-      .first
-  end
-
 private
 
   def set_delay_in_milliseconds

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -25,6 +25,7 @@ class ContentItemPresenter
     publishing_app
     publishing_scheduled_at
     rendering_app
+    scheduled_publishing_delay_seconds
     schema_name
     search_user_need_document_supertype
     title

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -23,6 +23,7 @@ class ContentItemPresenter
     phase
     public_updated_at
     publishing_app
+    publishing_scheduled_at
     rendering_app
     schema_name
     search_user_need_document_supertype

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -33,10 +33,9 @@ class ContentItemPresenter
     publishing_request_id
   ).freeze
 
-  def initialize(item, api_url_method, scheduled_publishing: nil)
+  def initialize(item, api_url_method)
     @item = item
     @api_url_method = api_url_method
-    @scheduled_publishing = scheduled_publishing
   end
 
   def as_json(options = nil)
@@ -46,13 +45,12 @@ class ContentItemPresenter
       "details" => RESOLVER.resolve(item.details),
     ).tap do |i|
       i["redirects"] = item["redirects"] if i["schema_name"] == "redirect"
-      i["publishing_scheduled_at"] = scheduled_publishing.scheduled_publication_time if scheduled_publishing
     end
   end
 
 private
 
-  attr_reader :item, :api_url_method, :scheduled_publishing
+  attr_reader :item, :api_url_method
 
   def links
     ExpandedLinksPresenter.new(item.expanded_links).present

--- a/spec/factories/scheduled_publishing_log_entry.rb
+++ b/spec/factories/scheduled_publishing_log_entry.rb
@@ -1,5 +1,0 @@
-FactoryBot.define do
-  factory :scheduled_publishing_log_entry, class: ScheduledPublishingLogEntry do
-    scheduled_publication_time Time.new(2018, 1, 1)
-  end
-end

--- a/spec/factories/scheduled_publishing_log_entry.rb
+++ b/spec/factories/scheduled_publishing_log_entry.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :scheduled_publishing_log_entry, class: ScheduledPublishingLogEntry do
+    scheduled_publication_time Time.new(2018, 1, 1)
+  end
+end

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -57,6 +57,7 @@ describe "Fetching content items", type: :request do
         first_published_at
         public_updated_at
         publishing_scheduled_at
+        scheduled_publishing_delay_seconds
         updated_at
         rendering_app
         publishing_app

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -56,6 +56,7 @@ describe "Fetching content items", type: :request do
         phase
         first_published_at
         public_updated_at
+        publishing_scheduled_at
         updated_at
         rendering_app
         publishing_app

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -90,27 +90,31 @@ describe ContentItem, type: :model do
       context "with no scheduled publishing log" do
         let(:attributes) { { "schema_name" => "publication" } }
 
-        it "sets no scheduled publishing date" do
+        it "sets no scheduled publishing details" do
           _, item = ContentItem.create_or_replace(@item.base_path, attributes, nil)
 
           expect(item.publishing_scheduled_at).to be_nil
+          expect(item.scheduled_publishing_delay_seconds).to be_nil
         end
       end
 
       context "with a scheduled publishing log entry" do
         let(:attributes) { { "schema_name" => "publication" } }
         let(:scheduled_publication_time) { Time.new(2017, 3, 1, 12, 0) }
+        let(:scheduled_publishing_delay) { 9200 }
         let(:log_entry) {
           build(
             :scheduled_publishing_log_entry,
-            scheduled_publication_time: scheduled_publication_time
+            scheduled_publication_time: scheduled_publication_time,
+            delay_in_milliseconds: 14700
           )
         }
 
-        it "sets the scheduled publishing date" do
+        it "sets the scheduled publishing details" do
           _, item = ContentItem.create_or_replace(@item.base_path, attributes, log_entry)
 
           expect(item.publishing_scheduled_at).to eq(scheduled_publication_time)
+          expect(item.scheduled_publishing_delay_seconds).to eq(14)
         end
       end
     end

--- a/spec/models/scheduled_publishing_log_entry_spec.rb
+++ b/spec/models/scheduled_publishing_log_entry_spec.rb
@@ -15,37 +15,4 @@ describe ScheduledPublishingLogEntry do
       expect(log_entry.delay_in_milliseconds).to be_within(1).of(20000)
     end
   end
-
-  describe "find latest by path" do
-    it "returns nil if there are no log entries for the given path" do
-      log_entry = ScheduledPublishingLogEntry.latest_with_path("/some_page")
-      expect(log_entry).to be_nil
-    end
-
-    it "returns a single log entry" do
-      expected_log_entry = ScheduledPublishingLogEntry.create(
-        base_path: "/a_scheduled_page",
-        scheduled_publication_time: Time.now,
-      )
-      log_entry = ScheduledPublishingLogEntry.latest_with_path("/a_scheduled_page")
-      expect(log_entry).to eq(expected_log_entry)
-    end
-
-    it "returns the log entry for the most recent publishing" do
-      ScheduledPublishingLogEntry.create(
-        base_path: "/some_path",
-        scheduled_publication_time: Time.new(2015, 5, 1),
-      )
-      ScheduledPublishingLogEntry.create(
-        base_path: "/some_path",
-        scheduled_publication_time: Time.new(2018, 3, 20),
-      )
-      ScheduledPublishingLogEntry.create(
-        base_path: "/some_path",
-        scheduled_publication_time: Time.new(2017, 12, 31),
-      )
-      log_entry = ScheduledPublishingLogEntry.latest_with_path("/some_path")
-      expect(log_entry.scheduled_publication_time).to eq(Time.new(2018, 3, 20))
-    end
-  end
 end

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -83,28 +83,4 @@ describe ContentItemPresenter do
       expect(presented.keys).to include("redirects")
     end
   end
-
-  context "when the document was not published by the scheduler" do
-    it "does not include a scheduled publication date" do
-      content_item = create(:content_item)
-      presented = ContentItemPresenter.new(content_item, api_url_method).as_json
-      expect(presented["publishing_scheduled_at"]).to be_nil
-    end
-  end
-
-  context "when the document was published by the scheduler" do
-    it "includes scheduled publication date" do
-      content_item = create(:content_item)
-      scheduled_publishing = create(:scheduled_publishing_log_entry)
-      presented = ContentItemPresenter.new(content_item, api_url_method, scheduled_publishing: scheduled_publishing).as_json
-      expect(presented["publishing_scheduled_at"]).to eq(scheduled_publishing.scheduled_publication_time)
-    end
-
-    it "validates against the schema" do
-      content_item = create(:content_item, :with_content_id, schema_name: "generic")
-      scheduled_publishing = create(:scheduled_publishing_log_entry)
-      presented = ContentItemPresenter.new(content_item, api_url_method, scheduled_publishing: scheduled_publishing).as_json
-      expect(presented.to_json).to be_valid_against_schema("generic")
-    end
-  end
 end

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -83,4 +83,20 @@ describe ContentItemPresenter do
       expect(presented.keys).to include("redirects")
     end
   end
+
+  context "when content has scheduled publishing details" do
+    it "validates against the schema" do
+      content_item = create(
+        :content_item,
+        :with_content_id,
+        schema_name: "generic",
+        publishing_scheduled_at: Time.new(2018, 6, 1, 9, 30),
+        scheduled_publishing_delay_seconds: 130
+      )
+
+      presented = ContentItemPresenter.new(content_item, api_url_method).as_json
+
+      expect(presented.to_json).to be_valid_against_schema("generic")
+    end
+  end
 end


### PR DESCRIPTION
This is an alternative implementation of #396.

- As suggested in #396, move the `publishing_scheduled_at` field to a database field rather than adding it at query time. This saves the content-store from searching the scheduled publishing log entries on every GET request.
- Add a new `scheduled_publishing_delay_seconds` field to allow publishers to check the delay without having to compare it to the updated time, which may be misleading if the document has been manually published after the scheduled publishing.

https://trello.com/c/pMHR10Rv/85-2-scheduled-publication-reporting

cc @cbaines 