### PR TITLE
Remove links field

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -95,7 +95,6 @@ class ContentItem
   field :rendering_app, type: String
   field :routes, type: Array, default: []
   field :redirects, type: Array, default: []
-  field :links, type: Hash, default: {}
   field :expanded_links, type: Hash, default: {}
   field :access_limited, type: Hash, default: {}
   field :auth_bypass_ids, type: Array, default: []

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -15,8 +15,7 @@ describe ContentItemPresenter do
       ],
     }
   end
-  let(:item) { build(:content_item, document_type: "travel_advice", links: links, locale: locale, expanded_links: expanded_links) }
-  let(:links) { {} }
+  let(:item) { build(:content_item, document_type: "travel_advice", locale: locale, expanded_links: expanded_links) }
   let(:locale) { "en" }
 
   let(:api_url_method) do


### PR DESCRIPTION
This is one step towards solving #632 and avoids unnecessary confusion over their being two fields for accessing the links.

There are only 310 content items left which have something in the `links`:

```rb
irb(main):005:0> ContentItem.where(:links.nin => [{}, nil]).count
=> 310
```

I don't think we need to write a migration to remove this field because as new content is presented to the content store, it'll get overwritten anyway.