### PR TITLE
Remove workaround for bad `mail` gem release.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gem "bootsnap", require: false
 gem "gds-api-adapters"
 gem "gds-sso"
 gem "govuk_app_config"
-gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "mongo", "2.15.0" # Later releases require Mongo >= 3.6
 gem "mongoid"
 gem "plek"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,7 @@ GEM
     database_cleaner-mongoid (2.0.1)
       database_cleaner-core (~> 2.0.0)
       mongoid
+    date (3.3.3)
     diff-lcs (1.5.0)
     docile (1.4.0)
     domain_name (0.5.20190701)
@@ -173,8 +174,11 @@ GEM
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
+    mail (2.8.0.1)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
@@ -192,11 +196,12 @@ GEM
       ruby2_keywords (~> 0.0.5)
     msgpack (1.6.0)
     multi_xml (0.6.0)
-    net-imap (0.3.1)
+    net-imap (0.3.4)
+      date
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.1.3)
+    net-protocol (0.2.1)
       timeout
     net-smtp (0.3.3)
       net-protocol
@@ -392,7 +397,7 @@ GEM
       tins (~> 1.0)
     thor (1.2.1)
     timecop (0.9.6)
-    timeout (0.3.0)
+    timeout (0.3.1)
     tins (1.31.1)
       sync
     tzinfo (2.0.5)
@@ -442,7 +447,6 @@ DEPENDENCIES
   govuk_schemas
   govuk_test
   listen
-  mail (~> 2.7.1)
   mongo (= 2.15.0)
   mongoid
   pact


### PR DESCRIPTION
Remove the version constraint that we were using to avoid the bad release of the `mail` gem, now that https://www.github.com/mikel/mail/issues/1489 is fixed.

Update to `2.8.0.1`, which fixes the permissions issue.

Generated with `gsed -i '/gem "mail"/d' && bundle update mail`.
