### PR TITLE
Lint: use list syntax for Dockerfile CMD.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ COPY --from=builder /app /app/
 
 USER app
 
-CMD bundle exec puma
+CMD ["bundle", "exec", "puma"]


### PR DESCRIPTION
Generated with `gsed -i 's/^CMD bundle exec puma$/CMD [bundle, exec, puma]/'`