### PR TITLE
Fix inconsistencies with Mongo JSON

### DIFF
--- a/app/lib/json_importer.rb
+++ b/app/lib/json_importer.rb
@@ -59,7 +59,7 @@ class JsonImporter
 private
 
   def insert_lines(lines)
-    @offline_table_class.insert_all(lines, unique_by: [@model_class.primary_key.to_sym])
+    @offline_table_class.insert_all(lines, unique_by: [@model_class.primary_key.to_sym], record_timestamps: false)
   end
 
   def update_model_table_from_offline_table

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -75,7 +75,7 @@ class ContentItem < ApplicationRecord
   # We want to force the JSON representation to use "base_path"
   # and prevent "id" being exposed outside of the model.
   def as_json(options = nil)
-    super(options).except("id")
+    super(options).except("id", "_id")
   end
 
   # We store the description in a hash because Publishing API can send through

--- a/db/migrate/20230623082107_allow_null_timestamps.rb
+++ b/db/migrate/20230623082107_allow_null_timestamps.rb
@@ -1,0 +1,6 @@
+class AllowNullTimestamps < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :content_items, :created_at, true
+    change_column_null :content_items, :updated_at, true
+  end
+end

--- a/db/migrate/20230623112332_allow_null_timestamps_on_scheduled_pub_and_pub_intents.rb
+++ b/db/migrate/20230623112332_allow_null_timestamps_on_scheduled_pub_and_pub_intents.rb
@@ -1,0 +1,8 @@
+class AllowNullTimestampsOnScheduledPubAndPubIntents < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :scheduled_publishing_log_entries, :created_at, true
+    change_column_null :scheduled_publishing_log_entries, :updated_at, true
+    change_column_null :publish_intents, :created_at, true
+    change_column_null :publish_intents, :updated_at, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_23_082107) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_23_112332) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_28_144838) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_23_082107) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -49,8 +49,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_28_144838) do
     t.integer "payload_version"
     t.jsonb "withdrawn_notice", default: {}
     t.string "publishing_request_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string "_id"
     t.index ["base_path"], name: "index_content_items_on_base_path", unique: true
     t.index ["content_id"], name: "index_content_items_on_content_id"
@@ -60,10 +60,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_28_144838) do
     t.index ["routes"], name: "index_content_items_on_routes", using: :gin
     t.index ["routes"], name: "ix_ci_routes_jsonb_path_ops", opclass: :jsonb_path_ops, using: :gin
     t.index ["updated_at"], name: "index_content_items_on_updated_at"
-  end
-
-  create_table "content_items_import", id: false, force: :cascade do |t|
-    t.jsonb "data"
   end
 
   create_table "publish_intents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/lib/json_importer_spec.rb
+++ b/spec/lib/json_importer_spec.rb
@@ -250,8 +250,8 @@ describe JsonImporter do
       allow(model_class).to receive(:primary_key).and_return(:model_primary_key)
     end
 
-    it "inserts the lines into the offline table, unique by the primary key" do
-      expect(offline_table_class).to receive(:insert_all).with(%w[line1 line2], unique_by: [:model_primary_key])
+    it "inserts the lines into the offline table, unique by the primary key and without touching timestamps" do
+      expect(offline_table_class).to receive(:insert_all).with(%w[line1 line2], unique_by: [:model_primary_key], record_timestamps: false)
       subject.send(:insert_lines, %w[line1 line2])
     end
   end


### PR DESCRIPTION
When we compare the JSON generated by this PostgreSQL branch side-by-side against the same data in the original MongoDB content-store, we find a few inconsistencies:

- the  `created_at`/`updated_at` timestamps were null in many of the MongoDB records, yet in the import process the `null` `created_at` on the PostgreSQL side had been defaulted to `Time.now` 
- the Mongo `_id` field was appearing in the generated JSON on the PostgreSQL side
- the UTC timezone was represented differently for top-level timestamps  ("+00:00" vs "Z")

This PR fixes the first two issues, a separate PR (#1094) against the `main` branch addresses the third. 
 
This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
