### PR TITLE
Show actual error from Router

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -35,7 +35,7 @@ class ContentItem
         revert(previous_item: previous_item, item: item)
         raise unless e.is_a?(GdsApi::BaseError)
 
-        item.errors.add(:routes, "Could not communicate with router.")
+        item.errors.add(:routes, "Could not communicate with router: #{e}.")
         result = false
       end
     else


### PR DESCRIPTION
https://sentry.io/organizations/govuk/issues/1676038415/?project=202242

Previously we could not know the cause of a communication issue
between this app and the Router, since we hard-coded the error
message. This changes the message to include the actual error.