### PR TITLE
Re-raise Router API expectations to ensure 5xx responses

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -31,12 +31,9 @@ class ContentItem
     if item.upsert
       begin
         item.register_routes(previous_item: previous_item)
-      rescue StandardError => e
+      rescue StandardError
         revert(previous_item: previous_item, item: item)
-        raise unless e.is_a?(GdsApi::BaseError)
-
-        item.errors.add(:routes, "Could not communicate with router: #{e}.")
-        result = false
+        raise
       end
     else
       result = false

--- a/spec/integration/submitting_content_item_spec.rb
+++ b/spec/integration/submitting_content_item_spec.rb
@@ -279,7 +279,8 @@ describe "content item write API", type: :request do
 
       it "fails to update content item" do
         @data["routes"] << { "path" => "/vat-rates.json", "type" => "exact" }
-        put_json "/content/vat-rates", @data
+        expect { put_json "/content/vat-rates", @data }
+          .to raise_error(GdsApi::HTTPInternalServerError)
         @item.reload
         expect(@item.title).to eq("Original title")
         expect(WebMock::RequestRegistry.instance.times_executed(stub.request_pattern)).to eq(3)


### PR DESCRIPTION
Trello: https://trello.com/c/cRI17wof/981-investigate-content-store-returning-5xx-errors-when-router-registration-fails

Previously we were treating communication with Router API as a client
error and returning a 422 response to the Publishing API when there was
a Router problem. This is a bit misleading as it is not the case that
updating the client request can resolve the error.

By instead raising an exception these errors will be converted into a
500 response by Rails. This will help us, in the event of more Router
API problems, distinguish server errors from client errors.