### PR TITLE
Add Prometheus exporter for EKS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN bundle config set without 'development test' && \
 COPY . ./
 
 FROM $base_image
-ENV RAILS_ENV=production GOVUK_APP_NAME=content-store
+ENV GOVUK_PROMETHEUS_EXPORTER=true RAILS_ENV=production GOVUK_APP_NAME=content-store
 # TODO: apt-get upgrade in the base image
 RUN apt-get update -qy && \
     apt-get upgrade -y

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,0 +1,2 @@
+require "govuk_app_config/govuk_prometheus_exporter"
+GovukPrometheusExporter.configure


### PR DESCRIPTION
Enable Prometheus exporter for EKS by:
1. adding `GOVUK_PROMETHEUS_EXPORTER=true` to Dockerfile
2. adding Prometheus initializer