### PR TITLE
Switch read mode to secondaryPreferred

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -31,4 +31,4 @@ production:
         write:
           w: <%= ENV['MONGO_WRITE_CONCERN'] || 'majority' %>
         read:
-          mode: :nearest
+          mode: :secondary_preferred


### PR DESCRIPTION
We are seeing content-store read requests time out.

This change to the read prefence [1] is intended to
see if we can reduce reads to the primary, which seems
to have a higher percentage rate of locks.

[1] https://docs.mongodb.com/v2.6/core/read-preference/