### PR TITLE
Typo in docs. Inconsistency between actual and stated number of contexts

### DIFF
--- a/doc/content_item_fields.md
+++ b/doc/content_item_fields.md
@@ -1,7 +1,7 @@
 # The Content Item Format
 
 A content item consists of a set key/value pairs. Different key/value pairs are
-present or required, depending on the context. The three contexts are:
+present or required, depending on the context. The two contexts are:
 
  - storing: content items being sent to the content store.
  - retrieving: content items being retrieved from the content store.


### PR DESCRIPTION
The text in `doc/content_item_fields.md` states:

> The three contexts are:

But only two contexts are listed. This PR changes that text to:

> The two contexts are: