### PR TITLE
Add explicit uid to user factory

### DIFF
--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,3 +1,5 @@
 FactoryBot.define do
-  factory :user
+  factory :user do
+    uid { SecureRandom.uuid }
+  end
 end


### PR DESCRIPTION
This should avoid an [error we're seeing on CI builds](https://ci.integration.publishing.service.gov.uk/job/content-store/job/master/1064/console):

```
An error occurred in a `before(:suite)` hook.
Failure/Error: FactoryBot.lint

FactoryBot::InvalidFactoryError:
  The following factories are invalid:

  * user - insertDocument :: caused by :: 11000 E11000 duplicate key error index: content_store_test.users.$uid_1  dup key: { : null } (11000) (on ip-10-1-4-148:27017, legacy retry, attempt 1) (Mongo::Error::OperationFailure)
```

It follows a similar pattern found [in Whitehall](https://github.com/alphagov/whitehall/blob/bf7cf0566a69a040e426e1ac5fa7245982ac46a9/test/factories/users.rb#L10-L12) and [in Content Publisher](https://github.com/alphagov/content-publisher/blob/3cdda97cd3f3acdb11f2d8adf175c6084e6de58a/spec/factories/user_factory.rb#L4).