### PR TITLE
Add rake task to update titles on hmrc_manual_section items.

### DIFF
--- a/lib/tasks/update_hmrc_manual_sections.rake
+++ b/lib/tasks/update_hmrc_manual_sections.rake
@@ -1,0 +1,26 @@
+def update_hmrc_manual_section_titles(dry_run: false)
+  ContentItem.where(document_type: "").each do |ci|
+    manual_content_id = GdsApi.publishing_api.lookup_content_id(ci.details["manual"]["base_path"])
+    if content_id
+      manual_content_id = GdsApi.publishing_api.get_live_content(manual_content_id)
+      ci.details["manual"]["title"] = manual_content_id["title"]
+      puts("Updating HMRC Manual Section #{ci.content_id} to set manual title to #{ci.details["manual"]["title"]}")
+      ci.save unless dry_run
+    else
+      put("ERROR: Couldn't find manual content item for path #{ci.details["manual"]["base_path"]}")
+    end
+  end
+end
+
+namespace :update_hmrc_manual_sections do
+  desc "Show hmrc_manual_section items that will be updated with the title of the containing manual"
+  task dry_run: :environment do
+    puts("DRY RUN (no actual changes will be saved)")
+    update_hmrc_manual_section_titles(dry_run: true)
+  end
+
+  desc "Update hmrc_manual_section items with the title of the containing manual"
+  task go: :environment do
+    update_hmrc_manual_section_titles
+  end
+end


### PR DESCRIPTION
To simplify front-end rendering, we need to add the parent manual title to hmrc manual section items. There's a PR to add this into the schema: 

https://github.com/alphagov/govuk-content-schemas/pull/1106

...and another to do the lookup in the future as the item is written into the content store:

https://github.com/alphagov/hmrc-manuals-api/pull/702

This PR adds a task to update the values on existing records (can be removed once this job is complete and all existing and new hmrc_manual_sections will have the title already).

https://trello.com/c/NToovfjr/1349-add-parent-manuals-title-to-the-hmrc-section-content-item