### PR TITLE
Revert "Bump plek from 4.0.0 to 4.1.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,7 +256,7 @@ GEM
     parser (3.1.2.1)
       ast (~> 2.4.1)
     parslet (2.0.0)
-    plek (4.1.0)
+    plek (4.0.0)
     prometheus_exporter (2.0.3)
       webrick
     pry (0.14.1)


### PR DESCRIPTION
Reverts alphagov/content-store#987

We are currently filling our log files with deprecation warnings for `Plek.current`, which is causing the machines to run out of disk space:
```
Plek.current is deprecated and will be removed. Use Plek.new or Plek.find instead.
```

Reverting until we replace all uses of this.