### PR TITLE
Reintroduce hash sorting for expanded content-item and links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gem "rails", "7.0.5"
 
 gem "bootsnap", require: false
+gem "deepsort"
 gem "gds-api-adapters"
 gem "gds-sso"
 gem "govuk_app_config"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,7 @@ GEM
       database_cleaner-core (~> 2.0.0)
       mongoid
     date (3.3.3)
+    deepsort (0.4.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     domain_name (0.5.20190701)
@@ -438,6 +439,7 @@ DEPENDENCIES
   ci_reporter_rspec
   climate_control
   database_cleaner-mongoid
+  deepsort
   factory_bot
   gds-api-adapters
   gds-sso

--- a/app/lib/hash_sorter.rb
+++ b/app/lib/hash_sorter.rb
@@ -1,0 +1,10 @@
+require "deepsort"
+
+class HashSorter
+  def self.sort(hash)
+    # Deepsort by default will sort keys in an array too -
+    # we don't want that, as (for instance) order of links
+    # may be important
+    hash.deep_sort(array: false)
+  end
+end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -32,13 +32,14 @@ class ContentItemPresenter
   end
 
   def as_json(options = nil)
-    item.as_json(options).slice(*PUBLIC_ATTRIBUTES).merge(
+    hash = item.as_json(options).slice(*PUBLIC_ATTRIBUTES).merge(
       "links" => RESOLVER.resolve(links),
       "description" => RESOLVER.resolve(item.description),
       "details" => RESOLVER.resolve(item.details),
-    ).tap do |i|
+    ).tap { |i|
       i["redirects"] = item["redirects"] if i["schema_name"] == "redirect"
-    end
+    }.deep_stringify_keys
+    HashSorter.sort(hash)
   end
 
 private

--- a/app/presenters/expanded_links_presenter.rb
+++ b/app/presenters/expanded_links_presenter.rb
@@ -6,7 +6,7 @@ class ExpandedLinksPresenter
   end
 
   def present
-    expanded_links.deep_symbolize_keys.each_with_object({}) do |(type, links), memo|
+    result = expanded_links.deep_symbolize_keys.each_with_object({}) do |(type, links), memo|
       links = Array.wrap(links)
       memo[type] = links.map do |link|
         link.dup.except(secret_fields).merge(
@@ -17,6 +17,7 @@ class ExpandedLinksPresenter
         ).compact
       end
     end
+    HashSorter.sort(result)
   end
 
 private

--- a/spec/lib/hash_sorter_spec.rb
+++ b/spec/lib/hash_sorter_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+describe HashSorter do
+  describe ".sort" do
+    let(:links) do
+      {
+        group_2: [
+          { base_path: "/group-1/link-1", api_path: "/api/content/group-1/link-1" },
+          { base_path: "/group-1/link-2", api_path: "/api/content/group-1/link-2" },
+          { base_path: "/group-1/link-3", api_path: "/api/content/group-1/link-3" },
+        ],
+        group_1: [
+          { base_path: "/group-2/link-3", api_path: "/api/content/group-2/link-3" },
+          { base_path: "/group-2/link-2", api_path: "/api/content/group-2/link-2" },
+          { base_path: "/group-2/link-1", api_path: "/api/content/group-2/link-1" },
+        ],
+      }
+    end
+    let(:result) { described_class.sort(links) }
+
+    it "sorts the top-level keys" do
+      expect(result.keys).to eq(%i[group_1 group_2])
+    end
+
+    it "does not sort the arrays" do
+      expect(result[:group_1].map { |e| e[:base_path] }).to eq(links[:group_1].map { |e| e[:base_path] })
+    end
+
+    it "sorts the keys on Hashes within arrays" do
+      %i[group_1 group_2].each do |group|
+        result[group].each do |hash|
+          expect(hash.keys).to eq(hash.keys.sort)
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -66,11 +66,11 @@ describe ContentItemPresenter do
     end
 
     it "inlines the 'text/html' content type in the details" do
-      expect(presenter.as_json["details"]).to eq(body: "<p>content</p>")
+      expect(presenter.as_json["details"]).to eq("body" => "<p>content</p>")
     end
 
     it "inlines the 'text/html' content type in the links" do
-      expect(presenter.as_json["links"][:person].first[:details]).to eq(body: "<p>content</p>")
+      expect(presenter.as_json["links"]["person"].first["details"]).to eq("body" => "<p>content</p>")
     end
   end
 

--- a/spec/presenters/expanded_links_presenter_spec.rb
+++ b/spec/presenters/expanded_links_presenter_spec.rb
@@ -205,4 +205,30 @@ RSpec.describe ExpandedLinksPresenter do
       end
     end
   end
+
+  describe "sorting the hash" do
+    let(:links) do
+      {
+        group_2: [
+          { base_path: "/group-1/link-1", api_path: "/api/content/group-1/link-1" },
+          { base_path: "/group-1/link-2", api_path: "/api/content/group-1/link-2" },
+          { base_path: "/group-1/link-3", api_path: "/api/content/group-1/link-3" },
+        ],
+        group_1: [
+          { base_path: "/group-2/link-3", api_path: "/api/content/group-2/link-3" },
+          { base_path: "/group-2/link-2", api_path: "/api/content/group-2/link-2" },
+          { base_path: "/group-2/link-1", api_path: "/api/content/group-2/link-1" },
+        ],
+      }
+    end
+    let(:result) { described_class.new(links).present }
+
+    it "sorts the results" do
+      expect(result.keys).to eq(result.keys.sort)
+
+      result.each_key do |group|
+        expect(result[group].all? { |link| link.keys == link.keys.sort }).to eq(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is an updated version of PR #1096, having isolated the cause of the problem described in #1097 (`.deep_symbolize_keys` called at the wrong level) and added a test case to catch the issue in #1099, plus explicit tests that the sorting behaviour is correct.

Trello cards [1](https://trello.com/c/1gljPBwl/720-find-out-why-the-contentitem-links-field-differs-between-mongo-pg) and [2](https://trello.com/c/nRO5J6HW/726-re-introduce-the-hash-sorting-in-content-store-but-this-time-without-breaking-the-frontends)

### Manual Testing

I've [deployed this to integration](https://github.com/alphagov/content-store/actions/runs/5411392314) and tested that :

a) this does not drop the `role_appointments[*] -> links` (as was found in #1096) :
 
![Screenshot from 2023-06-29 12-05-03](https://github.com/alphagov/content-store/assets/134501/54c50528-8d91-4761-8d6d-b49821b8851a)
Before on the left, after on the right. Also note the hashes on the right are sorted at all levels

b) the page renders correctly in the `collections` front end:
![image](https://github.com/alphagov/content-store/assets/134501/4deffd97-897c-465d-b17e-67efeb2236be)

 
This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
