### PR TITLE
Avoid false positives with publishing-api delay seconds

### DIFF
--- a/spec/integration/submitting_content_item_spec.rb
+++ b/spec/integration/submitting_content_item_spec.rb
@@ -183,7 +183,7 @@ describe "content item write API", type: :request do
 
       content_item = ContentItem.find_by(base_path: "/vat-rates")
       expect(content_item.publishing_scheduled_at).to be_within(0.001.seconds).of(publish_time)
-      expect(content_item.scheduled_publishing_delay_seconds).to eq(25)
+      expect(content_item.scheduled_publishing_delay_seconds).to be_between(24, 25).inclusive
     end
   end
 


### PR DESCRIPTION
I want to avoid more scenarios like the following on CI:

```
  1) content item write API with an earlier scheduled publishing log
entry adds the latency to the content item
     Failure/Error:
expect(content_item.scheduled_publishing_delay_seconds).to eq(25)

       expected: 25
            got: 24

       (compared using ==)
     # ./spec/integration/submitting_content_item_spec.rb:186:in `block
     # (3 levels) in <top (required)>''`

```