### PR TITLE
Create auth_bypass_ids field

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -98,6 +98,7 @@ class ContentItem
   field :links, type: Hash, default: {}
   field :expanded_links, type: Hash, default: {}
   field :access_limited, type: Hash, default: {}
+  field :auth_bypass_ids, type: Array, default: []
   field :phase, type: String, default: "live"
   field :analytics_identifier, type: String
   field :payload_version, type: Integer
@@ -106,6 +107,9 @@ class ContentItem
 
   # The updated_at field isn't set on upsert - https://jira.mongodb.org/browse/MONGOID-3716
   before_upsert :set_updated_at
+
+  before_save :populate_auth_bypass_ids
+  before_upsert :populate_auth_bypass_ids
 
   # We want to look up content items by whether they match a route and the type
   # of route.
@@ -169,6 +173,10 @@ class ContentItem
     return rendering_app if schema_name != "gone" || gone?
 
     rendering_app || "government-frontend"
+  end
+
+  def populate_auth_bypass_ids
+    self.auth_bypass_ids = auth_bypass_ids
   end
 
   def valid_bypass_id?(bypass_id)

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -312,6 +312,23 @@ describe ContentItem, type: :model do
     end
   end
 
+  describe "populate auth bypass ids field" do
+    it "automatically populates auth bypass ids on save" do
+      content_item = create(:access_limited_content_item, :by_auth_bypass_id)
+      expect(content_item["auth_bypass_ids"]).not_to be_empty
+      expect(content_item["auth_bypass_ids"])
+        .to eq(content_item.access_limited["auth_bypass_ids"])
+    end
+
+    it "automatically populates auth bypass ids on upsert" do
+      content_item = build(:access_limited_content_item, :by_auth_bypass_id)
+      expect { content_item.upsert }
+        .to change { content_item["auth_bypass_ids"] }
+        .from([])
+        .to(content_item.access_limited["auth_bypass_ids"])
+    end
+  end
+
   describe "description" do
     it "wraps the description as a hash" do
       content_item = FactoryBot.create(:content_item, description: "foo")


### PR DESCRIPTION
Trello: https://trello.com/c/AhyYCLZy/142-separate-authbypassids-from-access-limiting-in-content-store

This creates a new field that is intended to be the destination of data
that is transitioned from the access_limited object. The reason data is
being moved out of the access_limited field is that it creates confusion
given that auth_bypass doesn't do access limiting - quite the opposite
in fact.

To start with this transition this creates a field on ContentItem that
is written to each time data is saved which will be a replica of the
data in access_limited.