### PR TITLE
[WIP] Spike adding /api/content-id/:content_id route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   scope format: false do
     # The /api/content route is used for requests via the public API
     get "/api/content(/*path_without_root)" => "content_items#show", :as => :content_item_api, :public_api_request => true
+    get "/api/content-id/:content_id" => "content_items#show_by_id"
 
     get "/content(/*path_without_root)" => "content_items#show", :as => :content_item
     put "/content(/*base_path_without_root)" => "content_items#update"


### PR DESCRIPTION
This work explores adding a new public endpoint we can call to
quickly find out what content is represented by a specific content
ID. In absence of a route, the alternative has been to connect to
the VPN, SSH into a Content Store or Publishing API machine and
perform a lookup via the app console.

This idea isn't particularly new. We have a precedent in Whitehall:
https://github.com/alphagov/whitehall/blob/0ef9b6bb99e62e1e7d724b2cd9c7da4233d1bca4/config/routes.rb#L191

This spike works locally. If you app console and compare
`app.get("/api/content")` (the route of the homepage) with
`app.get("/api/content-id/f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a")`
(the content ID of the homepage), you get the same `app.response`.

To make this a viable MVP, we'd need to [add an index](https://api.rubyonrails.org/v6.1.0/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_index) on the `content_id`,
as currently the lookup is VERY slow (1-2 minutes per query!).

(We should **consider doing this anyway**, as it's a useful thing to be able
to query and currently queries are just too slow.)

And then to make this available via a public endpoint
rather than app console, we'd need to add a 'special route' like
we've done for `/api/content`:
https://github.com/alphagov/special-route-publisher/blob/c47ca1b995315d5abf3c811a321c7520467fe98e/data/special_routes.yaml#L1-L6