### PR TITLE
Use the `nearest` read mode for MongoDB

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -31,4 +31,4 @@ production:
         write:
           w: <%= ENV['MONGO_WRITE_CONCERN'] || 'majority' %>
         read:
-          mode: :secondary_preferred
+          mode: :nearest


### PR DESCRIPTION
The Content Store is a read heavy application, as it only processes
writes when things change, but it's constantly serving the frontend
applications with data.

This can be seen in the load on the MongoDB machines, currently the
primary gets off lightly with a low load, and the secondary machines
handle most of the operations.

Using the nearest MongoDB machine should spread the load more evenly,
and might even increase performance due to reduced network latency.

I've been looking at this, as the MongoDB machines often complain
about high load (especially on the AWS side of Staging).