### PR TITLE
Make schedule.rb empty to remove EC2 cron jobs

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,11 +1,1 @@
-require "whenever"
-
-# default cron env is "/usr/bin:/bin" which is not sufficient as govuk_setenv is in /usr/local/bin
-env :PATH, "/usr/local/bin:/usr/bin:/bin"
-
-set :output, error: "log/cron.error.log", standard: "log/cron.log"
-job_type :rake, "cd :path && govuk_setenv content-store bundle exec rake :task :output"
-
-every 1.day, at: "2:15 am" do
-  rake "publishing_delay_report:report_delays"
-end
+# File required to ensure cronjobs are removed


### PR DESCRIPTION
https://github.com/alphagov/govuk-helm-charts/blob/main/charts/app-config/values-integration.yaml#L646

Removing contents from schedule.rb as state is covered in EKS