### PR TITLE
Enable migrations to run against a new, empty cluster

### DIFF
--- a/db/migrate/20141219114603_remove_non_case_study_whitehall_unpublishings.rb
+++ b/db/migrate/20141219114603_remove_non_case_study_whitehall_unpublishings.rb
@@ -9,6 +9,8 @@ class RemoveNonCaseStudyWhitehallUnpublishings < Mongoid::Migration
       puts "Destroyed content item #{content_item.id}"
     end
     router_api.commit_routes
+  rescue GdsApi::SocketErrorException
+    puts "Router API is not available, skipping RemoveNonCaseStudyWhitehallUnpublishings"
   end
 
   def self.down
@@ -20,7 +22,7 @@ class RemoveNonCaseStudyWhitehallUnpublishings < Mongoid::Migration
       begin
         router_api.delete_route(redirect["path"], redirect["type"])
         puts "  Removed redirect '#{redirect['path']}'"
-      rescue GdsApi::HTTPNotFound => e
+      rescue GdsApi::HTTPNotFound, GdsApi::SocketErrorException => e
         puts "  Redirect #{redirect['path']} not found. Nothing done."
       end
     end

--- a/db/migrate/20150220114658_really_remove_non_case_study_whitehall_unpublishings.rb
+++ b/db/migrate/20150220114658_really_remove_non_case_study_whitehall_unpublishings.rb
@@ -10,6 +10,8 @@ class ReallyRemoveNonCaseStudyWhitehallUnpublishings < Mongoid::Migration
       puts "  -> destroyed content item"
     end
     router_api.commit_routes
+  rescue GdsApi::SocketErrorException
+    puts "Router API is not available, skipping RemoveNonCaseStudyWhitehallUnpublishings"
   end
 
   def self.down
@@ -21,7 +23,7 @@ class ReallyRemoveNonCaseStudyWhitehallUnpublishings < Mongoid::Migration
       begin
         router_api.delete_route(redirect["path"], redirect["type"])
         puts "  -> removed redirect '#{redirect['path']}'"
-      rescue GdsApi::HTTPNotFound => e
+      rescue GdsApi::HTTPNotFound, GdsApi::SocketErrorException => e
         puts "  -> redirect #{redirect['path']} not found. Nothing done."
       end
     end

--- a/db/migrate/20151013123045_make_inconsistent_policies_into_redirects.rb
+++ b/db/migrate/20151013123045_make_inconsistent_policies_into_redirects.rb
@@ -13,6 +13,7 @@ class MakeInconsistentPoliciesIntoRedirects < Mongoid::Migration
         routes: [],
       )
     end
+  rescue Mongoid::Errors::DocumentNotFound
   end
 
   def self.down; end

--- a/db/migrate/20151014135153_add_redirects_for_raib.rb
+++ b/db/migrate/20151014135153_add_redirects_for_raib.rb
@@ -13,6 +13,7 @@ class AddRedirectsForRaib < Mongoid::Migration
         routes: [],
       )
     end
+  rescue Mongoid::Errors::DocumentNotFound
   end
 
   def self.down; end

--- a/db/migrate/20151015100245_redirect_publications_to_statistics.rb
+++ b/db/migrate/20151015100245_redirect_publications_to_statistics.rb
@@ -13,6 +13,7 @@ class RedirectPublicationsToStatistics < Mongoid::Migration
         routes: [],
       )
     end
+  rescue Mongoid::Errors::DocumentNotFound
   end
 
   def self.down; end

--- a/db/migrate/20151015103826_fix_redirects_for_schools_commissioner.rb
+++ b/db/migrate/20151015103826_fix_redirects_for_schools_commissioner.rb
@@ -13,6 +13,7 @@ class FixRedirectsForSchoolsCommissioner < Mongoid::Migration
         routes: [],
       )
     end
+  rescue Mongoid::Errors::DocumentNotFound
   end
 
   def self.down; end

--- a/db/migrate/20151015111051_fix404ing_content_items.rb
+++ b/db/migrate/20151015111051_fix404ing_content_items.rb
@@ -6,6 +6,7 @@ class Fix404ingContentItems < Mongoid::Migration
       content_item = ContentItem.find_by(base_path: row.first)
       content_item.delete
     end
+  rescue Mongoid::Errors::DocumentNotFound
   end
 
   def self.down; end

--- a/db/migrate/20151020130422_set_redirects_for_odd_unpublishings.rb
+++ b/db/migrate/20151020130422_set_redirects_for_odd_unpublishings.rb
@@ -13,6 +13,7 @@ class SetRedirectsForOddUnpublishings < Mongoid::Migration
         routes: [],
       )
     end
+  rescue Mongoid::Errors::DocumentNotFound
   end
 
   def self.down; end

--- a/db/migrate/20170822104138_remove_obselete_content_items_index.rb
+++ b/db/migrate/20170822104138_remove_obselete_content_items_index.rb
@@ -1,6 +1,8 @@
 class RemoveObseleteContentItemsIndex < Mongoid::Migration
   def self.up
     collection.indexes.drop_one(key)
+  rescue StandardError
+    # if the collection doesn't exist, we don't care.
   end
 
   def self.down


### PR DESCRIPTION
When we tried to deploy content store in a new environment, with a fresh mongodb, these migrations failed.

This adds fixes for the various failures so we can run migrations against a new empty mongodb.