### PR TITLE
Handle errors for bad URI requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,12 +1,19 @@
 class ApplicationController < ActionController::API
   include GDS::SSO::ControllerMethods
+  class InvalidRequest < RuntimeError; end
+
   before_action :authenticate_user!
   rescue_from Mongoid::Errors::DocumentNotFound, with: :error_404
+  rescue_from InvalidRequest, with: :error_400
 
 private
 
   def error_404
     head :not_found
+  end
+
+  def error_400
+    head :bad_request
   end
 
   def config
@@ -23,10 +30,14 @@ private
 
   def encoded_request_path
     Addressable::URI.encode(request_path)
+  rescue Addressable::URI::InvalidURIError
+    raise InvalidRequest
   end
 
   def encoded_base_path
     Addressable::URI.encode(base_path)
+  rescue Addressable::URI::InvalidURIError
+    raise InvalidRequest
   end
 
   def request_path

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -158,6 +158,17 @@ describe "Fetching content items", type: :request do
     end
   end
 
+  context "a content item with an invalid path" do
+    it "returns a 400 Bad Request response" do
+      # we can't run the test with an actual invalid URI so we have to mock that
+      expect(Addressable::URI).to receive(:encode).and_wrap_original do |m|
+        m.call("/path\nprotocol:")
+      end
+      get "/content/invalid-uri"
+      expect(response.status).to eq(400)
+    end
+  end
+
   context "when requesting an exact route within a base_path" do
     let!(:content_item) do
       FactoryBot.create(

--- a/spec/integration/submitting_content_item_spec.rb
+++ b/spec/integration/submitting_content_item_spec.rb
@@ -333,6 +333,17 @@ describe "content item write API", type: :request do
     end
   end
 
+  context "given an invalid base_path" do
+    it "returns a Bad Request status" do
+      # we can't run the test with an actual invalid URI so we have to mock that
+      expect(Addressable::URI).to receive(:encode).and_wrap_original do |m|
+        m.call("/path\nprotocol:")
+      end
+      put_json "/content/invalid-uri", @data
+      expect(response.status).to eq(400)
+    end
+  end
+
   context "create with extra fields in the input" do
     before :each do
       @data["foo"] = "bar"


### PR DESCRIPTION
We occasionally are subject to malicious users trying to discover
weaknesses in our application by sending invalid URIs.

This change updates our handling so that we return a 400 Bad Request
response, rather than recording this as an application error.

I debated about whether to return a 400 (Bad Request) response or a 406
(Not Acceptable) response. However I noticed we already had precedence
for 400 for invalid JSON so I kept consistent with that.

Before:
<img width="1100" alt="Screenshot 2022-06-28 at 13 11 53" src="https://user-images.githubusercontent.com/282717/176175484-2bb0202a-e7d8-4194-bee8-8ec6ecb78ea7.png">

After:
<img width="998" alt="Screenshot 2022-06-28 at 13 12 11" src="https://user-images.githubusercontent.com/282717/176175458-7163735f-07d1-4e82-9c5a-d408e847b3cc.png">