### PR TITLE
Hide 'auth_bypass_ids' field from link expansion

### DIFF
--- a/app/presenters/expanded_links_presenter.rb
+++ b/app/presenters/expanded_links_presenter.rb
@@ -9,7 +9,7 @@ class ExpandedLinksPresenter
     expanded_links.each_with_object({}) do |(type, links), memo|
       links = Array.wrap(links)
       memo[type] = links.map do |link|
-        link.dup.merge(
+        link.dup.except(secret_fields).merge(
           api_path: api_path(link),
           api_url: api_url(link),
           web_url: web_url(link),
@@ -34,5 +34,9 @@ private
 
   def web_url(link)
     Plek.current.website_root + link[:base_path] if link[:base_path]
+  end
+
+  def secret_fields
+    :auth_bypass_ids
   end
 end

--- a/spec/presenters/expanded_links_presenter_spec.rb
+++ b/spec/presenters/expanded_links_presenter_spec.rb
@@ -55,6 +55,21 @@ RSpec.describe ExpandedLinksPresenter do
       it { is_expected.to include expected }
     end
 
+    context "links with arbitrary custom fields" do
+      let(:links) do
+        {
+          link_group: [{ foo: "bar", auth_bypass_ids: "secret" }],
+        }
+      end
+
+      subject { described_class.new(links).present[:link_group][0] }
+
+      it "contains the custom fields but does not contain fields marked as secret" do
+        is_expected.to include(:foo)
+        is_expected.not_to include(:auth_bypass_ids)
+      end
+    end
+
     context "groups of links" do
       let(:links) do
         {


### PR DESCRIPTION
This is private information and should not be shown when accessing
the content store - it is just for internal content store processing.

I've created a 'secret_fields' method which returns a hash, so that
we can easily add more secret fields in future if necessary.

Trello: https://trello.com/c/DR4BMQzv/134-dont-show-authbypassids-in-content-stores-expanded-links