### PR TITLE
Allow test database to be specified with ENV

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -11,7 +11,7 @@ development:
 test:
   clients:
     default:
-      uri: mongodb://localhost/content_store_test
+      uri: <%= ENV['TEST_MONGODB_URI'] || 'mongodb://localhost/content_store_test' %>
       options:
         write:
           w: 1


### PR DESCRIPTION
We currently have to override `mongoid.yml` in govuk-docker, because the test database URL is hard coded.