### PR TITLE
Update to gds-api-adaptors 88 + fix up test helpers.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,7 @@ GEM
     ffi (1.15.5)
     filelock (1.1.1)
     find_a_port (1.0.1)
-    gds-api-adapters (87.1.0)
+    gds-api-adapters (88.0.0)
       addressable
       link_header
       null_logger

--- a/app/models/route_set.rb
+++ b/app/models/route_set.rb
@@ -75,8 +75,6 @@ class RouteSet < OpenStruct
         register_redirect(route)
       end
     end
-
-    commit_routes
   end
 
   def delete!
@@ -88,8 +86,6 @@ class RouteSet < OpenStruct
       # Ignore this, as this path could have already been deleted
       next
     end
-
-    commit_routes
   end
 
 private
@@ -117,10 +113,6 @@ private
       route.fetch(:type),
       rendering_app,
     )
-  end
-
-  def commit_routes
-    router_api.commit_routes
   end
 
   def router_api

--- a/lib/tasks/register_backends.rake
+++ b/lib/tasks/register_backends.rake
@@ -10,6 +10,4 @@ task register_backends: :environment do
     puts "Adding backend #{backend} for #{rendering_app}"
     router_api.add_backend(rendering_app, backend)
   end
-
-  router_api.commit_routes
 end

--- a/spec/integration/deleting_a_content_item_spec.rb
+++ b/spec/integration/deleting_a_content_item_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe "Deleting a content item", type: :request do
       delete "/content/vat-rates"
 
       @delete_stubs.each { |stub| assert_requested(stub, times: 1) }
-      assert_requested(stub_router_commit, times: 1)
     end
 
     it "returns a 200" do

--- a/spec/integration/submitting_content_item_spec.rb
+++ b/spec/integration/submitting_content_item_spec.rb
@@ -272,7 +272,7 @@ describe "content item write API", type: :request do
 
     context "when the router-api is unavailable" do
       let!(:stub) do
-        stub_http_request(:post, "#{GdsApi::TestHelpers::Router::ROUTER_API_ENDPOINT}/routes/commit")
+        stub_http_request(:any, /^#{Regexp.escape(GdsApi::TestHelpers::Router::ROUTER_API_ENDPOINT)}\//)
           .to_return(status: 500)
       end
 

--- a/spec/support/router_helpers.rb
+++ b/spec/support/router_helpers.rb
@@ -7,38 +7,34 @@ module RouterHelpers
     # NOTE: WebMock stubs allow you to assert against already executed requests.
 
     routes.each do |(path, type)|
-      route_signature, = stub_route_registration(path, type, rendering_app)
+      route_signature = stub_route_registration(path, type, rendering_app)
       assert_requested(route_signature, times: 1)
     end
-    assert_requested(stub_router_commit, times: 1)
   end
 
   def assert_gone_routes_registered(routes)
     # NOTE: WebMock stubs allow you to assert against already executed requests.
 
     routes.each do |(path, type)|
-      route_signature, = stub_gone_route_registration(path, type)
+      route_signature = stub_gone_route_registration(path, type)
       assert_requested(route_signature, times: 1)
     end
-    assert_requested(stub_router_commit, times: 1)
   end
 
   def assert_redirect_routes_registered(redirects)
     # NOTE: WebMock stubs allow you to assert against already executed requests.
 
     redirects.each do |(path, type, destination, segments_mode)|
-      redirect_signature, = stub_redirect_registration(path, type, destination, "permanent", segments_mode)
+      redirect_signature = stub_redirect_registration(path, type, destination, "permanent", segments_mode)
       assert_requested(redirect_signature, times: 1)
     end
-    assert_requested(stub_router_commit, times: 1)
   end
 
   def refute_routes_registered(rendering_app, routes)
     routes.each do |(path, type)|
-      route_signature, = stub_route_registration(path, type, rendering_app)
+      route_signature = stub_route_registration(path, type, rendering_app)
       assert_not_requested(route_signature)
     end
-    assert_not_requested(stub_router_commit)
   end
 
   def assert_no_routes_registered_for_path(path)


### PR DESCRIPTION
No functional change. See https://github.com/alphagov/router-api/pull/550.

Depends on https://github.com/alphagov/gds-api-adapters/pull/1196 and #1077.

