### PR TITLE
Apply deterministic ordering to flakey test

### DIFF
--- a/spec/integration/submitting_content_item_spec.rb
+++ b/spec/integration/submitting_content_item_spec.rb
@@ -155,6 +155,7 @@ describe "content item write API", type: :request do
           put_json "/content/vat-rates", @data
 
           log_entries = ScheduledPublishingLogEntry.where(base_path: "/vat-rates")
+                                                   .order(scheduled_publication_time: :asc)
           expect(log_entries.count).to eq(2)
 
           expect(log_entries[0].scheduled_publication_time).to eq(first_scheduled_time)


### PR DESCRIPTION
In 1ffd624f I applied a fix to this test however this didn't appear to
be sufficient to root out the flakiness as I failed to notice that this
test relied on non-deterministic ordering. Attempting locally I didn't
manage to replicate the failure however I've seen it in Jenkins with:

```
1) content item write API creating a new content item with an earlier scheduled publishing logs the publishing delays for each scheduled publishing
    Failure/Error: expect(log_entries[0].scheduled_publication_time).to eq(first_scheduled_time)

      expected: 2020-08-31 12:00:00.000000000 +0000
           got: Tue, 01 Sep 2020 12:00:00.000000000 +0000

      (compared using ==)

      Diff:
      @@ -1 +1 @@
      -Mon, 31 Aug 2020 12:00:00 UTC +00:00
      +Tue, 01 Sep 2020 12:00:00 +0000
    # ./spec/integration/submitting_content_item_spec.rb:160:in `block (5 levels) in <top (required)>'
    # /var/lib/jenkins/bundles/ruby/2.6.0/gems/timecop-0.9.1/lib/timecop/timecop.rb:201:in `travel'
    # /var/lib/jenkins/bundles/ruby/2.6.0/gems/timecop-0.9.1/lib/timecop/timecop.rb:129:in `send_travel'
    # /var/lib/jenkins/bundles/ruby/2.6.0/gems/timecop-0.9.1/lib/timecop/timecop.rb:51:in `freeze'
    # ./spec/integration/submitting_content_item_spec.rb:147:in `block (4 levels) in <top (required)>'
```

Thus applying an ordering to this query should make the ordering
deterministic and resolve the flakiness.