### PR TITLE
Add task to exclude terms that match document type

### DIFF
--- a/app/lib/find_specific_term.rb
+++ b/app/lib/find_specific_term.rb
@@ -1,13 +1,13 @@
 require "csv"
 
 class FindSpecificTerm
-  attr_reader :term, :exclude_type
+  attr_reader :term, :exclude_types
 
   CONTENT_ITEM_HEADERS = ["Title", "URL", "Publishing application", "Tagged organisation", "Format", "Content ID"].freeze
 
-  def initialize(term, exclude_type = nil)
+  def initialize(term, exclude_types = [])
     @term = term
-    @exclude_type = exclude_type
+    @exclude_types = exclude_types
   end
 
   def call
@@ -26,7 +26,7 @@ private
     logger.info CONTENT_ITEM_HEADERS.join(",")
 
     term_content_items.each do |content_item|
-      logger.info content_item_fields(content_item).join(", ") unless content_item.document_type == exclude_type
+      logger.info content_item_fields(content_item).join(", ") unless exclude_types.include?(content_item.document_type)
     end
 
     logger.info "Found #{number_of_terms_items} items containing #{term}"
@@ -67,7 +67,7 @@ private
   end
 
   def number_of_terms_items
-    term_content_items.count { |content_item| content_item.document_type != exclude_type }
+    term_content_items.count { |content_item| exclude_types.exclude?(content_item.document_type) }
   end
 
   def term_content_items

--- a/app/lib/find_specific_term.rb
+++ b/app/lib/find_specific_term.rb
@@ -1,12 +1,13 @@
 require "csv"
 
 class FindSpecificTerm
-  attr_reader :term
+  attr_reader :term, :exclude_type
 
   CONTENT_ITEM_HEADERS = ["Title", "URL", "Publishing application", "Tagged organisation", "Format", "Content ID"].freeze
 
-  def initialize(term)
+  def initialize(term, exclude_type = nil)
     @term = term
+    @exclude_type = exclude_type
   end
 
   def call
@@ -22,15 +23,13 @@ private
   def report
     logger.info "Searching for #{term}..."
 
-    term_content_items = content_items(/#{term}/)
-
     logger.info CONTENT_ITEM_HEADERS.join(",")
 
     term_content_items.each do |content_item|
-      logger.info content_item_fields(content_item).join(", ")
+      logger.info content_item_fields(content_item).join(", ") unless content_item.document_type == exclude_type
     end
 
-    logger.info "Found #{term_content_items.count} items containing #{term}"
+    logger.info "Found #{number_of_terms_items} items containing #{term}"
 
     logger.info "Finished searching"
   end
@@ -65,5 +64,13 @@ private
       .or('details.more_information.content': term)
       .or('details.more_info_contact_form': term)
       .or('details.more_info_email_address': term).entries
+  end
+
+  def number_of_terms_items
+    term_content_items.count { |content_item| content_item.document_type != exclude_type }
+  end
+
+  def term_content_items
+    @term_content_items ||= content_items(/#{term}/)
   end
 end

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -8,4 +8,9 @@ namespace :report do
   task :find_specific_term_references, %i[term] => [:environment] do |_, args|
     FindSpecificTerm.call(args[:term])
   end
+
+  desc "Find all references to search term excluding document type"
+  task :find_specific_term_references_excluding_type, %i[term exclude_type] => [:environment] do |_, args|
+    FindSpecificTerm.call(args[:term], args[:exclude_type])
+  end
 end

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -9,8 +9,11 @@ namespace :report do
     FindSpecificTerm.call(args[:term])
   end
 
-  desc "Find all references to search term excluding document type"
-  task :find_specific_term_references_excluding_type, %i[term exclude_type] => [:environment] do |_, args|
-    FindSpecificTerm.call(args[:term], args[:exclude_type])
+  desc "Find all references to search term excluding document types"
+  task :find_specific_term_references_excluding_types, %i[term exclude_types] => [:environment] do |_, args|
+    raise "Missing excluded document types parameter" unless args[:exclude_types]
+
+    exclude_types = args[:exclude_types].split(" ")
+    FindSpecificTerm.call(args[:term], exclude_types)
   end
 end

--- a/spec/lib/find_specific_term_spec.rb
+++ b/spec/lib/find_specific_term_spec.rb
@@ -46,7 +46,7 @@ describe FindSpecificTerm do
 
       expect(Rails.logger).to receive(:info).with("Finished searching")
 
-      FindSpecificTerm.call(term, "test")
+      FindSpecificTerm.call(term, %w[test])
     end
   end
 end

--- a/spec/lib/find_specific_term_spec.rb
+++ b/spec/lib/find_specific_term_spec.rb
@@ -4,14 +4,16 @@ describe FindSpecificTerm do
   describe ".call" do
     let(:term) { "Test Content" }
 
-    it "finds 1 relevant content item" do
+    before do
       create(
         :content_item,
         document_type: "test",
         title: "Test Content",
         base_path: "/specific-term-test-content",
       )
+    end
 
+    it "finds 1 relevant content item" do
       expect(Rails.logger).to receive(:info).with("Searching for #{term}...")
 
       expect(Rails.logger).to receive(:info).with("Title,URL,Publishing application,Tagged organisation,Format,Content ID")
@@ -23,6 +25,28 @@ describe FindSpecificTerm do
       expect(Rails.logger).to receive(:info).with("Finished searching")
 
       FindSpecificTerm.call(term)
+    end
+
+    it "does not find content item if document type is excluded" do
+      create(
+        :content_item,
+        document_type: "other",
+        title: "Test Content 2",
+        base_path: "/specific-term-test-content-2",
+      )
+
+      expect(Rails.logger).to receive(:info).with("Searching for #{term}...")
+
+      expect(Rails.logger).to receive(:info).with("Title,URL,Publishing application,Tagged organisation,Format,Content ID")
+
+      expect(Rails.logger).to receive(:info).with("Found 1 items containing #{term}")
+
+      expect(Rails.logger).to_not receive(:info).with("Test Content, https://www.gov.uk/specific-term-test-content, publisher, , test, ")
+      expect(Rails.logger).to receive(:info).with("Test Content 2, https://www.gov.uk/specific-term-test-content-2, publisher, , other, ")
+
+      expect(Rails.logger).to receive(:info).with("Finished searching")
+
+      FindSpecificTerm.call(term, "test")
     end
   end
 end


### PR DESCRIPTION
# What's changed?

Adds a task to find content that doesn't match a particular format. 

Usage:

```
bundle exec rake report:find_specific_term_references_excluding_types[Term,"doc_type_1 doc_type_2"]
```

e.g.

```
bundle exec rake report:find_specific_term_references_excluding_types[Licence,"licence aaib_report"]
```

# Why?

Content items aren't always created using the expected format.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

