### PR TITLE
Remove ECR publish on PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,10 +7,6 @@ on:
     paths-ignore:
       - "Jenkinsfile"
       - ".git**"
-  pull_request:
-    paths-ignore:
-      - "Jenkinsfile"
-      - ".git**"
 
 jobs:
   publish:


### PR DESCRIPTION
After some discussion within the team, we have decided that its not necessary to have Github actions CI run on PR's for now.

What should happen on PR's is something we will visit again at a later date.