### PR TITLE
Turn brakeman on

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ library("govuk")
 
 node("mongodb-2.4") {
   govuk.buildProject(
+    brakeman: true,
     extraParameters: [
       stringParam(
         name: "PUBLISHING_API_PACT_BRANCH",

--- a/lib/route_consistency_checker.rb
+++ b/lib/route_consistency_checker.rb
@@ -63,8 +63,7 @@ private
     nil
   end
 
-  def find_content_item_for_field(path, kind)
-    items = ContentItem.where("#{kind}s.path" => path).entries
+  def first_item_or_nil(items, kind)
     if items.length > 1
       errors[path] << "Multiple content items returned for #{kind}."
       return nil
@@ -73,11 +72,13 @@ private
   end
 
   def find_content_item_by_route(path)
-    find_content_item_for_field(path, "route")
+    items = ContentItem.where("routes" => path).entries
+    first_item_or_nil(items, "route")
   end
 
   def find_content_item_by_redirect(path)
-    find_content_item_for_field(path, "redirect")
+    items = ContentItem.where("redirects" => path).entries
+    first_item_or_nil(items, "redirect")
   end
 
   def find_content_item(path)


### PR DESCRIPTION
In order to turn brakeman on we need to either fix the brakeman warnings or include an ignore file for the warnings we deem safe. I've chosen to fix the warnings in this instance because I think the code change is preferable to introducing a `brakeman.ignore` file.

The current implementation of `RouteConsistencyChecker` relies on string interpolation for a `WHERE` clause as follows:

```
def find_content_item_for_field(path, kind)
  ContentItem.where("#{kind}s.path" => path).entries
...
```

Only two methods call `find_content_item_for_field` and both of these send an explicit string that has not come from outside the class itself (one sends the string `route` and the other `redirect`). This method, as it stands, with the code that calls it, is safe.

Refactoring the code makes it slightly more verbose and somewhat less DRY. However, I think the benefit here outweighs the cost. This was the only instance of brakeman warning and the code is still very readable.

Also rename `find_content_item_for_field` now that the ActiveRecord query has been moved out of it.

[Trello](https://trello.com/c/JyrOAef3/560-fix-sql-injection-vulnerabilities-in-govuk-applications)