### PR TITLE
Set Mongo client to prefer reads from secondaries

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -31,4 +31,4 @@ production:
         write:
           w: <%= ENV['MONGO_WRITE_CONCERN'] || 'majority' %>
         read:
-          mode: :primary_preferred
+          mode: :secondary_preferred


### PR DESCRIPTION
This will spread the read requests across the secondary Mongo instances
automatically and spare the primary from taking all the load as is
happening currently. This should obviate the need to increase the sizes
of the Mongo instances and should also improve performance.