### PR TITLE
Do a real /healthcheck for MongoDB connectivity

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,7 @@ Rails.application.routes.draw do
     delete "/publish-intent(/*base_path_without_root)" => "publish_intents#destroy"
   end
 
-  get "/healthcheck", to: proc { [200, {}, %w[OK]] }
+  get "/healthcheck", to: GovukHealthcheck.rack_response(
+    GovukHealthcheck::Mongoid,
+  )
 end

--- a/spec/integration/healthcheck_spec.rb
+++ b/spec/integration/healthcheck_spec.rb
@@ -5,6 +5,6 @@ describe "healthcheck path", type: :request do
     get "/healthcheck"
 
     expect(response.status).to eq(200)
-    expect(response.body).to eq("OK")
+    expect(response.body).to include("status")
   end
 end


### PR DESCRIPTION
https://trello.com/c/36cdHP3z/620-improve-the-content-store-healthcheck-to-check-mongo-so-failing-instances-are-automatically-removed-from-the-lb

This more accurately reflects whether an instance of the app is able
to serve requests, which contributed to an incident [1].

[1]: https://docs.google.com/document/d/1q0dmaRaK1pnoKK_EGikdstUOtBEiaCaswMYS9ITFbL0/edit#