### PR TITLE
Don't expose supertypes in content items

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -73,6 +73,8 @@ class ContentItem
   field :description, type: Hash, default: { "value" => nil }
   field :format, type: String
   field :document_type, type: String
+
+  # Supertypes are deprecated, but are still sent by the publishing-api.
   field :content_purpose_document_supertype, type: String, default: ''
   field :content_purpose_subgroup, type: String, default: ''
   field :content_purpose_supergroup, type: String, default: ''

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -10,15 +10,9 @@ class ContentItemPresenter
     analytics_identifier
     base_path
     content_id
-    content_purpose_document_supertype
-    content_purpose_supergroup
-    content_purpose_subgroup
     document_type
-    email_document_supertype
     first_published_at
-    government_document_supertype
     locale
-    navigation_document_supertype
     phase
     public_updated_at
     publishing_app
@@ -26,10 +20,8 @@ class ContentItemPresenter
     rendering_app
     scheduled_publishing_delay_seconds
     schema_name
-    search_user_need_document_supertype
     title
     updated_at
-    user_journey_document_supertype
     withdrawn_notice
     publishing_request_id
   ).freeze

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -41,14 +41,6 @@ describe "Fetching content items", type: :request do
         description
         schema_name
         document_type
-        content_purpose_document_supertype
-        email_document_supertype
-        government_document_supertype
-        navigation_document_supertype
-        search_user_need_document_supertype
-        user_journey_document_supertype
-        content_purpose_supergroup
-        content_purpose_subgroup
         locale
         analytics_identifier
         phase


### PR DESCRIPTION
We're no longer using supertypes embedded in content items and search indices, because changing anything requires republishing of all the affected content. This makes sure that we don't expose the supertypes in the content item.

The data still is persisted in the database, we'll need to remove the supertypes from the publishing-api first.

This will make https://github.com/alphagov/govuk-content-schemas/pull/852 pass.

https://trello.com/c/hp5BJD2i