### PR TITLE
Re-apply 'primary preferred' read mode

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -30,3 +30,5 @@ production:
         server_selection_timeout: 5
         write:
           w: <%= ENV['MONGO_WRITE_CONCERN'] || 'majority' %>
+        read:
+          mode: :primary_preferred


### PR DESCRIPTION
Removed in https://github.com/alphagov/content-store/commit/e7383e24e4dd6a733f04538659ac379c9151e523

The default read mode for mongodb is primary:

_By default, an application directs its read operations to the primary member in a replica set._

However in a scenario where the primary fails we should be able to read from the secondaries until the primary is healthy.
This would allow frontend applications to respond with albeit slightly stale data rather than 500s.

Further reading:
https://docs.mongodb.com/manual/core/read-preference/

Slightly related to https://trello.com/c/cF8wkUuJ/174-investigate-mongo-replication-on-staging-failing-every-morning

DNM because we should test this config on integration first.