### PR TITLE
Update pact configuration for less test runs

### DIFF
--- a/lib/tasks/pact.rake
+++ b/lib/tasks/pact.rake
@@ -1,44 +1,17 @@
-unless Rails.env.production?
+return if Rails.env.production?
 
-  desc "Verifies the pact files for latest release and master"
-  task "pact:verify" do
-    require 'pact/tasks/task_helper'
+require 'pact/tasks'
+require 'pact/tasks/task_helper'
 
+desc "Verifies a particular branch of Publishing API against pacts"
+task "pact:verify:branch", [:branch_name] do |t, args|
+  abort "Please provide a branch name. eg rake #{t.name}[my_feature_branch]" unless args[:branch_name]
+
+  pact_version = args[:branch_name] == "master" ? args[:branch_name] : "branch-#{args[:branch_name]}"
+
+  ClimateControl.modify PUBLISHING_API_PACT_VERSION: pact_version, USE_LOCAL_PACT: nil do
     Pact::TaskHelper.handle_verification_failure do
       Pact::TaskHelper.execute_pact_verify
     end
-
-    unless ENV['USE_LOCAL_PACT'] # avoid running twice against the same pact file.
-      with_temporary_env('PUBLISHING_API_PACT_VERSION', "master") do
-        Pact::TaskHelper.handle_verification_failure do
-          Pact::TaskHelper.execute_pact_verify
-        end
-      end
-    end
   end
-
-  # task default: "pact:verify"
-
-  task "pact:verify:branch", [:branch_name] do |t, args|
-    abort "Please provide a branch name. eg rake #{t.name}[my_feature_branch]" unless args[:branch_name]
-
-    pact_version = "branch-#{args[:branch_name]}"
-
-    require 'pact/tasks/task_helper'
-
-    with_temporary_env('PUBLISHING_API_PACT_VERSION', pact_version) do
-      Pact::TaskHelper.handle_verification_failure do
-        Pact::TaskHelper.execute_pact_verify
-      end
-    end
-  end
-
-  def with_temporary_env(key, value)
-    original_value = ENV[key]
-    ENV[key] = value
-    yield
-  ensure
-    ENV[key] = original_value
-  end
-
 end


### PR DESCRIPTION
This resolves an issue where pact tests run multiple times for a
particular changes for reasons that may have been lost to history.

This updates the configuration to be consistent with Publishing API as
per: https://github.com/alphagov/publishing-api/pull/1555