### PR TITLE
Allow cross-origin requests to access public content endpoint

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -1,6 +1,7 @@
 class ContentItemsController < ApplicationController
   skip_before_action :authenticate_user!, only: [:show]
   before_action :parse_json_request, only: [:update]
+  before_action :set_cors_headers, only: [:show]
 
   def show
     item = GovukStatsd.time("show.find_content_item") do
@@ -128,6 +129,11 @@ private
     end
 
     expires_in bounded_max_age(cache_time), public: is_public
+  end
+
+  def set_cors_headers
+    # Allow any origin host to request the resource
+    response.headers["Access-Control-Allow-Origin"] = "*"
   end
 
   # Constrain the cache time to be within the minimum_ttl and default_ttl.

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -89,6 +89,10 @@ describe "Fetching content items", type: :request do
       expect(cache_control["public"]).to eq(true)
     end
 
+    it "sets a access-control-allow-origin header to allow cross origin requests" do
+      expect(response.headers.to_h).to include({ "Access-Control-Allow-Origin" => "*" })
+    end
+
     context "when the user is not authenticated" do
       around do |example|
         ClimateControl.modify(GDS_SSO_MOCK_INVALID: "1") { example.run }


### PR DESCRIPTION
This addresses https://github.com/alphagov/content-store/issues/1006

This sets a `Access-Control-Allow-Origin: *` header on HTTP responses to the show endpoint, this will allow requests to this API to originate (via JS) from hosts other than www.gov.uk.

The reason for adding this is resolve the issue raised on GitHub 1006 [1]. GOV.UK doesn't directly need this as it doesn't make use of client side requests to the Content Store and, if it did, they'd be from the same host. However this is added in to reflect that this is indeed a partially supported public API [2] and that we are not concerned with JS clients calling it from a different host.

I only put this on the one endpoint as there didn't seem to be any need to have it on endpoints other than ContentItems#show. I also didn't implement the HTTP OPTIONS method for the endpoint as I don't think it's strictly needed and can't see evidence of this enabled on other GOV.UK cross-origin endpoints:

➜  ~ curl -sI -X OPTIONS https://www.gov.uk/api/search.json\?fields\=publishing_app\&filter_publishing_app\=publisher\&filter_first_published_at\=from:2022-09-01,to:2022-09-30 | grep HTTP HTTP/2 404

[1]: https://github.com/alphagov/content-store/issues/1006
[2]: https://content-api.publishing.service.gov.uk/

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

