### PR TITLE
Small Dockerfile fixes for Replatforming.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,10 @@
 .git
 .gitignore
+Jenkinsfile
+Procfile
 README.md
+docs
+log
+spec
+test
+tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,9 @@ ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:3.1.2
 
 FROM $builder_image AS builder
 
-RUN mkdir /app
-
 WORKDIR /app
 
 COPY Gemfile* .ruby-version /app/
-
 RUN bundle install
 
 COPY . /app
@@ -18,12 +15,11 @@ FROM $base_image
 
 ENV GOVUK_APP_NAME=content-store
 
-RUN mkdir /app
+WORKDIR /app
 
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /app /app/
 
 USER app
-WORKDIR /app
 
 CMD bundle exec puma


### PR DESCRIPTION
Remove an unnecessary `mkdir /app from the Dockerfile, since this will be incompatible with an upcoming version of govuk-ruby-base.

Also remove some unneeded paths from the image.`