### PR TITLE
Update to ruby 2.7.1

### DIFF
--- a/app/lib/publication_delay_report.rb
+++ b/app/lib/publication_delay_report.rb
@@ -21,7 +21,7 @@ private
   CSV_HEADERS = ["URL", "Document Type", "Scheduled Time", "Delay (seconds)"].freeze
 
   def write_csv
-    CSV(file, headers: CSV_HEADERS, write_headers: true) do |csv|
+    CSV.instance(file, headers: CSV_HEADERS, write_headers: true) do |csv|
       delayed_content_items.each do |content_item|
         csv << csv_row(content_item)
       end


### PR DESCRIPTION
This PR contains the changes necessary for the app to run on Ruby 2.7.1.

The version of Ruby is left the same, since there is a script that can be run after all the apps have been updated to update the version all at once

Tested locally with ruby 2.7.1 and 2.6.6
CSV deprecation warnings see 6323f51

Also deprecation warning which might need updating at the gem source:
```
ruby-2.7.1/gems/mongoid-7.1.2/lib/mongoid/errors/mongoid_error.rb:51: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call

ruby-2.7.1/gems/i18n-1.8.5/lib/i18n.rb:195: warning: The called method `translate' is defined here
```