### PR TITLE
Remove transition code

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -11,8 +11,6 @@ class ContentItem
     previous_item = ContentItem.where(base_path: base_path).first
     lock = UpdateLock.new(previous_item)
 
-    attributes = transition_auth_bypass_id_fields(attributes)
-
     payload_version = attributes["payload_version"]
     lock.check_availability!(payload_version)
 
@@ -247,11 +245,5 @@ private
     }
   end
 
-  def self.transition_auth_bypass_id_fields(attributes)
-    attributes["auth_bypass_ids"] ||= attributes.dig("access_limited", "auth_bypass_ids") || []
-    attributes.fetch("access_limited", {}).delete("auth_bypass_ids")
-    attributes
-  end
-
-  private_class_method :scheduled_publication_details, :transition_auth_bypass_id_fields
+  private_class_method :scheduled_publication_details
 end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -130,51 +130,6 @@ describe ContentItem, type: :model do
         end
       end
     end
-
-    describe "transition_auth_bypass_id_fields" do
-      let(:auth_bypass_id) { SecureRandom.hex }
-
-      it "sets auth_bypass_ids from new auth_bypass_ids field" do
-        attributes = {
-          "schema_name" => "publication",
-          "auth_bypass_ids" => [auth_bypass_id],
-        }
-
-        _, item = ContentItem.create_or_replace(@item.base_path, attributes, nil)
-
-        expect(item.auth_bypass_ids).to eq([auth_bypass_id])
-      end
-
-      it "sets auth_bypass_ids from access_limited and removes from access_limited" do
-        user_id = SecureRandom.hex
-        attributes = {
-          "schema_name" => "publication",
-          "access_limited" => {
-            "auth_bypass_ids" => [auth_bypass_id],
-            "users" => [user_id],
-          },
-        }
-
-        _, item = ContentItem.create_or_replace(@item.base_path, attributes, nil)
-
-        expect(item.auth_bypass_ids).to eq([auth_bypass_id])
-        expect(item.access_limited).to eq("users" => [user_id])
-      end
-
-      it "sets the auth_bypass_id from new auth_bypass_ids field only if also set in access_limited" do
-        attributes = {
-          "schema_name" => "publication",
-          "auth_bypass_ids" => [auth_bypass_id],
-          "access_limited" => {
-            "auth_bypass_ids" => [SecureRandom.hex],
-          },
-        }
-        _, item = ContentItem.create_or_replace(@item.base_path, attributes, nil)
-
-        expect(item.auth_bypass_ids).to eq([auth_bypass_id])
-        expect(item.auth_bypass_ids.count).to eq(1)
-      end
-    end
   end
 
   describe ".find_by_path" do


### PR DESCRIPTION
Follows on from: https://github.com/alphagov/publishing-api/pull/1629
Reverts: https://github.com/alphagov/content-store/commit/5910091d012468a21a27dae21536241e7e2037fe#diff-7a1fc60457a3430a2bd0c87f52941d6a

Now that publishing-api is no longer sending auth_bypass_ids in the access_limited hash,
we no longer need to check for it.