### PR TITLE
Hold back bad version 2.8.0 of the `mail` rubygem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem "rails", "7.0.4"
 gem "gds-api-adapters"
 gem "gds-sso"
 gem "govuk_app_config"
+gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "mongo", "2.15.0" # Later releases require Mongo >= 3.6
 gem "mongoid"
 gem "plek"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -438,6 +438,7 @@ DEPENDENCIES
   govuk_schemas
   govuk_test
   listen
+  mail (~> 2.7.1)
   mongo (= 2.15.0)
   mongoid
   pact


### PR DESCRIPTION
Version 2.8.0 of the `mail` gem has the wrong filesystem permissions on a few of its .rb files (seems to be the generated tables?), which breaks the app when running as an unprivileged user. We therefore need to hold back this version of the gem until a new version is released that fixes the issue.

The upstream bug is mikel/mail#1489. We can remove this workaround once the bug is fixed.
