### PR TITLE
Use new auth bypass ids field

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -11,6 +11,8 @@ class ContentItem
     previous_item = ContentItem.where(base_path: base_path).first
     lock = UpdateLock.new(previous_item)
 
+    attributes = transition_auth_bypass_id_fields(attributes)
+
     payload_version = attributes["payload_version"]
     lock.check_availability!(payload_version)
 
@@ -245,5 +247,11 @@ private
     }
   end
 
-  private_class_method :scheduled_publication_details
+  def self.transition_auth_bypass_id_fields(attributes)
+    attributes["auth_bypass_ids"] ||= attributes.dig("access_limited", "auth_bypass_ids") || []
+    attributes.fetch("access_limited", {}).delete("auth_bypass_ids")
+    attributes
+  end
+
+  private_class_method :scheduled_publication_details, :transition_auth_bypass_id_fields
 end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -232,10 +232,6 @@ private
     access_limited.fetch("organisations", [])
   end
 
-  def auth_bypass_ids
-    access_limited.fetch("auth_bypass_ids", [])
-  end
-
   def details_is_empty?
     details.nil? || details.values.reject(&:blank?).empty?
   end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -108,9 +108,6 @@ class ContentItem
   # The updated_at field isn't set on upsert - https://jira.mongodb.org/browse/MONGOID-3716
   before_upsert :set_updated_at
 
-  before_save :populate_auth_bypass_ids
-  before_upsert :populate_auth_bypass_ids
-
   # We want to look up content items by whether they match a route and the type
   # of route.
   index("routes.path" => 1, "routes.type" => 1)
@@ -173,10 +170,6 @@ class ContentItem
     return rendering_app if schema_name != "gone" || gone?
 
     rendering_app || "government-frontend"
-  end
-
-  def populate_auth_bypass_ids
-    self.auth_bypass_ids = auth_bypass_ids
   end
 
   def valid_bypass_id?(bypass_id)

--- a/spec/factories/content_item.rb
+++ b/spec/factories/content_item.rb
@@ -20,6 +20,10 @@ FactoryBot.define do
       title { "" }
     end
 
+    trait :with_auth_bypass_id do
+      auth_bypass_ids { [SecureRandom.uuid] }
+    end
+
     factory :content_item do
       format { "answer" }
       title { "Test content" }
@@ -77,32 +81,6 @@ FactoryBot.define do
       trait :by_org_id do
         access_limited {
           {
-            "organisations" => %w(f17250b0-7540-0131-f036-005056030202),
-          }
-        }
-      end
-
-      trait :by_auth_bypass_id do
-        access_limited {
-          {
-            "auth_bypass_ids" => %w(85aa9fd5-c514-4964-b931-5b597e4ec668),
-          }
-        }
-      end
-
-      trait :by_auth_bypass_id_and_user_id do
-        access_limited {
-          {
-            "auth_bypass_ids" => %w(85aa9fd5-c514-4964-b931-5b597e4ec668),
-            "users" => %w(M6GdNZggrbGiJrLjMSbKqA f17250b0-7540-0131-f036-005056030202),
-          }
-        }
-      end
-
-      trait :by_auth_bypass_id_and_org_id do
-        access_limited {
-          {
-            "auth_bypass_ids" => %w(85aa9fd5-c514-4964-b931-5b597e4ec668),
             "organisations" => %w(f17250b0-7540-0131-f036-005056030202),
           }
         }

--- a/spec/integration/access_limited_spec.rb
+++ b/spec/integration/access_limited_spec.rb
@@ -62,7 +62,7 @@ describe "Fetching an access-limited by content item", type: :request do
     end
 
     context "request has valid user ID but invalid bypass ID" do
-      let(:access_limited_content_item) { create(:access_limited_content_item, :by_auth_bypass_id_and_user_id) }
+      let(:access_limited_content_item) { create(:access_limited_content_item, :by_user_id, :with_auth_bypass_id) }
       before do
         get "/content/#{access_limited_content_item.base_path}",
             params: {}, headers: {
@@ -81,7 +81,7 @@ describe "Fetching an access-limited by content item", type: :request do
     end
 
     context "request has an invalid user ID and invalid bypass ID" do
-      let(:access_limited_content_item) { create(:access_limited_content_item, :by_auth_bypass_id_and_user_id) }
+      let(:access_limited_content_item) { create(:access_limited_content_item, :by_user_id, :with_auth_bypass_id) }
       before do
         get "/content/#{access_limited_content_item.base_path}",
             params: {}, headers: {
@@ -161,7 +161,7 @@ describe "Fetching an access-limited by content item", type: :request do
     end
 
     context "request has valid org ID but invalid bypass ID" do
-      let(:access_limited_content_item) { create(:access_limited_content_item, :by_auth_bypass_id_and_org_id) }
+      let(:access_limited_content_item) { create(:access_limited_content_item, :by_org_id, :with_auth_bypass_id) }
       before do
         get "/content/#{access_limited_content_item.base_path}",
             params: {}, headers: {
@@ -181,8 +181,8 @@ describe "Fetching an access-limited by content item", type: :request do
   end
 
   context "access limited by bypass id" do
-    let(:access_limited_content_item) { create(:access_limited_content_item, :by_auth_bypass_id) }
-    let(:auth_bypass_id) { access_limited_content_item.access_limited["auth_bypass_ids"].first }
+    let(:access_limited_content_item) { create(:access_limited_content_item, :with_auth_bypass_id) }
+    let(:auth_bypass_id) { access_limited_content_item.auth_bypass_ids.first }
 
 
 

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -298,8 +298,8 @@ describe ContentItem, type: :model do
     end
 
     context "access-limited by bypass_id" do
-      let!(:content_item) { create(:access_limited_content_item, :by_auth_bypass_id) }
-      let(:auth_bypass_id) { content_item.access_limited["auth_bypass_ids"].first }
+      let!(:content_item) { create(:content_item, :with_auth_bypass_id) }
+      let(:auth_bypass_id) { content_item.auth_bypass_ids.first }
       let(:logged_in_user) { "authenticated_user_uid" }
 
       it "is viewable by an authorised bypass id" do

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -312,23 +312,6 @@ describe ContentItem, type: :model do
     end
   end
 
-  describe "populate auth bypass ids field" do
-    it "automatically populates auth bypass ids on save" do
-      content_item = create(:access_limited_content_item, :by_auth_bypass_id)
-      expect(content_item["auth_bypass_ids"]).not_to be_empty
-      expect(content_item["auth_bypass_ids"])
-        .to eq(content_item.access_limited["auth_bypass_ids"])
-    end
-
-    it "automatically populates auth bypass ids on upsert" do
-      content_item = build(:access_limited_content_item, :by_auth_bypass_id)
-      expect { content_item.upsert }
-        .to change { content_item["auth_bypass_ids"] }
-        .from([])
-        .to(content_item.access_limited["auth_bypass_ids"])
-    end
-  end
-
   describe "description" do
     it "wraps the description as a hash" do
       content_item = FactoryBot.create(:content_item, description: "foo")

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -130,6 +130,51 @@ describe ContentItem, type: :model do
         end
       end
     end
+
+    describe "transition_auth_bypass_id_fields" do
+      let(:auth_bypass_id) { SecureRandom.hex }
+
+      it "sets auth_bypass_ids from new auth_bypass_ids field" do
+        attributes = {
+          "schema_name" => "publication",
+          "auth_bypass_ids" => [auth_bypass_id],
+        }
+
+        _, item = ContentItem.create_or_replace(@item.base_path, attributes, nil)
+
+        expect(item.auth_bypass_ids).to eq([auth_bypass_id])
+      end
+
+      it "sets auth_bypass_ids from access_limited and removes from access_limited" do
+        user_id = SecureRandom.hex
+        attributes = {
+          "schema_name" => "publication",
+          "access_limited" => {
+            "auth_bypass_ids" => [auth_bypass_id],
+            "users" => [user_id],
+          },
+        }
+
+        _, item = ContentItem.create_or_replace(@item.base_path, attributes, nil)
+
+        expect(item.auth_bypass_ids).to eq([auth_bypass_id])
+        expect(item.access_limited).to eq("users" => [user_id])
+      end
+
+      it "sets the auth_bypass_id from new auth_bypass_ids field only if also set in access_limited" do
+        attributes = {
+          "schema_name" => "publication",
+          "auth_bypass_ids" => [auth_bypass_id],
+          "access_limited" => {
+            "auth_bypass_ids" => [SecureRandom.hex],
+          },
+        }
+        _, item = ContentItem.create_or_replace(@item.base_path, attributes, nil)
+
+        expect(item.auth_bypass_ids).to eq([auth_bypass_id])
+        expect(item.auth_bypass_ids.count).to eq(1)
+      end
+    end
   end
 
   describe ".find_by_path" do


### PR DESCRIPTION
Part of: Trello: https://trello.com/c/AhyYCLZy
Follows on from: PRs #630 and #631 
Related to:  PR #636 

# What's changed
Switch the code to use the new auth_bypass_ids field and no longer check or populate the old field

Uses the new auth_bypass_ids, and no longer populates it from the auth_bypass_ids in the access_limited field.