### PR TITLE
Provide fallback value for ecrRepositoryName

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
     uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@main
     with:
       gitRef: ${{ inputs.gitRef || github.ref }}
-      ecrRepositoryName: ${{ inputs.ecrRepositoryName }}
+      ecrRepositoryName: ${{ inputs.ecrRepositoryName || 'content-store' }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Commit 5c9e9f6af13a18e17e8cf7d7cdd8bd3d6e5bb2c1 added a choice of ECR repository name on build-and-publish-image.

One might think that the default value of the input is there to provide a fallback for non-workflow_dispatch triggered jobs.

One might, apparently, be wrong[1].

Automatic deploys on content-store have been failing since the choice was introduced, while manual deploys are succeeding. The error is that the image tag is invalid, and it is invalid because it is missing the value of `ECR_REPOSITORY`.

Thanks to Bruce for identifying the related commits, which provided me with a clue of where to look for answers!

[1] https://dev.to/mrmike/github-action-handling-input-default-value-5f2g

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
