### PR TITLE
Add choice of ECR repository name on build-and-publish-image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,13 @@ on:
         - staging
         - production
         default: 'integration'
+      ecrRepositoryName: 'ECR repo name to push image to'
+        required: true
+        type: choice
+        options:
+        - content-store
+        - content-store-postgresql-branch
+        default: 'content-store'
   workflow_run:
     workflows: [CI]
     types: [completed]
@@ -31,6 +38,7 @@ jobs:
     uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@main
     with:
       gitRef: ${{ inputs.gitRef || github.ref }}
+      ecrRepositoryName: ${{ inputs.ecrRepositoryName }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Allows us to build the port-to-postgresql branch to a differently-named container in ECR (`content-store-postgresql-branch`) 
as part of [dual-running both versions behind a proxy on integration](https://trello.com/c/BIQ9GmY5/601-deploy-content-store-proxy-and-content-store-on-postgresql-in-integration-for-the-draft-content-store)

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
