### PR TITLE
Migrate existing auth_bypass_ids from access_limited attribute to new field

### DIFF
--- a/db/migrate/20191011142024_remove_auth_by_pass_i_ds_from_access_limited.rb
+++ b/db/migrate/20191011142024_remove_auth_by_pass_i_ds_from_access_limited.rb
@@ -1,0 +1,10 @@
+class RemoveAuthByPassIDsFromAccessLimited < Mongoid::Migration
+  def self.up
+    ContentItem
+      .where(:access_limited.nin => [{}, nil])
+      .each { |ci| ci.unset("access_limited.auth_bypass_ids") }
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
Part of: Trello: https://trello.com/c/AhyYCLZy
Related to: PRs #634 
Follows on from: PRs #630 and #631

## What's changed?

Migrates the existing `auth_bypass_ids` from the `access_limited` attribute to the new `auth_bypass_ids` field.

## Why?
`auth_bypass_ids` are being decoupled from access limiting, and will instead be stored in a separate field. This ensures that we don't lose the existing `auth_bypass_ids` and cause users that don't have a signon accounts to lose access to the individual content items they have been given access to.