### PR TITLE
Replace CSP with a comment explaining why we don't have one

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,1 +1,1 @@
-GovukContentSecurityPolicy.configure
+# As this is an API application without HTML rendering we have not set-up a Content Security Policy


### PR DESCRIPTION
Trello: https://trello.com/c/lxxx5XLZ/178-govuk-has-a-half-implemented-content-security-policy-csp

This comment has been done to explain to future people why this app doesn't need one.

This CSP was added as part of a round of Rails upgrades [1] on GOV.UK apps which was applied quite uniformly, so the context of this app being API only wasn't considered.

[1]: https://github.com/alphagov/content-store/pull/746

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
