### PR TITLE
Add Rake tasks for registering routes

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -201,8 +201,6 @@ class ContentItem
     base_path&.sub(%r{^/}, "")
   end
 
-protected
-
   def route_set
     @route_set ||= RouteSet.from_content_item(self)
   end

--- a/lib/tasks/routes.rake
+++ b/lib/tasks/routes.rake
@@ -1,0 +1,13 @@
+namespace :routes do
+  desc "Register routes for a content item"
+  task :register, %w(base_path) => %w(environment) do |_, args|
+    item = ContentItem.find_by!(base_path: args[:base_path])
+    item.route_set.register!
+  end
+
+  desc "Delete routes for a content item"
+  task :delete, %w(base_path) => %w(environment) do |_, args|
+    item = ContentItem.find_by!(base_path: args[:base_path])
+    item.route_set.delete!
+  end
+end


### PR DESCRIPTION
In the unlikely event that registering routes with the router failed but the content-store believes that it succeeded, it will refuse to send the routes again even if the document is represented. This is because it caches the routes from the previous item and compares.

These Rake tasks bypass these checks allowing routes to be registered with the router.

[Trello Card](https://trello.com/c/gnK6FhQb/828-gather-current-convenience-scripts-rake-tasks-that-might-help-during-brexit-publishing)