### PR TITLE
Allow verify-pact workflow to accept an artifact input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,8 @@ jobs:
     name: Run Pact tests
     uses: ./.github/workflows/verify-pact.yml
     with:
+      # Note: As of January 2023 this relies on Jenkins CI to generate
+      # this Pact consumer version. Replatforming does not tag
+      # deployed-to-production and the Publishing API CI build doesn't run
+      # against the tag when one is created.
       pact_consumer_version: 'branch-deployed-to-production'

--- a/.github/workflows/verify-pact.yml
+++ b/.github/workflows/verify-pact.yml
@@ -6,14 +6,25 @@ on:
       ref:
         required: false
         type: string
-      pact_consumer_version:
-        required: true
+      # A GitHub Action artifact which contains the pact definition files
+      # Publishing API calls this action to test new pacts against this
+      # workflow
+      pact_artifact:
+        required: false
         type: string
+      # Which version of the pacts to use from the Pact Broker service
+      # This option will be ignored if pact_artifact is set
+      pact_consumer_version:
+        required: false
+        type: string
+        default: branch-deployed-to-production
 
 jobs:
   pact_verify:
     name: Verify pact tests
     runs-on: ubuntu-latest
+    env:
+      RAILS_ENV: test
     steps:
       - name: Setup MongoDB
         uses: alphagov/govuk-infrastructure/.github/actions/setup-mongodb@main
@@ -32,12 +43,21 @@ jobs:
           bundler-cache: true
 
       - name: Initialize database
-        env:
-          RAILS_ENV: test
         run: bundle exec rails db:setup
 
-      - name: Run Pact tests
+      - name: Verify pact consumer version
+        if: inputs.pact_artifact == ''
         env:
-          RAILS_ENV: test
           PACT_CONSUMER_VERSION: ${{ inputs.pact_consumer_version }}
         run: bundle exec rake pact:verify
+
+      - name: Download pact artifact
+        if: inputs.pact_artifact != ''
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.pact_artifact }}
+          path: tmp/pacts
+
+      - name: Verify pact artifact
+        if: inputs.pact_artifact != ''
+        run: bundle exec rake pact:verify:at[tmp/pacts/publishing_api-content_store.json]


### PR DESCRIPTION
This provides an alternative method for this workflow to execute
Publishing API pact tests. Rather than accessing the Pact tests via the
internet, downloading them from the pact-broker, this instead allows an
input of an artifact filename. This action will download that artifact
and run against the pacts.

The motivation for this approach is that it can allow the Publishing API
CI [1] to execute these tests without the initiator of a Publishing API
needing access to write to the GOV.UK Pact Broker. This is a problem we
are currently experiencing with Dependabot as it does not have access to
GitHub Action secrets.

At the moment, and likely for the forseeable future, there isn't a
scenario where we'd need to use any file other than
`publishing_api-content_store.json` so I've hardcoded this. We can
always change it to a parameter in future if there is a need.

[1]: https://github.com/alphagov/publishing-api/blob/a4bf641a571b8eeeb61f3ca1640a1ff26233423e/.github/workflows/ci.yml#L97-L103

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
