### PR TITLE
Remove hashdiff

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gem 'mongo', '2.4.3'
 gem 'mongoid', '6.2.1'
 gem "mongoid_rails_migrations", git: "https://github.com/alphagov/mongoid_rails_migrations", branch: "avoid-calling-bundler-require-in-library-code-v1.1.0-plus-mongoid-v5-fix"
 
-gem 'hashdiff', require: false
 gem 'uuidtools', '2.1.5'
 gem 'whenever', '~> 1.0.0', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -362,7 +362,6 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (~> 1.6)
   govuk-lint
   govuk_app_config (~> 1.20)
-  hashdiff
   mongo (= 2.4.3)
   mongoid (= 6.2.1)
   mongoid_rails_migrations!
@@ -379,4 +378,4 @@ DEPENDENCIES
   whenever (~> 1.0.0)
 
 BUNDLED WITH
-   1.17.1
+   1.17.2


### PR DESCRIPTION
This was added in 9b2a2bd4d417da2a6a6f0976f9b4f28bb4060696 and the task was removed in 1e0efdfc9b3f26ffcedf0611ce7a1164302ef3db but the dependency was left in.

Alternative to #591.