### PR TITLE
New test for the find specific term rake task

### DIFF
--- a/spec/lib/find_specific_term_spec.rb
+++ b/spec/lib/find_specific_term_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+describe FindSpecificTerm do
+  describe ".call" do
+    let(:term) { "Test Content" }
+
+    it "finds 1 relevant content item" do
+      create(
+        :content_item,
+        document_type: "test",
+        title: "Test Content",
+        base_path: "/specific-term-test-content",
+      )
+
+      expect(Rails.logger).to receive(:info).with("Searching for #{term}...")
+
+      expect(Rails.logger).to receive(:info).with("Title,URL,Publishing application,Tagged organisation,Format,Content ID")
+
+      expect(Rails.logger).to receive(:info).with("Found 1 items containing #{term}")
+
+      expect(Rails.logger).to receive(:info).with("Test Content, https://www.gov.uk/specific-term-test-content, publisher, , test, ")
+
+      expect(Rails.logger).to receive(:info).with("Finished searching")
+
+      FindSpecificTerm.call(term)
+    end
+  end
+end


### PR DESCRIPTION
This task was added back in after being removed during CD work, didn't realise it was still in use by the content community. So to make content-store compliant with test coverage for CD it needs to be tested adequately.

Trello: https://trello.com/c/aDiHro0u/26-enable-continuous-deployment-for-content-store