### PR TITLE
Set created_at timestamps on Content Items

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,6 +1,6 @@
 class ContentItem
   include Mongoid::Document
-  include Mongoid::Timestamps::Updated
+  include Mongoid::Timestamps
 
   def self.revert(previous_item:, item:)
     item.remove unless previous_item
@@ -18,7 +18,15 @@ class ContentItem
 
     item = ContentItem.new(base_path: base_path)
 
-    item.assign_attributes(attributes.merge(scheduled_publication_details(log_entry)))
+    # This doesn't seem to get set correctly on an upsert so this is to
+    # maintain it
+    created_at = previous_item ? previous_item.created_at : Time.now.utc
+
+    item.assign_attributes(
+      attributes
+        .merge(scheduled_publication_details(log_entry))
+        .merge(created_at: created_at)
+    )
 
     if item.upsert
       begin

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -9,6 +9,18 @@ describe ContentItem, type: :model do
         .to receive(:check_availability!)
     end
 
+    it "sets updated_at and created_at timestamps" do
+      _, item = ContentItem.create_or_replace(@item.base_path, { schema_name: "publication" }, nil)
+      expect(item.created_at).to be_kind_of(ActiveSupport::TimeWithZone)
+      expect(item.updated_at).to be_kind_of(ActiveSupport::TimeWithZone)
+    end
+
+    it "maintains the created_at value from previous item" do
+      @item.save
+      _, item = ContentItem.create_or_replace(@item.base_path, { schema_name: "publication" }, nil)
+      expect(item.reload.created_at).to eq(@item.reload.created_at)
+    end
+
     describe "exceptions" do
       context "when unknown attributes are provided" do
         let(:attributes) { { "foo" => "foo", "bar" => "bar" } }


### PR DESCRIPTION
Trello: https://trello.com/c/eFxqPwNP/115-more-diagnostic-information-to-diagnose-404-scheduled-publishing-problems-2

This is to provide more visibility about when they are actually created
which can help with determining the point a route was active on GOV.UK
and be useful in debugging situations where it would previously 404 and
it was not known why.