### PR TITLE
Fix the container build which broke in #9d32811

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM $base_image
 ARG mongo_package=mongodb-database-tools-ubuntu2204-x86_64-100.7.2.deb
 ARG mongo_package_repo=https://fastdl.mongodb.org/tools/db
 WORKDIR /tmp
-RUN curl "${mongo_package_repo}/${mongo_package}" --output "${mongo_package}" --silent && \
+RUN curl -LSsf "${mongo_package_repo}/${mongo_package}" --output "${mongo_package}" && \
     apt-get install -y --no-install-recommends "./${mongo_package}" && \
     rm -fr /tmp/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,11 @@ RUN bootsnap precompile --gemfile .
 FROM $base_image
 
 # TODO: remove this temporary MongoDB package once we no longer need mongoexport (once the migration to Postgres is done).
-ARG mongo_package=mongodb-database-tools-ubuntu2204-x86_64-100.7.2.tgz
+ARG mongo_package=mongodb-database-tools-ubuntu2204-x86_64-100.7.2.deb
 ARG mongo_package_repo=https://fastdl.mongodb.org/tools/db
 WORKDIR /tmp
-RUN wget --progress=mega "${mongo_package}/${mongo_package_repo}" && \
-    apt-get install -y --no-install-recommends "${mongo_package}" && \
+RUN curl "${mongo_package_repo}/${mongo_package}" --output "${mongo_package}" --silent && \
+    apt-get install -y --no-install-recommends "./${mongo_package}" && \
     rm -fr /tmp/*
 
 ENV GOVUK_APP_NAME=content-store


### PR DESCRIPTION
On merging #1088, the subsequent [container build step failed](https://github.com/alphagov/content-store/actions/runs/5277850735/jobs/9546404952). On investigation, there were a few issues - `wget` is not actually installed on the base image, the package/repo references were the wrong way round, the package was a .tgz not a .deb, etc. 

This PR fixes the build by:
- replacing wget with `curl`
- downloading the `.deb` package instead of the `.tgz` 
- adding the all-important './' to the apt-get install cmd 

I've tested the image can now be built locally with `docker build .` (I should have tested the build on the branch locally before merging rather than leaving it to CI, my bad) 

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
