### PR TITLE
Fix syntax error in deploy.yml workflow.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,8 @@ on:
         - staging
         - production
         default: 'integration'
-      ecrRepositoryName: 'ECR repo name to push image to'
+      ecrRepositoryName:
+        description: 'ECR repo name to push image to'
         required: true
         type: choice
         options:


### PR DESCRIPTION
I didn't spot this in #1086. GitHub really ought to syntax-check these automatically pre-merge.