### PR TITLE
Remove all the code related to need_ids

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -80,7 +80,6 @@ class ContentItem
 
   field :schema_name, type: String
   field :locale, type: String, default: I18n.default_locale.to_s
-  field :need_ids, type: Array, default: []
   field :first_published_at, type: DateTime
   field :public_updated_at, type: DateTime
   field :publishing_scheduled_at, type: DateTime

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -19,7 +19,6 @@ class ContentItemPresenter
     government_document_supertype
     locale
     navigation_document_supertype
-    need_ids
     phase
     public_updated_at
     publishing_app

--- a/doc/content_item_fields.md
+++ b/doc/content_item_fields.md
@@ -77,17 +77,6 @@ The description of the content. This will be used, for example, for the HTML
 meta-description of the content when formatted as HTML, but may also be used
 when linking to the content (eg, in search results).
 
-## `need_ids`
-
-An array of strings. Present in all contexts.
-
-An array of need ids associated with the content. These should be strings
-(though will typically be integers encoded as decimal strings); eg "100001".
-
-Note: currently needs are not published on GOV.UK, so there won't be an entry
-in the content store for them. If this changes in future, the `need_ids` field
-may be replaced by using the `links` field to store this relation.
-
 ## `locale`
 
 The I18n locale code for the content item. Present in all contexts.

--- a/doc/input_examples/frontend-app/quick_answer.json
+++ b/doc/input_examples/frontend-app/quick_answer.json
@@ -12,7 +12,6 @@
   ],
   "redirects": [
   ],
-  "need_ids": ["100535"],
   "locale": "en",
   "public_updated_at": "2014-04-29T09:59:40+01:00",
   "tags": "TBC",

--- a/doc/input_examples/generic.json
+++ b/doc/input_examples/generic.json
@@ -4,7 +4,6 @@
   "title": "Content Title",
   "description": "Short description of content",
   "format": "the format of this content",
-  "need_ids": ["array", "of", "need", "ids"],
   "locale": "en",
   "first_published_at": "2014-01-02T03:04:05+00:00",
   "public_updated_at": "2014-03-04T13:58:11+00:00", // the time the content was updated.

--- a/doc/output_examples/generic.json
+++ b/doc/output_examples/generic.json
@@ -4,7 +4,6 @@
   "title": "Content Title",
   "description": "Short description of content",
   "format": "the format of this content",
-  "need_ids": ["array", "of", "need", "ids"],
   "locale": "en",
   "first_published_at": "2014-01-02T03:04:05+00:00",
   "public_updated_at": "2014-03-04T13:58:11+00:00",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -83,7 +83,6 @@ components:
         - government_document_supertype
         - links
         - navigation_document_supertype
-        - need_ids
         - phase
         - public_updated_at
         - publishing_app
@@ -133,11 +132,6 @@ components:
         navigation_document_supertype:
           type: string
           description: Used to filter pages on the new taxonomy-based navigation pages.
-        need_ids:
-          type: array
-          description: An array of need IDs from Maslow.
-          items:
-            type: string
         phase:
           type: string
           enum: [alpha, beta, live]
@@ -292,7 +286,6 @@ components:
       government_document_supertype: other
       locale: en
       navigation_document_supertype: guidance
-      need_ids: []
       phase: live
       public_updated_at: '2014-12-12T14:55:23.000+00:00'
       publishing_app: publisher

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -14,7 +14,6 @@ describe "Fetching content items", type: :request do
         format: "publication",
         schema_name: "publication",
         document_type: "travel_advice",
-        need_ids: ["100136"],
         public_updated_at: 30.minutes.ago,
         details: {
           "body" => "<div class=\"highlight-answer\">\n<p>The standard <abbr title=\"Value Added Tax\">VAT</abbr> rate is <em>20%</em></p>\n</div>\n",
@@ -50,7 +49,6 @@ describe "Fetching content items", type: :request do
         user_journey_document_supertype
         content_purpose_supergroup
         content_purpose_subgroup
-        need_ids
         locale
         analytics_identifier
         phase
@@ -74,7 +72,6 @@ describe "Fetching content items", type: :request do
         "description" => "Current VAT rates",
         "schema_name" => "publication",
         "document_type" => "travel_advice",
-        "need_ids" => ["100136"],
         "locale" => "en",
         "analytics_identifier" => nil,
         "phase" => "live",

--- a/spec/integration/submitting_content_item_spec.rb
+++ b/spec/integration/submitting_content_item_spec.rb
@@ -11,7 +11,6 @@ describe "content item write API", type: :request do
       "format" => "answer",
       "schema_name" => "answer",
       "document_type" => "answer",
-      "need_ids" => %w(100123 100124),
       "locale" => "en",
       "public_updated_at" => "2014-05-14T13:00:06Z",
       "payload_version" => 1,
@@ -40,7 +39,6 @@ describe "content item write API", type: :request do
       expect(item.title).to eq("VAT rates")
       expect(item.description).to eq("Current VAT rates")
       expect(item.format).to eq("answer")
-      expect(item.need_ids).to eq(%w(100123 100124))
       expect(item.locale).to eq("en")
       expect(item.phase).to eq("live")
       expect(item.public_updated_at).to match_datetime("2014-05-14T13:00:06Z")
@@ -213,7 +211,6 @@ describe "content item write API", type: :request do
           title: "Original title",
           base_path: "/vat-rates",
           format: format,
-          need_ids: ["100321"],
           public_updated_at: Time.zone.parse("2014-03-12T14:53:54Z"),
           details: { "foo" => "bar" }
         )
@@ -230,7 +227,6 @@ describe "content item write API", type: :request do
       put_json "/content/vat-rates", @data
       @item.reload
       expect(@item.title).to eq("VAT rates")
-      expect(@item.need_ids).to eq(%w(100123 100124))
       expect(@item.public_updated_at).to eq(Time.zone.parse("2014-05-14T13:00:06Z"))
       expect(@item.updated_at).to be_within(10.seconds).of(Time.zone.now)
       expect(@item.details).to eq("body" => "<p>Some body text</p>\n")

--- a/spec/integration/submitting_placeholder_item_spec.rb
+++ b/spec/integration/submitting_placeholder_item_spec.rb
@@ -43,7 +43,6 @@ describe "submitting placeholder items to the content store", type: :request do
           :content_item,
           title: "Original title",
           base_path: "/vat-rates",
-          need_ids: ["100321"],
           public_updated_at: Time.zone.parse("2014-03-12T14:53:54Z"),
           details: { "foo" => "bar" }
         )

--- a/spec/integration/submitting_redirect_item_spec.rb
+++ b/spec/integration/submitting_redirect_item_spec.rb
@@ -44,7 +44,6 @@ describe "submitting redirect items to the content store", type: :request do
       @item = create(
         :content_item,
         base_path: "/crb-checks",
-        need_ids: ["100321"],
         public_updated_at: Time.zone.parse("2014-03-12T14:53:54Z"),
         details: { "foo" => "bar" }
       )
@@ -60,7 +59,6 @@ describe "submitting redirect items to the content store", type: :request do
       @item.reload
       expect(@item.format).to eq("redirect")
       expect(@item.title).to be_nil
-      expect(@item.need_ids).to eq([])
       expect(@item.public_updated_at).to eq(Time.zone.parse("2014-05-14T13:00:06Z"))
       expect(@item.updated_at).to be_within(10.seconds).of(Time.zone.now)
       expect(@item.details).to eq({})


### PR DESCRIPTION
The use of this field has been replaced with the `meets_user_needs`
link type.