### PR TITLE
Switch the cookie serializer to json

### DIFF
--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -2,4 +2,4 @@
 
 # Specify a serializer for the signed and encrypted cookie jars.
 # Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :marshal
+Rails.application.config.action_dispatch.cookies_serializer = :json


### PR DESCRIPTION
To avoid any remote code execution issues with the marshal
serializer. Not that they'll affect the content store, and internal
application that to my knowledge doesn't use cookies... ¯\_(ツ)_/¯