### PR TITLE
Render all content_item timestamps in JSON as ISO8601 format. 

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -26,6 +26,13 @@ class ContentItemPresenter
     publishing_request_id
   ].freeze
 
+  DATETIME_ATTRIBUTES = %w[
+    updated_at
+    public_updated_at
+    first_published_at
+    publishing_scheduled_at
+  ].freeze
+
   def initialize(item, api_url_method)
     @item = item
     @api_url_method = api_url_method
@@ -38,6 +45,7 @@ class ContentItemPresenter
       "details" => RESOLVER.resolve(item.details),
     ).tap { |i|
       i["redirects"] = item["redirects"] if i["schema_name"] == "redirect"
+      render_timestamps_as_iso8601(item, i)
     }.deep_stringify_keys
     HashSorter.sort(hash)
   end
@@ -48,5 +56,11 @@ private
 
   def links
     ExpandedLinksPresenter.new(item.expanded_links).present
+  end
+
+  def render_timestamps_as_iso8601(item, hash)
+    DATETIME_ATTRIBUTES.each do |attr|
+      hash[attr] = item[attr].iso8601 if item[attr].respond_to?(:iso8601)
+    end
   end
 end

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -77,7 +77,7 @@ describe "Fetching content items", type: :request do
       content_item.reload # reload to pick up any time rounding in the database.
 
       data = JSON.parse(response.body)
-      expect(data["public_updated_at"]).to eq(content_item.public_updated_at.as_json)
+      expect(data["public_updated_at"]).to eq(content_item.public_updated_at.iso8601.as_json)
       expect(Time.zone.parse(data["updated_at"])).to be_within(1.second).of(Time.zone.now.utc)
     end
 

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -114,4 +114,22 @@ describe ContentItemPresenter do
       expect(presented.to_json).to be_valid_against_frontend_schema("generic")
     end
   end
+
+  it "renders timestamps in iso8601 format" do
+    content_item = create(:content_item, first_published_at: Time.zone.now, publishing_scheduled_at: Time.zone.now)
+    presented = ContentItemPresenter.new(content_item, api_url_method).as_json
+    %w[updated_at public_updated_at first_published_at publishing_scheduled_at].each do |key|
+      expect(presented[key]).to eq(content_item[key].iso8601)
+    end
+  end
+
+  context "when some timestamps are nil" do
+    it "renders them as nil" do
+      content_item = build(:content_item, public_updated_at: nil, first_published_at: nil, publishing_scheduled_at: nil)
+      presented = ContentItemPresenter.new(content_item, api_url_method).as_json
+      %w[public_updated_at first_published_at publishing_scheduled_at].each do |key|
+        expect(presented[key]).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is the standard format for timestamps, and also has the benefit of eliminating almost all millisecond-differences between updated_at timestamps while dual-running PostgreSQL & MongoDB versions ([Trello card](https://trello.com/c/N97rWb93/738-make-content-store-contentitempresenter-render-updatedat-with-just-single-second-precision-rather-than-millisecond-precision))

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
