### PR TITLE
Remove redundant Jenkinsfile config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,8 +4,6 @@ library("govuk")
 
 node("mongodb-2.4") {
   govuk.buildProject(
-    brakeman: true,
-    rubyLintDiff: false,
     extraParameters: [
       stringParam(
         name: "PUBLISHING_API_PACT_BRANCH",


### PR DESCRIPTION
The RubyLintDiff argument no longer has any affect and brakeman defaults to true.