### PR TITLE
Backfill auth bypass ids

### DIFF
--- a/db/migrate/20191010094643_backfill_auth_bypass_ids.rb
+++ b/db/migrate/20191010094643_backfill_auth_bypass_ids.rb
@@ -1,0 +1,12 @@
+class BackfillAuthBypassIds < Mongoid::Migration
+  def self.up
+    # We're moving auth_bypass_ids from access_limited to a root field of it's
+    # own
+    ContentItem
+      .where(:access_limited.nin => [{}, nil], :auth_bypass_ids.exists => false)
+      .each { |ci| ci.set(auth_bypass_ids: ci.access_limited.fetch("auth_bypass_ids", [])) }
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/AhyYCLZy/142-separate-authbypassids-from-access-limiting-in-content-store

This depends on https://github.com/alphagov/content-store/pull/630 being deployed to production and builds on it.

This loops through content items to set each of them with an
auth_bypass_ids field if they have an access_limited object.