### PR TITLE
Resolve text/html content in links

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -33,7 +33,7 @@ class ContentItemPresenter
 
   def as_json(options = nil)
     item.as_json(options).slice(*PUBLIC_ATTRIBUTES).merge(
-      "links" => links,
+      "links" => RESOLVER.resolve(links),
       "description" => RESOLVER.resolve(item.description),
       "details" => RESOLVER.resolve(item.details),
     ).tap do |i|

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -37,7 +37,18 @@ describe ContentItemPresenter do
     let(:item) do
       FactoryBot.create(
         :content_item,
-        links: links,
+        expanded_links: {
+          person: [
+            {
+              details: {
+                body: [
+                  { content_type: "text/html", content: "<p>content</p>" },
+                  { content_type: "text/plain", content: "content" },
+                ],
+              },
+            },
+          ],
+        },
         description: [
           { content_type: "text/html", content: "<p>content</p>" },
           { content_type: "text/plain", content: "content" },
@@ -57,6 +68,10 @@ describe ContentItemPresenter do
 
     it "inlines the 'text/html' content type in the details" do
       expect(presenter.as_json["details"]).to eq(body: "<p>content</p>")
+    end
+
+    it "inlines the 'text/html' content type in the links" do
+      expect(presenter.as_json["links"][:person].first[:details]).to eq(body: "<p>content</p>")
     end
   end
 


### PR DESCRIPTION
Currently we resolve text/html content in the description and in the details hash, but not in the links.

This leads to some inconsistency content items, specifically people where the links to roles include the different content types but the content item for the role itself does not. This also makes it harder to write "dumb" frontend apps as they need to be aware on the different content types and perform the resolving in the frontend app.

Example:

```json
{
  "api_path": "/api/content/government/ministers/prime-minister",
  "base_path": "/government/ministers/prime-minister",
  "content_id": "845e5811-c0f1-11e4-8223-005056011aef",
  "document_type": "ministerial_role",
  "locale": "en",
  "public_updated_at": "2018-11-05T08:52:39Z",
  "schema_name": "role",
  "title": "Prime Minister",
  "withdrawn": false,
  "details": {
    "body": [
      {
        "content_type": "text/html",
        "content": "The Prime Minister is the leader of Her Majesty's Government and is ultimately responsible for the policy and decisions of the government.\r\n\r\nAs leader of the UK government the Prime Minister also:\r\n\r\n* oversees the [operation of the Civil Service](https://www.gov.uk/government/ministers/minister-for-the-civil-service) and government agencies\r\n* appoints members of the government\r\n* is the principal government figure in the House of Commons\r\n"
      }
    ]
  }
},
```

I'm not sure if there are any frontend apps which currently rely on this behaviour, although I suspect not since this change hasn't been made yet. I'm going to deploy this to staging first and see if we notice an increase in 5xx errors.

See https://github.com/alphagov/content-store/pull/172 for more background on this feature.