### PR TITLE
Update default cache TTL to 5 minutes

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -105,7 +105,7 @@ module ContentStore
     ]
 
     # Caching defaults
-    config.default_ttl = ENV.fetch("DEFAULT_TTL", 20.minutes).to_i.seconds
+    config.default_ttl = ENV.fetch("DEFAULT_TTL", 5.minutes).to_i.seconds
     config.minimum_ttl = [config.default_ttl, 5.seconds].min
 
     config.paths["log"] = ENV["LOG_PATH"] if ENV["LOG_PATH"]


### PR DESCRIPTION
This changes the default value of this configuration option to match how
it is configured in govuk-puppet for all environments [1].

This has been applied to reduce confusion where it looks like this code
is set to quite a deliberate value, whereas it was one that represented
an in between state in a migration.

[1]: https://github.com/alphagov/govuk-puppet/pull/11538