### PR TITLE
Replace Plek.current with Plek.new

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,7 +256,7 @@ GEM
     parser (3.1.2.1)
       ast (~> 2.4.1)
     parslet (2.0.0)
-    plek (4.0.0)
+    plek (4.1.0)
     prometheus_exporter (2.0.3)
       webrick
     pry (0.14.1)

--- a/app/presenters/expanded_links_presenter.rb
+++ b/app/presenters/expanded_links_presenter.rb
@@ -29,11 +29,11 @@ private
 
   def api_url(link)
     api_path = api_path(link)
-    Plek.current.website_root + api_path if api_path
+    Plek.new.website_root + api_path if api_path
   end
 
   def web_url(link)
-    Plek.current.website_root + link[:base_path] if link[:base_path]
+    Plek.new.website_root + link[:base_path] if link[:base_path]
   end
 
   def secret_fields

--- a/config/application.rb
+++ b/config/application.rb
@@ -114,7 +114,7 @@ module ContentStore
 
     def router_api
       @router_api ||= GdsApi::Router.new(
-        Plek.current.find("router-api"),
+        Plek.new.find("router-api"),
         bearer_token: ENV["ROUTER_API_BEARER_TOKEN"] || "example",
       )
     end

--- a/spec/presenters/expanded_links_presenter_spec.rb
+++ b/spec/presenters/expanded_links_presenter_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ExpandedLinksPresenter do
   describe ".present" do
     subject { described_class.new(links).present }
 
-    let(:prefix) { Plek.current.website_root }
+    let(:prefix) { Plek.new.website_root }
     let(:base_path) { "/test-page" }
     let(:api_path) { "/api/content/test-page" }
     let(:links) do
@@ -28,7 +28,7 @@ RSpec.describe ExpandedLinksPresenter do
 
       before do
         double = instance_double(Plek, website_root: production_prefix)
-        allow(Plek).to receive(:current).and_return(double)
+        allow(Plek).to receive(:new).and_return(double)
       end
 
       it { is_expected.to include expected }
@@ -49,7 +49,7 @@ RSpec.describe ExpandedLinksPresenter do
 
       before do
         double = instance_double(Plek, website_root: development_prefix)
-        allow(Plek).to receive(:current).and_return(double)
+        allow(Plek).to receive(:new).and_return(double)
       end
 
       it { is_expected.to include expected }


### PR DESCRIPTION
Usage of `Plek.current` was marked as deprecated in https://github.com/alphagov/plek/pull/94, therefore we should remove uses of the old syntax before upgrading Plek, else we'll log lots of deprecation warnings.

This resolves the issue that caused us to revert Plek from `4.1.0` to `4.0.0` in https://github.com/alphagov/content-store/pull/989.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

