### PR TITLE
fix passing of path arg to MongoExporter in rake task

### DIFF
--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -2,8 +2,8 @@
 namespace :mongo do
   namespace :export do
     desc "export all collections to JSON files in the given path"
-    task :all, %i[path] => :environment do
-      MongoExporter.export_all(path:)
+    task :all, %i[path] => :environment do |_, args|
+      MongoExporter.export_all(path: args[:path])
     end
 
     desc "export the given collection to JSON file in the given path"


### PR DESCRIPTION
The `export_all` rake task added in #1088 had a problem with the `path:` argument, leading to an error when run via Kubernetes CronJob:
```
NameError: undefined local variable or method `path' for main:Object

      MongoExporter.export_all(path:)
```

This PR fixes the error, and has been tested from a shell on the content-store-app container

[Trello card](https://trello.com/c/GMoOthyj/671-add-step-to-overnight-environment-sync-job-to-export-mongodb-to-json-and-import-to-postgresql)

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
