### PR TITLE
Add a feature flag to disable modifying Router backends on the fly.

### DIFF
--- a/app/models/route_set.rb
+++ b/app/models/route_set.rb
@@ -67,7 +67,14 @@ class RouteSet < OpenStruct
         register_gone_route(route)
       end
     else
-      register_rendering_app
+      # TODO: clean up NO_SET_ROUTER_BACKEND_ADDRESS_ON_PUBLISH after
+      # Replatforming MVP launch (i.e. once GOV.UK is running on Kubernetes in
+      # production). This could be done by removing the flag (i.e. kicking the
+      # can down the road) or by removing the concept of dynamically
+      # configuring Router backends entirely (probably better), or perhaps even
+      # something else.
+      truthy_env_values = /^[1ty]/i
+      register_rendering_app unless truthy_env_values.match?(ENV["NO_SET_ROUTER_BACKEND_ADDRESS_ON_PUBLISH"])
 
       routes.each do |route|
         register_route(route, rendering_app)

--- a/spec/models/route_set_spec.rb
+++ b/spec/models/route_set_spec.rb
@@ -170,6 +170,26 @@ describe RouteSet, type: :model do
       route_set.register!
     end
 
+    describe "when NO_SET_ROUTER_BACKEND_ADDRESS_ON_PUBLISH=1" do
+      around do |t|
+        ClimateControl.modify NO_SET_ROUTER_BACKEND_ADDRESS_ON_PUBLISH: "1" do
+          t.run
+        end
+      end
+
+      it "does not call router_api.add_backend" do
+        expect(Rails.application.router_api).not_to receive(:add_backend)
+        expect(Rails.application.router_api).to receive(:commit_routes)
+
+        route_set = RouteSet.new(base_path: "/path", rendering_app: "frontend")
+        route_set.routes = [
+          { path: "/path", type: "exact" },
+          { path: "/path/sub/path", type: "prefix" },
+        ]
+        route_set.register!
+      end
+    end
+
     it "registers and commits all registerable redirects for a redirect item" do
       redirects = [
         { path: "/path", type: "exact", destination: "/new-path" },


### PR DESCRIPTION
Content Store currently updates the backend address in Router every time a content item or publishing intent is saved. This was originally done [to simplify a long-since-completed migration](https://github.com/alphagov/content-store/pull/23), but it's now both unnecessary and causes problems with parallel running for Replatforming, where the backend addresses necessarily differ between the old and new installations.

This lets us disable this esoteric behaviour on the Kubernetes side during the Replatforming pilot phase.

Tested: verified that router_api.add_backend is called when the NO_SET_ROUTER_BACKEND_ADDRESS_ON_PUBLISH env var is not set and not otherwise.