### PR TITLE
Restore offline table import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 # Ignore the default SQLite database.
 /db/*.sqlite3
 
+# Ignore any db dumps
+/db/mongo-dumps
+
 # Ignore all logfiles and tempfiles.
 /log/*.log
 /tmp

--- a/spec/lib/json_importer_spec.rb
+++ b/spec/lib/json_importer_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe JsonImporter do
-  subject { JsonImporter.new(model_class:, file: "content-items.json", batch_size:) }
+  subject { JsonImporter.new(model_class:, file: "content-items.json", offline_table_class: model_class, batch_size:) }
   let(:model_class) { ContentItem }
   let(:batch_size) { 1 }
 
@@ -221,8 +221,8 @@ describe JsonImporter do
           allow(subject).to receive(:process_line).with("line2").and_return("line2")
         end
 
-        it "calls insert_all on the model_class" do
-          expect(ContentItem).to receive(:insert_all).once.with(%w[line1 line2])
+        it "calls insert_all on the model_class, not recording timestamps and unique by id" do
+          expect(ContentItem).to receive(:insert_all).once.with(%w[line1 line2], { record_timestamps: false, unique_by: [:id] })
           subject.call
         end
       end


### PR DESCRIPTION
Restore offline-table JSON import functionality to the `port-to-postgresql` branch, lost after rebase-gone-wrong.
This should hopefully fix the overnight mongo-to-postgresql ETL job.

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
