### PR TITLE
Make find_by_path more efficient

### DIFF
--- a/lib/find_by_path.rb
+++ b/lib/find_by_path.rb
@@ -20,13 +20,18 @@ class FindByPath
 private
 
   def find_matching_items(path)
-    model_class
-      .or(base_path: path)
-      .or(routes: { "$elemMatch" => { path: path, type: "exact" } })
-      .or(redirects: { "$elemMatch" => { path: path, type: "exact" } })
-      .or(routes: { "$elemMatch" => { :path.in => potential_prefixes(path), type: "prefix" } })
-      .or(redirects: { "$elemMatch" => { :path.in => potential_prefixes(path), type: "prefix" } })
-      .entries
+    query = model_class
+              .or(base_path: path)
+              .or(routes: { "$elemMatch" => { path: path, type: "exact" } })
+              .or(routes: { "$elemMatch" => { :path.in => potential_prefixes(path), type: "prefix" } })
+
+    if model_class.fields.key?("redirects")
+      query = query
+        .or(redirects: { "$elemMatch" => { path: path, type: "exact" } })
+        .or(redirects: { "$elemMatch" => { :path.in => potential_prefixes(path), type: "prefix" } })
+    end
+
+    query.entries
   end
 
   def best_match(matches, path)


### PR DESCRIPTION
This makes a couple of changes to the FindByPath module to try improve its performance. Firstly it only checks redirects if there are any, this allows PublishIntent to make it's queries by index scans rather than collection scans. Secondly it splits the work into two queries, the first being a simple find by id and only if that fails doing the query to check the routes/redirects.

I'm going to run this on integration/staging for a bit to try determine if it has an impact.

In integration:

![Screenshot 2020-09-02 at 10 18 57](https://user-images.githubusercontent.com/282717/91963582-f0469b80-ed05-11ea-885f-289862d73fc7.png)

In staging:

![Screenshot 2020-09-02 at 10 20 00](https://user-images.githubusercontent.com/282717/91963593-f50b4f80-ed05-11ea-88ff-c1f3105bee80.png)

It seems that this makes a noticeable impact on PublishIntent, yet only a negligible impact on ContentItem look ups. It also doesn't seem to fully remove spikes as this later graph showed:

![Screenshot 2020-09-02 at 10 24 03](https://user-images.githubusercontent.com/282717/91964087-a01c0900-ed06-11ea-9a4c-64550161f481.png)

So this may well help the situations that have caused problems, but it looks like it won't fully resolve them.