### PR TITLE
Set RAILS_LOG_TO_STDOUT in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN bundle config set without 'development test' && \
 COPY . ./
 
 FROM $base_image
-ENV RAILS_ENV=production GOVUK_APP_NAME=content-store
+ENV RAILS_ENV=production RAILS_LOG_TO_STDOUT=1 GOVUK_APP_NAME=content-store
 # TODO: apt-get upgrade in the base image
 RUN apt-get update -qy && \
     apt-get upgrade -y


### PR DESCRIPTION
This always needs to be set when a Rails app is running in a container, so it makes sense to set it in the Dockerfile rather than making the user remember to set it.