### PR TITLE
Remove housekeeping task which clears publishing intents

### DIFF
--- a/app/models/publish_intent.rb
+++ b/app/models/publish_intent.rb
@@ -53,11 +53,6 @@ class PublishIntent
     ContentItem.where(base_path: self.base_path).first
   end
 
-  # Called nightly from a cron job
-  def self.cleanup_expired
-    where(:publish_time.lt => PUBLISH_TIME_LEEWAY.ago).delete_all
-  end
-
   def base_path_without_root
     base_path&.sub(%r{^/}, "")
   end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -6,10 +6,6 @@ env :PATH, '/usr/local/bin:/usr/bin:/bin'
 set :output, error: 'log/cron.error.log', standard: 'log/cron.log'
 job_type :rake, "cd :path && govuk_setenv content-store bundle exec rake :task :output"
 
-every 1.day, at: "2:00 am" do
-  rake "housekeeping:cleanup_publish_intents"
-end
-
 every 1.day, at: "2:15 am" do
   rake "publishing_delay_report:report_delays"
 end

--- a/lib/tasks/housekeeping.rake
+++ b/lib/tasks/housekeeping.rake
@@ -1,6 +1,0 @@
-namespace :housekeeping do
-  desc "Delete any publish intents in the past"
-  task cleanup_publish_intents: :environment do
-    PublishIntent.cleanup_expired
-  end
-end

--- a/spec/models/publish_intent_spec.rb
+++ b/spec/models/publish_intent_spec.rb
@@ -152,31 +152,4 @@ describe PublishIntent, type: :model do
       ])
     end
   end
-
-  describe ".cleanup_expired" do
-    before :each do
-      create(:publish_intent, publish_time: 3.days.ago)
-      create(:publish_intent, publish_time: 2.days.ago)
-      create(:publish_intent, publish_time: 1.hour.ago)
-      create(:publish_intent, publish_time: 10.minutes.from_now)
-      create(:publish_intent, publish_time: 10.days.from_now)
-      create(:publish_intent, publish_time: 1.year.from_now)
-    end
-
-    it "deletes all publish_intents with publish_at in the past" do
-      PublishIntent.cleanup_expired
-
-      expect(PublishIntent.count).to eq(3)
-      expect(PublishIntent.where(:publish_time.gte => Time.zone.now).count).to eq(3)
-    end
-
-    it "does not delete very recently passed intents" do
-      recent = create(:publish_intent, publish_time: 30.seconds.ago)
-
-      PublishIntent.cleanup_expired
-
-      expect(PublishIntent.where(base_path: recent.base_path).first).to be
-      expect(PublishIntent.count).to eq(4)
-    end
-  end
 end


### PR DESCRIPTION
Publishing intents are automatically deleted now as soon as the content item is published.

In https://github.com/alphagov/content-store/pull/392 we added a Sentry alert to tell us if this task actually does anything. The error has never appeared in Sentry so it's fine to remove this task.

[Trello Card](https://trello.com/c/1M1JNno5/158-review-and-remove-content-store-housekeeping-task)