### PR TITLE
Add Pact tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,8 @@ jobs:
           GOVUK_CONTENT_SCHEMAS_PATH: vendor/publishing-api/content_schemas
         run: bundle exec rake spec
 
+  pact-test:
+    name: Run Pact tests
+    uses: ./.github/workflows/verify-pact.yml
+    with:
+      pact_consumer_version: 'branch-deployed-to-production'

--- a/.github/workflows/verify-pact.yml
+++ b/.github/workflows/verify-pact.yml
@@ -1,0 +1,43 @@
+name: Run Pact tests
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: false
+        type: string
+      pact_consumer_version:
+        required: true
+        type: string
+
+jobs:
+  pact_verify:
+    name: Verify pact tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup MongoDB
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-mongodb@main
+        with:
+          version: 2.6
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          repository: alphagov/content-store
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Initialize database
+        env:
+          RAILS_ENV: test
+        run: bundle exec rails db:setup
+
+      - name: Run Pact tests
+        env:
+          RAILS_ENV: test
+          PACT_CONSUMER_VERSION: ${{ inputs.pact_consumer_version }}
+        run: bundle exec rake pact:verify


### PR DESCRIPTION
This adds a reuseable workflow to run Pact tests. This workflow is called during CI and also CI for Publishing API.
