### PR TITLE
Find gsi-family domain references in content

### DIFF
--- a/lib/find_gsi_domain_references.rb
+++ b/lib/find_gsi_domain_references.rb
@@ -1,0 +1,60 @@
+require 'csv'
+
+class FindGsiDomainReferences
+  CSV_HEADERS = ["Title", "URL", "Publishing application", "Publishing organisation", "Format", "Domain", "Content ID"].freeze
+
+  def call
+    write_csv
+  end
+
+  def self.call(*args)
+    new(*args).call
+  end
+
+  private_class_method :new
+
+private
+
+  def write_csv
+    CSV.open("#{Rails.root}/tmp/gsi_domain_content_items.csv", 'wb') do |csv|
+      csv << CSV_HEADERS
+
+      domains = %w(gsi gse gcsx gsx)
+
+      domains.each do |domain|
+        puts "Searching for #{domain}.gov.uk..."
+
+        domain_content_items = content_items(/#{domain}\.gov\.uk/)
+
+        domain_content_items.each do |content_item|
+          csv << csv_row(content_item, domain)
+        end
+
+        puts "Found #{domain_content_items.count} items containing #{domain}.gov.uk"
+      end
+    end
+
+    puts 'Finished searching'
+    puts "CSV file at #{Rails.root}/tmp/gsi_domain_content_items.csv"
+  end
+
+  def csv_row(content_item, domain)
+    [
+      content_item.try(:title),
+      content_item.try(:base_path),
+      content_item.try(:publishing_app),
+      content_item.expanded_links.dig(:organisations, 0, :title),
+      content_item.try(:document_type),
+      domain,
+      content_item.try(:content_id)
+    ]
+  end
+
+  def content_items(domain)
+    ContentItem.where('details.body': domain).entries +
+      ContentItem.where('details.parts.body': domain).entries +
+      ContentItem.where('details.email_addresses.email': domain).entries +
+      ContentItem.where('details.more_info_contact_form': domain).entries +
+      ContentItem.where('details.more_info_email_address': domain).entries
+  end
+end

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -3,4 +3,9 @@ namespace :report do
   task publication_delay_report: :environment do
     PublicationDelayReport.call($stdout)
   end
+
+  desc "Find all references to GSI/GSE/GCSX/GSX domains"
+  task find_gsi_domain_references: :environment do
+    FindGsiDomainReferences.call
+  end
 end


### PR DESCRIPTION
The government is migrating away from GSI domains by March 2019.

This script searches for all references to gsi-family domains (gsi/gse/gcsx/gsx) and outputs them to a CSV file.

This output can be used to automatically or manually change the references from the relevant publishing apps.

Built on top of work by @deborahchua 

Trello: https://trello.com/c/jfpoEh55/698-next-steps-on-changing-gsigovuk-domains-to-non-gsigovuk-in-static-and-dynamic-content-on-govuk

Sample console output:

```
vagrant@development:/var/govuk/content-store$ bundle exec rake report:find_gsi_domain_references
Searching for gsi.gov.uk...
Found 11458 items containing gsi.gov.uk
Searching for gse.gov.uk...
Found 17 items containing gse.gov.uk
Searching for gcsx.gov.uk...
Found 12 items containing gcsx.gov.uk
Searching for gsx.gov.uk...
Found 15 items containing gsx.gov.uk
Finished searching
CSV file at /var/govuk/content-store/tmp/gsi_domain_content_items.csv
```