### PR TITLE
Mock out router-api calls when DISABLE_ROUTER_API is true

### DIFF
--- a/app/lib/mock_router_api.rb
+++ b/app/lib/mock_router_api.rb
@@ -3,33 +3,19 @@
 # This is to allow dual-running of both MongoDB and PostgreSQL Content Stores
 # for a transition period during the migration to PostgreSQL
 class MockRouterApi
-  def delete_route(*args)
-    log("delete_route", args)
+  # Whatever the application tries to send to router-api,
+  # just log it and do nothing else
+  def method_missing(method_name, *args, **kwargs, &_block)
+    log(method_name.to_s, args, kwargs)
   end
 
-  def add_backend(*args)
-    log "add_backend", args
-  end
-
-  def add_redirect_route(*args)
-    log "add_redirect_route", args
-  end
-
-  def add_gone_route(*args)
-    log "add_gone_route", args
-  end
-
-  def add_route(*args)
-    log "add_route", args
-  end
-
-  def commit_routes(*args)
-    log "commit_routes", args
+  def respond_to_missing?(method, *)
+    GdsApi.router.methods.include?(method) || super
   end
 
 private
 
-  def log(method, args)
-    logger.debug "Mocked call to router_api: #{method}(#{args})"
+  def log(method, *args, **kwargs)
+    logger.debug "Mocked call to router_api: #{method}(#{args}, #{kwargs})"
   end
 end

--- a/app/lib/mock_router_api.rb
+++ b/app/lib/mock_router_api.rb
@@ -1,0 +1,35 @@
+# When DISABLE_ROUTER_API is set to true, the application will use this
+# class instead of GdsApi::Router
+# This is to allow dual-running of both MongoDB and PostgreSQL Content Stores
+# for a transition period during the migration to PostgreSQL
+class MockRouterApi
+  def delete_route(*args)
+    log("delete_route", args)
+  end
+
+  def add_backend(*args)
+    log "add_backend", args
+  end
+
+  def add_redirect_route(*args)
+    log "add_redirect_route", args
+  end
+
+  def add_gone_route(*args)
+    log "add_gone_route", args
+  end
+
+  def add_route(*args)
+    log "add_route", args
+  end
+
+  def commit_routes(*args)
+    log "commit_routes", args
+  end
+
+private
+
+  def log(method, args)
+    logger.debug "Mocked call to router_api: #{method}(#{args})"
+  end
+end

--- a/app/lib/mock_router_api.rb
+++ b/app/lib/mock_router_api.rb
@@ -16,6 +16,6 @@ class MockRouterApi
 private
 
   def log(method, *args, **kwargs)
-    logger.debug "Mocked call to router_api: #{method}(#{args}, #{kwargs})"
+    Rails.logger.info "Mocked call to router_api: #{method}(#{args}, #{kwargs})"
   end
 end

--- a/app/models/route_set.rb
+++ b/app/models/route_set.rb
@@ -137,7 +137,7 @@ private
   end
 
   def router_api
-    Rails.application.router_api
+    @router_api ||= Rails.application.router_api
   end
 
   def paths

--- a/config/application.rb
+++ b/config/application.rb
@@ -113,10 +113,18 @@ module ContentStore
     config.register_router_retries = 3
 
     def router_api
-      @router_api ||= GdsApi::Router.new(
-        Plek.find("router-api"),
-        bearer_token: ENV["ROUTER_API_BEARER_TOKEN"] || "example",
-      )
+      @router_api ||= new_router_api_adapter
+    end
+
+    def new_router_api_adapter
+      if ENV["DISABLE_ROUTER_API"].to_s == "true"
+        MockRouterApi.new
+      else
+        GdsApi::Router.new(
+          Plek.find("router-api"),
+          bearer_token: ENV["ROUTER_API_BEARER_TOKEN"] || "example",
+        )
+      end
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -113,7 +113,7 @@ module ContentStore
     config.register_router_retries = 3
 
     def router_api
-      if ENV["DISABLE_ROUTER_API"].to_s == "true"
+      if ENV["DISABLE_ROUTER_API"] == "true"
         MockRouterApi.new
       else
         GdsApi.router

--- a/config/application.rb
+++ b/config/application.rb
@@ -113,17 +113,10 @@ module ContentStore
     config.register_router_retries = 3
 
     def router_api
-      @router_api ||= new_router_api_adapter
-    end
-
-    def new_router_api_adapter
       if ENV["DISABLE_ROUTER_API"].to_s == "true"
         MockRouterApi.new
       else
-        GdsApi::Router.new(
-          Plek.find("router-api"),
-          bearer_token: ENV["ROUTER_API_BEARER_TOKEN"] || "example",
-        )
+        GdsApi.router
       end
     end
   end

--- a/lib/tasks/register_backends.rake
+++ b/lib/tasks/register_backends.rake
@@ -3,11 +3,13 @@ desc "
   database.
 "
 task register_backends: :environment do
+  router_api = Rails.application.router_api
+
   ContentItem.distinct(:rendering_app).compact.each do |rendering_app|
     backend = "#{Plek.find(rendering_app)}/"
     puts "Adding backend #{backend} for #{rendering_app}"
-    Rails.application.router_api.add_backend(rendering_app, backend)
+    router_api.add_backend(rendering_app, backend)
   end
 
-  Rails.application.router_api.commit_routes
+  router_api.commit_routes
 end

--- a/spec/config/application_config_spec.rb
+++ b/spec/config/application_config_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe ContentStore::Application, "configuration" do
+  let(:config) { Rails.application }
+
+  describe "#router_api" do
+    context "when DISABLE_ROUTER_API is 'true'" do
+      around do |t|
+        ClimateControl.modify DISABLE_ROUTER_API: "true" do
+          t.run
+        end
+      end
+
+      it "returns a MockRouterApi" do
+        expect(config.router_api).to be_a(MockRouterApi)
+      end
+    end
+
+    context "when DISABLE_ROUTER_API is not 'true'" do
+      around do |t|
+        ClimateControl.modify DISABLE_ROUTER_API: "" do
+          t.run
+        end
+      end
+
+      it "returns an instance of what GdsApi.router returns" do
+        expect(config.router_api).to be_a(GdsApi.router.class)
+      end
+    end
+  end
+end

--- a/spec/lib/mock_router_api_spec.rb
+++ b/spec/lib/mock_router_api_spec.rb
@@ -11,7 +11,7 @@ describe MockRouterApi do
 
     it "does not make any requests" do
       expect(a_request(:any, /.*/)).not_to have_been_made
-      subject.send(:an_arbitrary_method_name, 1, 2, 3)
+      subject.send(an_arbitrary_method_name, 1, 2, 3)
     end
   end
 end

--- a/spec/lib/mock_router_api_spec.rb
+++ b/spec/lib/mock_router_api_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+describe MockRouterApi do
+  describe "#delete_route" do
+    it "logs the method and arguments with debug level" do
+      expect(subject).to receive(:log).with("delete_route", [1, 2, 3])
+      subject.delete_route(1, 2, 3)
+    end
+
+    it "does not make any requests" do
+      expect(a_request(:any, "*")).not_to have_been_made
+      subject.delete_route(1, 2, 3)
+    end
+  end
+
+  describe "#add_backend" do
+    it "logs the method and arguments with debug level" do
+      expect(subject).to receive(:log).with("add_backend", [1, 2, 3])
+      subject.add_backend(1, 2, 3)
+    end
+
+    it "does not make any requests" do
+      expect(a_request(:any, "*")).not_to have_been_made
+      subject.add_backend(1, 2, 3)
+    end
+  end
+
+  describe "#add_redirect_route" do
+    it "logs the method and arguments with debug level" do
+      expect(subject).to receive(:log).with("add_redirect_route", [1, 2, 3])
+      subject.add_redirect_route(1, 2, 3)
+    end
+
+    it "does not make any requests" do
+      expect(a_request(:any, "*")).not_to have_been_made
+      subject.add_redirect_route(1, 2, 3)
+    end
+  end
+
+  describe "#add_gone_route" do
+    it "logs the method and arguments with debug level" do
+      expect(subject).to receive(:log).with("add_gone_route", [1, 2, 3])
+      subject.add_gone_route(1, 2, 3)
+    end
+
+    it "does not make any requests" do
+      expect(a_request(:any, "*")).not_to have_been_made
+      subject.add_gone_route(1, 2, 3)
+    end
+  end
+
+  describe "#add_route" do
+    it "logs the method and arguments with debug level" do
+      expect(subject).to receive(:log).with("add_route", [1, 2, 3])
+      subject.add_route(1, 2, 3)
+    end
+
+    it "does not make any requests" do
+      expect(a_request(:any, "*")).not_to have_been_made
+      subject.add_route(1, 2, 3)
+    end
+  end
+
+  describe "#commit_routes" do
+    it "logs the method and arguments with debug level" do
+      expect(subject).to receive(:log).with("commit_routes", [1, 2, 3])
+      subject.commit_routes(1, 2, 3)
+    end
+
+    it "does not make any requests" do
+      expect(a_request(:any, "*")).not_to have_been_made
+      subject.commit_routes(1, 2, 3)
+    end
+  end
+end

--- a/spec/lib/mock_router_api_spec.rb
+++ b/spec/lib/mock_router_api_spec.rb
@@ -1,75 +1,17 @@
 require "rails_helper"
 
 describe MockRouterApi do
-  describe "#delete_route" do
+  describe "#any_method" do
+    let(:an_arbitrary_method_name) { "abcdefghijklmnopqrstuvwxyz_".chars.sample(10).join }
+
     it "logs the method and arguments with debug level" do
-      expect(subject).to receive(:log).with("delete_route", [1, 2, 3])
-      subject.delete_route(1, 2, 3)
+      expect(subject).to receive(:log).with(an_arbitrary_method_name, [1, 2, 3], { keyword: "value" })
+      subject.send(an_arbitrary_method_name, 1, 2, 3, keyword: "value")
     end
 
     it "does not make any requests" do
-      expect(a_request(:any, "*")).not_to have_been_made
-      subject.delete_route(1, 2, 3)
-    end
-  end
-
-  describe "#add_backend" do
-    it "logs the method and arguments with debug level" do
-      expect(subject).to receive(:log).with("add_backend", [1, 2, 3])
-      subject.add_backend(1, 2, 3)
-    end
-
-    it "does not make any requests" do
-      expect(a_request(:any, "*")).not_to have_been_made
-      subject.add_backend(1, 2, 3)
-    end
-  end
-
-  describe "#add_redirect_route" do
-    it "logs the method and arguments with debug level" do
-      expect(subject).to receive(:log).with("add_redirect_route", [1, 2, 3])
-      subject.add_redirect_route(1, 2, 3)
-    end
-
-    it "does not make any requests" do
-      expect(a_request(:any, "*")).not_to have_been_made
-      subject.add_redirect_route(1, 2, 3)
-    end
-  end
-
-  describe "#add_gone_route" do
-    it "logs the method and arguments with debug level" do
-      expect(subject).to receive(:log).with("add_gone_route", [1, 2, 3])
-      subject.add_gone_route(1, 2, 3)
-    end
-
-    it "does not make any requests" do
-      expect(a_request(:any, "*")).not_to have_been_made
-      subject.add_gone_route(1, 2, 3)
-    end
-  end
-
-  describe "#add_route" do
-    it "logs the method and arguments with debug level" do
-      expect(subject).to receive(:log).with("add_route", [1, 2, 3])
-      subject.add_route(1, 2, 3)
-    end
-
-    it "does not make any requests" do
-      expect(a_request(:any, "*")).not_to have_been_made
-      subject.add_route(1, 2, 3)
-    end
-  end
-
-  describe "#commit_routes" do
-    it "logs the method and arguments with debug level" do
-      expect(subject).to receive(:log).with("commit_routes", [1, 2, 3])
-      subject.commit_routes(1, 2, 3)
-    end
-
-    it "does not make any requests" do
-      expect(a_request(:any, "*")).not_to have_been_made
-      subject.commit_routes(1, 2, 3)
+      expect(a_request(:any, /.*/)).not_to have_been_made
+      subject.send(:an_arbitrary_method_name, 1, 2, 3)
     end
   end
 end

--- a/spec/models/route_set_spec.rb
+++ b/spec/models/route_set_spec.rb
@@ -125,17 +125,19 @@ describe RouteSet, type: :model do
   end
 
   describe "#register!" do
+    let(:route_set) { RouteSet.new(base_path: "/path", rendering_app: "frontend") }
+    let(:router_api) { route_set.router_api }
+
     context "for a non-redirect route set" do
       before :each do
-        @route_set = RouteSet.new(base_path: "/path", rendering_app: "frontend")
-        @route_set.routes = [
+        route_set.routes = [
           { path: "/path", type: "exact" },
           { path: "/path/sub/path", type: "prefix" },
         ]
       end
 
       it "registers and commits all registerable routes" do
-        @route_set.register!
+        route_set.register!
         assert_routes_registered(
           "frontend",
           [
@@ -146,10 +148,10 @@ describe RouteSet, type: :model do
       end
 
       it "registers and commits all registerable routes and redirects" do
-        @route_set.redirects = [
+        route_set.redirects = [
           { path: "/path.json", type: "exact", destination: "/api/content/path" },
         ]
-        @route_set.register!
+        route_set.register!
         assert_routes_registered(
           "frontend",
           [
@@ -164,9 +166,9 @@ describe RouteSet, type: :model do
     it "is a no-op with no routes or redirects" do
       route_set = RouteSet.new(base_path: "/path", rendering_app: "frontend")
 
-      expect(route_set.router_api).not_to receive(:add_backend)
-      expect(route_set.router_api).not_to receive(:add_route)
-      expect(route_set.router_api).not_to receive(:commit_routes)
+      expect_any_instance_of(GdsApi::Router).not_to receive(:add_backend)
+      expect_any_instance_of(GdsApi::Router).not_to receive(:add_route)
+      expect_any_instance_of(GdsApi::Router).not_to receive(:commit_routes)
 
       route_set.register!
     end
@@ -185,7 +187,7 @@ describe RouteSet, type: :model do
           { path: "/path", type: "exact" },
           { path: "/path/sub/path", type: "prefix" },
         ]
-        expect(route_set.router_api).not_to receive(:add_backend)
+        expect_any_instance_of(GdsApi::Router).not_to receive(:add_backend)
         route_set.register!
       end
 

--- a/spec/models/route_set_spec.rb
+++ b/spec/models/route_set_spec.rb
@@ -162,11 +162,12 @@ describe RouteSet, type: :model do
     end
 
     it "is a no-op with no routes or redirects" do
-      expect(Rails.application.router_api).not_to receive(:add_backend)
-      expect(Rails.application.router_api).not_to receive(:add_route)
-      expect(Rails.application.router_api).not_to receive(:commit_routes)
-
       route_set = RouteSet.new(base_path: "/path", rendering_app: "frontend")
+
+      expect(route_set.router_api).not_to receive(:add_backend)
+      expect(route_set.router_api).not_to receive(:add_route)
+      expect(route_set.router_api).not_to receive(:commit_routes)
+
       route_set.register!
     end
 
@@ -177,15 +178,23 @@ describe RouteSet, type: :model do
         end
       end
 
-      it "does not call router_api.add_backend" do
-        expect(Rails.application.router_api).not_to receive(:add_backend)
-        expect(Rails.application.router_api).to receive(:commit_routes)
+      let(:route_set) { RouteSet.new(base_path: "/path", rendering_app: "frontend") }
 
-        route_set = RouteSet.new(base_path: "/path", rendering_app: "frontend")
+      it "does not call router_api.add_backend" do
         route_set.routes = [
           { path: "/path", type: "exact" },
           { path: "/path/sub/path", type: "prefix" },
         ]
+        expect(route_set.router_api).not_to receive(:add_backend)
+        route_set.register!
+      end
+
+      it "does call commit_routes" do
+        route_set.routes = [
+          { path: "/path", type: "exact" },
+          { path: "/path/sub/path", type: "prefix" },
+        ]
+        expect(route_set).to receive(:commit_routes)
         route_set.register!
       end
     end


### PR DESCRIPTION
Allows [router-api](https://github.com/alphagov/router-api) calls to be disabled by setting this environment variable. 
This then allows us to avoid the potential for conflicts when we deploy both the Mongo and [PostgreSQL](https://github.com/alphagov/content-store-on-postgresql) versions simultaneously behind a [mirroring proxy](https://github.com/alphagov/content-store-proxy), during the migration of content-store from Mongo to PostgreSQL. In this scenario, only the primary will update routes in Router API, and the secondary will not.

[Trello card](https://trello.com/c/pgBHpAZ7/616-put-all-router-api-updates-behind-a-feature-flag-in-content-store) / [Overall Epic](https://trello.com/c/C1BQDFTG/502-plan-for-migrating-content-store-off-mongodb)

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
