### PR TITLE
Use the internal signon url

### DIFF
--- a/config/initializers/gds_sso.rb
+++ b/config/initializers/gds_sso.rb
@@ -2,7 +2,7 @@ GDS::SSO.config do |config|
   config.user_model   = "User"
   config.oauth_id     = ENV.fetch("OAUTH_ID", "oauth_id")
   config.oauth_secret = ENV.fetch("OAUTH_SECRET", "secret")
-  config.oauth_root_url = Plek.new.external_url_for("signon")
+  config.oauth_root_url = Plek.find("signon")
   config.cache = Rails.cache
   config.api_only = true
 end


### PR DESCRIPTION
This is useful if we don't have DNS records set up for the external URLs, as in the test environment.

```
> Plek.find("signon")
=> "https://signon.test.govuk-internal.digital"
> Plek.new.external_url_for("signon")
=> "https://signon.test.publishing.service.gov.uk"
```

See e.g. publishing-api:

https://github.com/alphagov/publishing-api/blob/a899ce1cf24c7aaac97cb8262297fbeb4331d23e/config/initializers/gds_sso.rb
