### PR TITLE
Support access limiting by user organisation

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -171,16 +171,18 @@ class ContentItem
     rendering_app || "government-frontend"
   end
 
-  def viewable_by_user_id?(user_id)
-    auth_user_ids.include?(user_id)
-  end
-
-  def viewable_by_bypass_id?(bypass_id)
+  def valid_bypass_id?(bypass_id)
     auth_bypass_ids.include?(bypass_id)
   end
 
+  def user_access?(user_id: nil, user_organisation_id: nil)
+    return true if auth_user_ids.empty? && auth_organisation_ids.empty?
+
+    auth_user_ids.include?(user_id) || auth_organisation_ids.include?(user_organisation_id)
+  end
+
   def access_limited?
-    auth_bypass_ids.present? || auth_user_ids.present?
+    auth_user_ids.any? || auth_organisation_ids.any?
   end
 
   def register_routes(previous_item: nil)
@@ -223,6 +225,10 @@ private
 
   def auth_user_ids
     access_limited.fetch('users', [])
+  end
+
+  def auth_organisation_ids
+    access_limited.fetch('organisations', [])
   end
 
   def auth_bypass_ids

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -171,12 +171,16 @@ class ContentItem
     rendering_app || "government-frontend"
   end
 
-  def viewable_by?(user_uid)
-    authorised_user_uids.empty? || authorised_user_uids.include?(user_uid)
+  def viewable_by_user_id?(user_id)
+    auth_user_ids.include?(user_id)
   end
 
-  def includes_auth_bypass_id?(auth_bypass_id)
-    auth_bypass_ids.include?(auth_bypass_id)
+  def viewable_by_bypass_id?(bypass_id)
+    auth_bypass_ids.include?(bypass_id)
+  end
+
+  def access_limited?
+    auth_bypass_ids.present? || auth_user_ids.present?
   end
 
   def register_routes(previous_item: nil)
@@ -217,7 +221,7 @@ private
     true
   end
 
-  def authorised_user_uids
+  def auth_user_ids
     access_limited.fetch('users', [])
   end
 

--- a/spec/factories/content_item.rb
+++ b/spec/factories/content_item.rb
@@ -81,6 +81,15 @@ FactoryBot.define do
           }
         }
       end
+
+      trait :by_auth_bypass_id_and_user_id do
+        access_limited {
+          {
+            "auth_bypass_ids" => ["85aa9fd5-c514-4964-b931-5b597e4ec668"],
+            "users" => ["M6GdNZggrbGiJrLjMSbKqA", "f17250b0-7540-0131-f036-005056030202"],
+          }
+        }
+      end
     end
   end
 end

--- a/spec/factories/content_item.rb
+++ b/spec/factories/content_item.rb
@@ -74,6 +74,14 @@ FactoryBot.define do
         }
       end
 
+      trait :by_org_id do
+        access_limited {
+          {
+            "organisations" => %w(f17250b0-7540-0131-f036-005056030202),
+          }
+        }
+      end
+
       trait :by_auth_bypass_id do
         access_limited {
           {
@@ -85,8 +93,17 @@ FactoryBot.define do
       trait :by_auth_bypass_id_and_user_id do
         access_limited {
           {
-            "auth_bypass_ids" => ["85aa9fd5-c514-4964-b931-5b597e4ec668"],
-            "users" => ["M6GdNZggrbGiJrLjMSbKqA", "f17250b0-7540-0131-f036-005056030202"],
+            "auth_bypass_ids" => %w(85aa9fd5-c514-4964-b931-5b597e4ec668),
+            "users" => %w(M6GdNZggrbGiJrLjMSbKqA f17250b0-7540-0131-f036-005056030202),
+          }
+        }
+      end
+
+      trait :by_auth_bypass_id_and_org_id do
+        access_limited {
+          {
+            "auth_bypass_ids" => %w(85aa9fd5-c514-4964-b931-5b597e4ec668),
+            "organisations" => %w(f17250b0-7540-0131-f036-005056030202),
           }
         }
       end

--- a/spec/integration/access_limited_spec.rb
+++ b/spec/integration/access_limited_spec.rb
@@ -1,79 +1,130 @@
 require 'rails_helper'
 
-describe "Fetching an access-limited by user-id content item", type: :request do
-  let(:access_limited_content_item) { create(:access_limited_content_item, :by_user_id) }
-  let(:authorised_user_uid) { access_limited_content_item.access_limited['users'].first }
+describe "Fetching an access-limited by content item", type: :request do
+  context "access limited by user id" do
+    let(:access_limited_content_item) { create(:access_limited_content_item, :by_user_id) }
+    let(:authorised_user_uid) { access_limited_content_item.access_limited['users'].first }
+    context "request without an authentication header" do
+      it "returns a 403 (Forbidden) response" do
+        get "/content/#{access_limited_content_item.base_path}"
 
-  context "request without an authentication header" do
-    it "returns a 403 (Forbidden) response" do
-      get "/content/#{access_limited_content_item.base_path}"
+        json = JSON.parse(response.body)
 
-      json = JSON.parse(response.body)
-
-      expect(response.status).to eq(403)
-      expect(json["errors"]["type"]).to eq("access_forbidden")
-      expect(json["errors"]["code"]).to eq("403")
-    end
-  end
-
-  context "request with an authorised user ID specified in the header" do
-    before do
-      get "/content/#{access_limited_content_item.base_path}",
-          params: {}, headers: { 'X-Govuk-Authenticated-User' => authorised_user_uid }
+        expect(response.status).to eq(403)
+        expect(json["errors"]["type"]).to eq("access_forbidden")
+        expect(json["errors"]["code"]).to eq("403")
+      end
     end
 
-    it "returns the details for the requested item" do
-      expect(response.status).to eq(200)
-      expect(response.content_type).to eq("application/json")
+    context "request with an authorised user ID specified in the header" do
+      before do
+        get "/content/#{access_limited_content_item.base_path}",
+            params: {}, headers: { 'X-Govuk-Authenticated-User' => authorised_user_uid }
+      end
 
-      data = JSON.parse(response.body)
-      expect(data['title']).to eq(access_limited_content_item.title)
-    end
-
-    it "marks the cache-control as private" do
-      expect(cache_control["private"]).to eq(true)
-    end
-  end
-
-  context "request with an unauthorised user ID specified in the header" do
-    it "returns a 403 (Forbidden) response" do
-      get "/content/#{access_limited_content_item.base_path}",
-          params: {}, headers: { 'X-Govuk-Authenticated-User' => 'unauthorised-user' }
-
-      json = JSON.parse(response.body)
-
-      expect(response.status).to eq(403)
-      expect(json["errors"]["type"]).to eq("access_forbidden")
-      expect(json["errors"]["code"]).to eq("403")
-    end
-  end
-
-  context "with a auth bypass ID specified in the header" do
-    let(:access_limited_content_item) { create(:access_limited_content_item, :by_auth_bypass_id) }
-    let(:auth_bypass_id) { access_limited_content_item.access_limited["auth_bypass_ids"].first }
-
-    before do
-      get "/content/#{access_limited_content_item.base_path}",
-          params: {}, headers: { 'Govuk-Auth-Bypass-Id' => auth_bypass_id }
-    end
-
-    it "marks the cache-control as private" do
-      expect(cache_control["private"]).to eq(true)
-    end
-
-    context "if the auth bypass ID matches" do
-      it "returns the requested item" do
+      it "returns the details for the requested item" do
         expect(response.status).to eq(200)
         expect(response.content_type).to eq("application/json")
 
         data = JSON.parse(response.body)
         expect(data['title']).to eq(access_limited_content_item.title)
       end
+
+      it "marks the cache-control as private" do
+        expect(cache_control["private"]).to eq(true)
+      end
     end
 
-    context "if the auth bypass ID does not match" do
-      let(:auth_bypass_id) { SecureRandom.uuid }
-      it "returns a 403 Forbidden response" do
+    context "request with an unauthorised user ID specified in the header" do
+      it "returns a 403 (Forbidden) response" do
+        get "/content/#{access_limited_content_item.base_path}",
+            params: {}, headers: { 'X-Govuk-Authenticated-User' => 'unauthorised-user' }
+
+        json = JSON.parse(response.body)
+
+        expect(response.status).to eq(403)
+        expect(json["errors"]["type"]).to eq("access_forbidden")
+        expect(json["errors"]["code"]).to eq("403")
+      end
+    end
+
+    context "request with an invalid user ID specified in the header" do
+      it "returns a 403 (Forbidden) response" do
+        get "/content/#{access_limited_content_item.base_path}",
+            params: {}, headers: { 'X-Govuk-Authenticated-User' => 'invalid' }
+
+        json = JSON.parse(response.body)
+
+        expect(response.status).to eq(403)
+        expect(json["errors"]["type"]).to eq("access_forbidden")
+        expect(json["errors"]["code"]).to eq("403")
+      end
+    end
+
+    context "request has valid user ID but invalid bypass ID" do
+      let(:access_limited_content_item) { create(:access_limited_content_item, :by_auth_bypass_id_and_user_id) }
+      before do
+        get "/content/#{access_limited_content_item.base_path}",
+            params: {}, headers: {
+              'X-Govuk-Authenticated-User' => authorised_user_uid,
+              'Govuk-Auth-Bypass-Id' => "fake id"
+             }
+      end
+
+      it "returns the details for the requested item" do
+        expect(response.status).to eq(200)
+        expect(response.content_type).to eq("application/json")
+
+        data = JSON.parse(response.body)
+        expect(data['title']).to eq(access_limited_content_item.title)
+      end
+
+      it "marks the cache-control as private" do
+        expect(cache_control["private"]).to eq(true)
+      end
+    end
+  end
+
+  context "access limited by bypass id" do
+    let(:access_limited_content_item) { create(:access_limited_content_item, :by_auth_bypass_id) }
+    let(:auth_bypass_id) { access_limited_content_item.access_limited["auth_bypass_ids"].first }
+
+    context "request without a bypass header" do
+      it "returns a 403 (Forbidden) response" do
+        get "/content/#{access_limited_content_item.base_path}"
+
+        json = JSON.parse(response.body)
+
+        expect(response.status).to eq(403)
+        expect(json["errors"]["type"]).to eq("access_forbidden")
+        expect(json["errors"]["code"]).to eq("403")
+      end
+    end
+
+    context "request with an authorised bypass ID specified in the header" do
+      before do
+        get "/content/#{access_limited_content_item.base_path}",
+            params: {}, headers: { 'Govuk-Auth-Bypass-Id' => auth_bypass_id }
+      end
+
+      it "returns the details for the requested item" do
+        expect(response.status).to eq(200)
+        expect(response.content_type).to eq("application/json")
+
+        data = JSON.parse(response.body)
+        expect(data['title']).to eq(access_limited_content_item.title)
+      end
+
+      it "marks the cache-control as private" do
+        expect(cache_control["private"]).to eq(true)
+      end
+    end
+
+    context "request with an unauthorised bypass ID specified in the header" do
+      it "returns a 403 (Forbidden) response" do
+        get "/content/#{access_limited_content_item.base_path}",
+            params: {}, headers: { 'Govuk-Auth-Bypass-Id' => SecureRandom.uuid }
+
         json = JSON.parse(response.body)
 
         expect(response.status).to eq(403)

--- a/spec/integration/access_limited_spec.rb
+++ b/spec/integration/access_limited_spec.rb
@@ -71,6 +71,56 @@ describe "Fetching an access-limited by content item", type: :request do
              }
       end
 
+      it "returns a 403 (Forbidden) response" do
+        json = JSON.parse(response.body)
+
+        expect(response.status).to eq(403)
+        expect(json["errors"]["type"]).to eq("access_forbidden")
+        expect(json["errors"]["code"]).to eq("403")
+      end
+    end
+
+    context "request has an invalid user ID and invalid bypass ID" do
+      let(:access_limited_content_item) { create(:access_limited_content_item, :by_auth_bypass_id_and_user_id) }
+      before do
+        get "/content/#{access_limited_content_item.base_path}",
+            params: {}, headers: {
+              'X-Govuk-Authenticated-User' => "fake user id",
+              'Govuk-Auth-Bypass-Id' => "fake bypass id"
+             }
+      end
+
+      it "returns a 403 response" do
+        json = JSON.parse(response.body)
+
+        expect(response.status).to eq(403)
+        expect(json["errors"]["type"]).to eq("access_forbidden")
+        expect(json["errors"]["code"]).to eq("403")
+      end
+    end
+  end
+
+  context "access limited by org id" do
+    let(:access_limited_content_item) { create(:access_limited_content_item, :by_org_id) }
+    let(:auth_org_id) { access_limited_content_item.access_limited['organisations'].first }
+    context "request without an authentication header" do
+      it "returns a 403 (Forbidden) response" do
+        get "/content/#{access_limited_content_item.base_path}"
+
+        json = JSON.parse(response.body)
+
+        expect(response.status).to eq(403)
+        expect(json["errors"]["type"]).to eq("access_forbidden")
+        expect(json["errors"]["code"]).to eq("403")
+      end
+    end
+
+    context "request with an authorised org ID specified in the header" do
+      before do
+        get "/content/#{access_limited_content_item.base_path}",
+            params: {}, headers: { 'X-Govuk-Authenticated-User-Organisation' => auth_org_id }
+      end
+
       it "returns the details for the requested item" do
         expect(response.status).to eq(200)
         expect(response.content_type).to eq("application/json")
@@ -83,15 +133,11 @@ describe "Fetching an access-limited by content item", type: :request do
         expect(cache_control["private"]).to eq(true)
       end
     end
-  end
 
-  context "access limited by bypass id" do
-    let(:access_limited_content_item) { create(:access_limited_content_item, :by_auth_bypass_id) }
-    let(:auth_bypass_id) { access_limited_content_item.access_limited["auth_bypass_ids"].first }
-
-    context "request without a bypass header" do
+    context "request with an unauthorised org ID specified in the header" do
       it "returns a 403 (Forbidden) response" do
-        get "/content/#{access_limited_content_item.base_path}"
+        get "/content/#{access_limited_content_item.base_path}",
+            params: {}, headers: { 'X-Govuk-Authenticated-User-Organisation' => 'unauthorised-org' }
 
         json = JSON.parse(response.body)
 
@@ -100,6 +146,45 @@ describe "Fetching an access-limited by content item", type: :request do
         expect(json["errors"]["code"]).to eq("403")
       end
     end
+
+    context "request with an invalid org ID specified in the header" do
+      it "returns a 403 (Forbidden) response" do
+        get "/content/#{access_limited_content_item.base_path}",
+            params: {}, headers: { 'X-Govuk-Authenticated-User-Organisation' => 'invalid' }
+
+        json = JSON.parse(response.body)
+
+        expect(response.status).to eq(403)
+        expect(json["errors"]["type"]).to eq("access_forbidden")
+        expect(json["errors"]["code"]).to eq("403")
+      end
+    end
+
+    context "request has valid org ID but invalid bypass ID" do
+      let(:access_limited_content_item) { create(:access_limited_content_item, :by_auth_bypass_id_and_org_id) }
+      before do
+        get "/content/#{access_limited_content_item.base_path}",
+            params: {}, headers: {
+              'X-Govuk-Authenticated-User-Organisation' => auth_org_id,
+              'Govuk-Auth-Bypass-Id' => "fake id"
+             }
+      end
+
+      it "returns a 403 (Forbidden) response" do
+        json = JSON.parse(response.body)
+
+        expect(response.status).to eq(403)
+        expect(json["errors"]["type"]).to eq("access_forbidden")
+        expect(json["errors"]["code"]).to eq("403")
+      end
+    end
+  end
+
+  context "access limited by bypass id" do
+    let(:access_limited_content_item) { create(:access_limited_content_item, :by_auth_bypass_id) }
+    let(:auth_bypass_id) { access_limited_content_item.access_limited["auth_bypass_ids"].first }
+
+
 
     context "request with an authorised bypass ID specified in the header" do
       before do
@@ -120,6 +205,21 @@ describe "Fetching an access-limited by content item", type: :request do
       end
     end
 
+    context "request without an bypass ID, but a user ID specified in the header" do
+      before do
+        get "/content/#{access_limited_content_item.base_path}",
+            params: {}, headers: { 'X-Govuk-Authenticated-User' => 'some-user' }
+      end
+
+      it "returns the details for the requested item" do
+        expect(response.status).to eq(200)
+        expect(response.content_type).to eq("application/json")
+
+        data = JSON.parse(response.body)
+        expect(data['title']).to eq(access_limited_content_item.title)
+      end
+    end
+
     context "request with an unauthorised bypass ID specified in the header" do
       it "returns a 403 (Forbidden) response" do
         get "/content/#{access_limited_content_item.base_path}",
@@ -130,6 +230,24 @@ describe "Fetching an access-limited by content item", type: :request do
         expect(response.status).to eq(403)
         expect(json["errors"]["type"]).to eq("access_forbidden")
         expect(json["errors"]["code"]).to eq("403")
+      end
+    end
+
+    context "request with an authorised bypass ID and an 'invalid' user_id" do
+      before do
+        get "/content/#{access_limited_content_item.base_path}",
+            params: {}, headers: {
+              'X-Govuk-Authenticated-User' => 'invalid',
+              'Govuk-Auth-Bypass-Id' => auth_bypass_id
+            }
+      end
+
+      it "returns the details for the requested item" do
+        expect(response.status).to eq(200)
+        expect(response.content_type).to eq("application/json")
+
+        data = JSON.parse(response.body)
+        expect(data['title']).to eq(access_limited_content_item.title)
       end
     end
   end

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -140,19 +140,6 @@ describe "Fetching content items", type: :request do
     end
   end
 
-  context "when the authenticated_user_uid header is invalid" do
-    let(:content_item) { create(:content_item) }
-
-    before do
-      get "/content/#{content_item.base_path}", params: {},
-        headers: { 'X-Govuk-Authenticated-User' => "invalid" }
-    end
-
-    it "returns a 403 Forbidden response" do
-      expect(response.status).to eq(403)
-    end
-  end
-
   context "a non-existent content item" do
     before(:each) { get "/content/does/not/exist" }
 

--- a/spec/integration/public_api_request_spec.rb
+++ b/spec/integration/public_api_request_spec.rb
@@ -24,7 +24,6 @@ describe "Public API requests for content items", type: :request do
   it "corrrectly expands linked items with Public API URLs" do
     get "/api/content#{content_item.base_path}"
     data = JSON.parse(response.body)
-
     expect(data["links"]["related"].first["content_id"]).to eq(linked_item.content_id)
   end
 

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -249,14 +249,9 @@ describe ContentItem, type: :model do
       it 'is not access limited' do
         expect(content_item.access_limited?).to be(false)
       end
-
-      it 'is viewable by all' do
-        expect(content_item.viewable_by?(nil)).to be(true)
-        expect(content_item.viewable_by?('a-user-uid')).to be(true)
-      end
     end
 
-    context 'an access-limited by user-id content item' do
+    context 'access-limited by user-id' do
       let!(:content_item) { create(:access_limited_content_item, :by_user_id) }
       let(:authorised_user_uid) { content_item.access_limited['users'].first }
 
@@ -265,16 +260,15 @@ describe ContentItem, type: :model do
       end
 
       it 'is viewable by an authorised user' do
-        expect(content_item.viewable_by?(authorised_user_uid)).to be(true)
+        expect(content_item.viewable_by_user_id?(authorised_user_uid)).to be(true)
       end
 
       it 'is not viewable by an unauthorised user' do
-        expect(content_item.viewable_by?('unauthorised-user')).to be(false)
-        expect(content_item.viewable_by?(nil)).to be(false)
+        expect(content_item.viewable_by_user_id?('fake-id')).to be(false)
       end
     end
 
-    context "an access-limited by auth_bypass_id content item" do
+    context "access-limited by bypass_id" do
       let!(:content_item) { create(:access_limited_content_item, :by_auth_bypass_id) }
       let(:auth_bypass_id) { content_item.access_limited['auth_bypass_ids'].first }
       let(:logged_in_user) { 'authenticated_user_uid' }
@@ -283,16 +277,12 @@ describe ContentItem, type: :model do
         expect(content_item.access_limited?).to be(true)
       end
 
-      it "includes a valid auth_bypass_id" do
-        expect(content_item.includes_auth_bypass_id?(auth_bypass_id)).to be(true)
+      it 'is viewable by an authorised bypass id' do
+        expect(content_item.viewable_by_bypass_id?(auth_bypass_id)).to be(true)
       end
 
-      it "does not include a valid auth bypass token when the id is invalid" do
-        expect(content_item.includes_auth_bypass_id?("foo")).to be(false)
-      end
-
-      it 'is viewable by an authenticated user' do
-        expect(content_item.viewable_by?(logged_in_user)).to be(true)
+      it 'is not viewable by an unauthorised user' do
+        expect(content_item.viewable_by_bypass_id?('fake-id')).to be(false)
       end
     end
   end


### PR DESCRIPTION
This PR adds support for allowing users to see content restricted to organisations.

It compares the `X-Govuk-Authenticated-User-Organisation` header sent in the request to the organisations listed within the access limiting properties.