### PR TITLE
Default to running pacts against production Publishing API

### DIFF
--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -22,7 +22,7 @@ Pact.service_provider "Content Store" do
     else
       base_url = ENV.fetch("PACT_BROKER_BASE_URL", "https://pact-broker.cloudapps.digital")
       url = "#{base_url}/pacts/provider/#{url_encode(name)}/consumer/#{url_encode(consumer_name)}"
-      version_part = ENV['PUBLISHING_API_PACT_VERSION'] ? "versions/#{url_encode(ENV['PUBLISHING_API_PACT_VERSION'])}" : 'latest'
+      version_part = "versions/#{url_encode(ENV.fetch('PUBLISHING_API_PACT_VERSION', 'branch-deployed-to-production'))}"
 
       pact_uri "#{url}/#{version_part}"
     end


### PR DESCRIPTION
This makes the default `rake pact:verify` consistent with the default
pact the Jenkins job runs.