### PR TITLE
Change content_item DateTime field definitions to ActiveSupport::TimeWithZone

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -82,9 +82,9 @@ class ContentItem
 
   field :schema_name, type: String
   field :locale, type: String, default: I18n.default_locale.to_s
-  field :first_published_at, type: DateTime
-  field :public_updated_at, type: DateTime
-  field :publishing_scheduled_at, type: DateTime
+  field :first_published_at, type: ::ActiveSupport::TimeWithZone
+  field :public_updated_at, type: ::ActiveSupport::TimeWithZone
+  field :publishing_scheduled_at, type: ::ActiveSupport::TimeWithZone
   field :scheduled_publishing_delay_seconds, type: Integer
   field :details, type: Hash, default: {}
   field :publishing_app, type: String


### PR DESCRIPTION
## Why

When we compare JSON from this original Mongo version of content-store with that generated by the same data imported in to PostgreSQL, we find that some timestamp fields - namely, those which in the PostgreSQL version are top-level distinct fields on the ContentItem - have a difference in how the UTC timezone is represented:

Mongo:  
```
> item.as_json['first_published_at']
=> "2014-04-04T00:00:00.000+00:00"

```

PostgreSQL:
```
> item.as_json['first_published_at']
=> "2014-04-04T00:00:00.000Z"

```
On investigation ([Trello card](https://trello.com/c/N4ylLI0Q/705-see-if-theres-a-way-to-make-the-rds-postgres-content-stores-utc-timezone-representation-match-that-of-mongo-content-store)), we found that the difference is due to the fact the the `field` definitions in the Mongoid model classes define these timestamps as `DateTime`, whereas `ActiveRecord` represents timestamps with `ActiveSupport::TimeWithZone`.
These two classes represent the UTC timezone differently.

This causes problems when trying to verify that the migration to PostgreSQL ([Trello card epic](https://trello.com/c/C1BQDFTG/502-plan-for-migrating-content-store-off-mongodb)) has not altered the data, and that the PostgreSQL version will be 100% compatible with the Mongo version. We _believe_ that all the content-store-API-consuming apps we know of can handle either representation, but it will give us much greater confidence in the migration if we are able to compare the JSON generated by both versions side-by-side, character-by-character, and prove that they are the same.

# Testing

I've tested this against a local copy of the live content-store, and it seems that no explicit data migration is needed - we can just change the field definitions from `DateTime` to `::ActiveSupport::TimeWithZone`, and Mongoid automatically parses the stored data in to the required class.


This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
