### PR TITLE
Reduce default TTL for GOV.UK pages to 20 minutes

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -106,7 +106,7 @@ module ContentStore
     ]
 
     # Caching defaults
-    config.default_ttl = ENV.fetch("DEFAULT_TTL", 30.minutes).to_i.seconds
+    config.default_ttl = ENV.fetch("DEFAULT_TTL", 20.minutes).to_i.seconds
     config.minimum_ttl = [config.default_ttl, 5.seconds].min
 
     config.paths["log"] = ENV["LOG_PATH"] if ENV["LOG_PATH"]


### PR DESCRIPTION
Partially implements GOV.UK RFC 144. We will gradually reduce the TTL to 5 minutes, once we're more confident on the impact on performance. The next step will be to audit frontend applications to ensure that this TTL is honoured.

To be merged once https://github.com/alphagov/govuk-rfcs/pull/144 is approved.