### PR TITLE
Clean up NO_SET_ROUTER_BACKEND_ADDRESS_ON_PUBLISH flag.

### DIFF
--- a/app/models/route_set.rb
+++ b/app/models/route_set.rb
@@ -67,15 +67,6 @@ class RouteSet < OpenStruct
         register_gone_route(route)
       end
     else
-      # TODO: clean up NO_SET_ROUTER_BACKEND_ADDRESS_ON_PUBLISH after
-      # Replatforming MVP launch (i.e. once GOV.UK is running on Kubernetes in
-      # production). This could be done by removing the flag (i.e. kicking the
-      # can down the road) or by removing the concept of dynamically
-      # configuring Router backends entirely (probably better), or perhaps even
-      # something else.
-      truthy_env_values = /^[1ty]/i
-      register_rendering_app unless truthy_env_values.match?(ENV["NO_SET_ROUTER_BACKEND_ADDRESS_ON_PUBLISH"])
-
       routes.each do |route|
         register_route(route, rendering_app)
       end
@@ -102,10 +93,6 @@ class RouteSet < OpenStruct
   end
 
 private
-
-  def register_rendering_app
-    router_api.add_backend(rendering_app, "#{Plek.find(rendering_app)}/")
-  end
 
   def register_redirect(route)
     router_api.add_redirect_route(

--- a/spec/models/route_set_spec.rb
+++ b/spec/models/route_set_spec.rb
@@ -136,7 +136,7 @@ describe RouteSet, type: :model do
         ]
       end
 
-      it "registers and commits all registerable routes" do
+      it "registers all registerable routes" do
         route_set.register!
         assert_routes_registered(
           "frontend",
@@ -147,7 +147,7 @@ describe RouteSet, type: :model do
         )
       end
 
-      it "registers and commits all registerable routes and redirects" do
+      it "registers all registerable routes and redirects" do
         route_set.redirects = [
           { path: "/path.json", type: "exact", destination: "/api/content/path" },
         ]
@@ -166,42 +166,12 @@ describe RouteSet, type: :model do
     it "is a no-op with no routes or redirects" do
       route_set = RouteSet.new(base_path: "/path", rendering_app: "frontend")
 
-      expect_any_instance_of(GdsApi::Router).not_to receive(:add_backend)
       expect_any_instance_of(GdsApi::Router).not_to receive(:add_route)
-      expect_any_instance_of(GdsApi::Router).not_to receive(:commit_routes)
 
       route_set.register!
     end
 
-    describe "when NO_SET_ROUTER_BACKEND_ADDRESS_ON_PUBLISH=1" do
-      around do |t|
-        ClimateControl.modify NO_SET_ROUTER_BACKEND_ADDRESS_ON_PUBLISH: "1" do
-          t.run
-        end
-      end
-
-      let(:route_set) { RouteSet.new(base_path: "/path", rendering_app: "frontend") }
-
-      it "does not call router_api.add_backend" do
-        route_set.routes = [
-          { path: "/path", type: "exact" },
-          { path: "/path/sub/path", type: "prefix" },
-        ]
-        expect_any_instance_of(GdsApi::Router).not_to receive(:add_backend)
-        route_set.register!
-      end
-
-      it "does call commit_routes" do
-        route_set.routes = [
-          { path: "/path", type: "exact" },
-          { path: "/path/sub/path", type: "prefix" },
-        ]
-        expect(route_set).to receive(:commit_routes)
-        route_set.register!
-      end
-    end
-
-    it "registers and commits all registerable redirects for a redirect item" do
+    it "registers all registerable redirects for a redirect item" do
       redirects = [
         { path: "/path", type: "exact", destination: "/new-path" },
         { path: "/path/sub/path", type: "prefix", destination: "/somewhere-else" },
@@ -217,7 +187,7 @@ describe RouteSet, type: :model do
       assert_redirect_routes_registered([["/path", "exact", "/new-path"], ["/path/sub/path", "prefix", "/somewhere-else"], ["/path/longer/sub/path", "prefix", "/somewhere-else-2", "ignore"]])
     end
 
-    it "registers and commits all registerable gone routes for a gone item" do
+    it "registers all registerable gone routes for a gone item" do
       route_set = RouteSet.new(base_path: "/path", rendering_app: "frontend", is_gone: true)
       route_set.gone_routes = [
         { path: "/path", type: "exact" },

--- a/spec/support/router_helpers.rb
+++ b/spec/support/router_helpers.rb
@@ -6,9 +6,6 @@ module RouterHelpers
   def assert_routes_registered(rendering_app, routes)
     # NOTE: WebMock stubs allow you to assert against already executed requests.
 
-    be_signature = stub_router_backend_registration(rendering_app, "https://#{rendering_app}.test.gov.uk/")
-    assert_requested(be_signature, times: 1)
-
     routes.each do |(path, type)|
       route_signature, = stub_route_registration(path, type, rendering_app)
       assert_requested(route_signature, times: 1)
@@ -37,9 +34,6 @@ module RouterHelpers
   end
 
   def refute_routes_registered(rendering_app, routes)
-    be_signature = stub_router_backend_registration(rendering_app, "http://#{rendering_app}.test.gov.uk/")
-    assert_not_requested(be_signature)
-
     routes.each do |(path, type)|
       route_signature, = stub_route_registration(path, type, rendering_app)
       assert_not_requested(route_signature)


### PR DESCRIPTION
This flag was [added for the transition to Kubernetes](https://github.com/alphagov/content-store/pull/1015). It's no longer needed. Remove the flag here so that we can remove it from the config once this lands.

Also remove some references to "commit" in test names (router-api no longer has a "commit" operation).