### PR TITLE
Present content-item JSON with deep-sorted keys

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gem "rails", "7.0.5"
 
 gem "bootsnap", require: false
+gem "deepsort"
 gem "gds-api-adapters"
 gem "gds-sso"
 gem "govuk_app_config"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,7 @@ GEM
       database_cleaner-core (~> 2.0.0)
       mongoid
     date (3.3.3)
+    deepsort (0.4.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     domain_name (0.5.20190701)
@@ -438,6 +439,7 @@ DEPENDENCIES
   ci_reporter_rspec
   climate_control
   database_cleaner-mongoid
+  deepsort
   factory_bot
   gds-api-adapters
   gds-sso

--- a/app/lib/hash_sorter.rb
+++ b/app/lib/hash_sorter.rb
@@ -1,0 +1,10 @@
+require "deepsort"
+
+class HashSorter
+  def self.sort(hash)
+    # Deepsort by default will sort keys in an array too -
+    # we don't want that, as (for instance) order of links
+    # may be important
+    hash.deep_sort(array: false)
+  end
+end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -32,13 +32,14 @@ class ContentItemPresenter
   end
 
   def as_json(options = nil)
-    item.as_json(options).slice(*PUBLIC_ATTRIBUTES).merge(
+    item_hash = item.as_json(options).slice(*PUBLIC_ATTRIBUTES).merge(
       "links" => RESOLVER.resolve(links),
       "description" => RESOLVER.resolve(item.description),
       "details" => RESOLVER.resolve(item.details),
     ).tap do |i|
       i["redirects"] = item["redirects"] if i["schema_name"] == "redirect"
     end
+    HashSorter.sort(item_hash)
   end
 
 private

--- a/app/presenters/expanded_links_presenter.rb
+++ b/app/presenters/expanded_links_presenter.rb
@@ -6,15 +6,16 @@ class ExpandedLinksPresenter
   end
 
   def present
-    expanded_links.each_with_object({}) do |(type, links), memo|
+    HashSorter.sort(expanded_links).each_with_object({}) do |(type, links), memo|
       links = Array.wrap(links)
       memo[type] = links.map do |link|
-        link.dup.except(secret_fields).merge(
+        hash = link.dup.except(secret_fields).merge(
           api_path: api_path(link),
           api_url: api_url(link),
           web_url: web_url(link),
           links: link[:links].present? ? self.class.new(link[:links]).present : {},
-        ).compact
+        ).compact.deep_symbolize_keys # deep_sort errors if the keys are not all syms or all strings
+        HashSorter.sort(hash)
       end
     end
   end

--- a/spec/lib/hash_sorter_spec.rb
+++ b/spec/lib/hash_sorter_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+describe HashSorter do
+  describe ".sort" do
+    context "given a nested Hash" do
+      let(:hash) do
+        {
+          z: "y",
+          x: "zzz",
+          b: {
+            b1: "bb1",
+            a1: "ba1",
+          },
+        }
+      end
+
+      it "returns a Hash with all keys in alphabetical order" do
+        expect(HashSorter.sort(hash)).to eq(
+          {
+            b: {
+              a1: "ba1",
+              b1: "bb1",
+            },
+            x: "zzz",
+            z: "y",
+          },
+        )
+      end
+
+      context "when the Hash contains arrays" do
+        let(:hash) do
+          {
+            z: "y",
+            x: "zzz",
+            b: %w[zzz ccc aaa],
+          }
+        end
+
+        it "returns a Hash with the array in the original order" do
+          expect(HashSorter.sort(hash)).to eq(
+            {
+              b: %w[zzz ccc aaa],
+              x: "zzz",
+              z: "y",
+            },
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
... for equivalence with `port-to-postgres` version

When dual-running content-store on MongoDB (main) and PostgreSQL (port-to-postgresql branch), we find that [the JSON generated by the two versions differs](https://trello.com/c/1gljPBwl/720-find-out-why-the-contentitem-links-field-differs-between-mongo-pg). After much investigation, it seems that the remaining source of difference is the order of keys in the content_items - particularly in the `links` JSON.

The source of this difference is that Mongo stores the data as BSON, which [preserves the order of the JSON it is given](https://softwareengineering.stackexchange.com/a/340269](https://softwareengineering.stackexchange.com/a/340269) ):

> A BSON data structure is an ordered object, not a dictionary  

whereas in PostgreSQL we store the JSON as `JSONB`, which [sorts the keys of an object on write](https://www.postgresql.org/docs/current/datatype-json.html](https://www.postgresql.org/docs/current/datatype-json.html) ):

> jsonb does not preserve white space, does not preserve the order of object keys, and does not keep duplicate object keys

As a result, even when the JSON is functionally equivalent, a character-by-character comparison of the two will fail. To have a good level of confidence in the [Mongo-to-PostgreSQL migration](https://trello.com/c/C1BQDFTG/502-plan-for-migrating-content-store-off-mongodb), we need to be able to demonstrate that the JSON from the two versions is exactly equivalent.

So this PR introduces the `deepsort` gem, and a trivial wrapper class to make sure that we don't accidentally sort nested array elements as well. We use it to sort content-items and their expanded_links.


This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
