### PR TITLE
Group scheduled publishing delay stats by document type

### DIFF
--- a/lib/tasks/data_hygiene/publishing_delay_reporter.rb
+++ b/lib/tasks/data_hygiene/publishing_delay_reporter.rb
@@ -1,13 +1,39 @@
 class Tasks::DataHygiene::PublishingDelayReporter
+  STATISTICS_TYPES = %w(
+    national_statistics
+    official_statistics
+    national_statistics_announcement
+    official_statistics_announcement
+  ).freeze
+
   def report
     now = Time.zone.now
 
     log_entries = ScheduledPublishingLogEntry.where(created_at: (now - 1.day)..now)
-    delays = log_entries.map(&:delay_in_milliseconds)
+    stats_reporter = StatsReporter.new(log_entries)
 
-    unless delays.empty?
-      GovukStatsd.gauge("scheduled_publishing.aggregate.mean_ms", Stats.mean(delays))
-      GovukStatsd.gauge("scheduled_publishing.aggregate.95_percentile_ms", Stats.percentile(delays, 95))
+    STATISTICS_TYPES.each do |stats_type|
+      stats_reporter.report(stats_type) { |entry| entry.document_type == stats_type }
+    end
+
+    stats_reporter.report("other_document_types") { |entry| STATISTICS_TYPES.exclude?(entry.document_type) }
+
+    stats_reporter.report("all_document_types")
+  end
+
+  class StatsReporter
+    attr_reader :log_entries
+
+    def initialize(log_entries)
+      @log_entries = log_entries
+    end
+
+    def report(namespace, &filter)
+      delays = log_entries.select(&filter).map(&:delay_in_milliseconds)
+      return if delays.empty?
+
+      GovukStatsd.gauge("scheduled_publishing.aggregate.#{namespace}.mean_ms", Stats.mean(delays))
+      GovukStatsd.gauge("scheduled_publishing.aggregate.#{namespace}.95_percentile_ms", Stats.percentile(delays, 95))
     end
   end
 end


### PR DESCRIPTION
Report statistics and statistics announcements separately to other publication types:

- It's important for national and official statistics to be published on time, so monitor these separately
- Statistics announcements can have incorrect publishing delays. In most cases they are reported correctly, but sometimes they can appear to be published hours or days late because a publisher has linked an announcement to a statistics set _after_ the statistics are published.

https://trello.com/c/pMHR10Rv/85-2-scheduled-publication-reporting