### PR TITLE
Check content hash for more fields for GSI email addresses

### DIFF
--- a/lib/find_gsi_domain_references.rb
+++ b/lib/find_gsi_domain_references.rb
@@ -59,7 +59,9 @@ private
       .or('details.nodes.body.content': domain)
       .or('details.email_addresses.email': domain)
       .or('details.introductory_paragraph': domain)
+      .or('details.introductory_paragraph.content': domain)
       .or('details.more_information': domain)
+      .or('details.more_information.content': domain)
       .or('details.more_info_contact_form': domain)
       .or('details.more_info_email_address': domain).entries
   end


### PR DESCRIPTION
This commit checks the `content` hash for the `details.introductory_paragraph` and `details.more_information` fields when search for GSI-family email addresses.