### PR TITLE
Add a scheduled publication delay report

### DIFF
--- a/lib/publication_delay_report.rb
+++ b/lib/publication_delay_report.rb
@@ -1,0 +1,48 @@
+class PublicationDelayReport
+  def initialize(file)
+    @file = file
+  end
+
+  def call
+    write_csv
+  end
+
+  def self.call(*args)
+    new(*args).call
+  end
+
+  private_class_method :new
+
+private
+
+  attr_reader :file
+
+  MINIMUM_DELAY_SECONDS = 1
+  CSV_HEADERS = ["URL", "Document Type", "Scheduled Time", "Delay (seconds)"].freeze
+
+  def write_csv
+    CSV(file, headers: CSV_HEADERS, write_headers: true) do |csv|
+      delayed_content_items.each do |content_item|
+        csv << csv_row(content_item)
+      end
+    end
+  end
+
+  def csv_row(content_item)
+    [
+      content_item.base_path,
+      content_item.document_type,
+      content_item.publishing_scheduled_at,
+      content_item.scheduled_publishing_delay_seconds,
+    ]
+  end
+
+  def delayed_content_items
+    ContentItem
+      .where(
+        :scheduled_publishing_delay_seconds.gt => MINIMUM_DELAY_SECONDS,
+        :publishing_scheduled_at.gt => 7.days.ago,
+      )
+      .order(publishing_scheduled_at: :asc)
+  end
+end

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -1,0 +1,6 @@
+namespace :report do
+  desc "Run a publication delay report of the last week"
+  task publication_delay_report: :environment do
+    PublicationDelayReport.call($stdout)
+  end
+end

--- a/spec/lib/publication_delay_report_spec.rb
+++ b/spec/lib/publication_delay_report_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+describe PublicationDelayReport do
+  describe ".call" do
+    subject { described_class.call($stdout) }
+
+    context "with a delayed publication a day ago" do
+      before do
+        create(
+          :content_item,
+          document_type: "test",
+          publishing_scheduled_at: 1.day.ago,
+          scheduled_publishing_delay_seconds: 10,
+        )
+      end
+
+      it "should include the publication in the CSV file" do
+        expect { subject }.to output(/test/).to_stdout
+      end
+    end
+
+    context "with a delayed publication a month ago" do
+      before do
+        create(
+          :content_item,
+          document_type: "test",
+          publishing_scheduled_at: 30.days.ago,
+          scheduled_publishing_delay_seconds: 10,
+        )
+      end
+
+      it "should not include the publication in the CSV file" do
+        expect { subject }.to_not output(/test/).to_stdout
+      end
+    end
+  end
+end


### PR DESCRIPTION
This report shows content items with a delay in the scheduled publication for the last week. It outputs its results as a CSV file to standard output. The plan is for this to be automatically sent to various people every week.

[Trello Card](https://trello.com/c/rkOiRFUV/128-run-the-statistics-publication-delay-report-weekly-and-send-it-to-alice-2)