### PR TITLE
Explicitly name gds-* dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,11 +9,13 @@ updates:
       - dependency-name: brakeman
         dependency-type: direct
       # Internal gems
-      - dependency-name: "gds*"
-        dependency-type: direct
       - dependency-name: "govuk*"
         dependency-type: direct
       - dependency-name: "rubocop-govuk"
+        dependency-type: direct
+      - dependency-name: "gds-api-adapters"
+        dependency-type: direct
+      - dependency-name: "gds-sso"
         dependency-type: direct
       - dependency-name: plek
         dependency-type: direct


### PR DESCRIPTION
The dependencies named in the code in this commit have non-standard
names and we are not encouraging further creation of `gds-*` named
dependencies. Therefore we have taken the decision to name these
dependencies explicitly. Read the [discussion] in #750.

Trello: https://trello.com/c/uPoriyfJ/2049-add-dependabot-configuration-to-each-repo-blitz-pair

[discussion]: https://github.com/alphagov/content-store/pull/750#discussion_r454208436