### PR TITLE
(re-)fix issue that causes doubly-nested description Hashes on PostgreSQL

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -81,7 +81,8 @@ class ContentItem < ApplicationRecord
   # We store the description in a hash because Publishing API can send through
   # multiple content types.
   def description=(value)
-    super("value" => value)
+    # ...but only wrap the given value in a Hash if it's not already a Hash
+    value.is_a?(Hash) ? super : super("value" => value)
   end
 
   def description

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -40,7 +40,7 @@ describe ContentItem, type: :model do
       it "does not retain values of any attributes which were not given" do
         @item.reload
         expect(@item.title).to be_nil
-        expect(@item.description).to eq("value" => nil)
+        expect(@item["description"]).to eq("value" => nil)
       end
     end
 
@@ -452,11 +452,26 @@ describe ContentItem, type: :model do
   end
 
   describe "description" do
-    it "wraps the description as a hash" do
-      content_item = FactoryBot.create(:content_item, description: "foo")
+    context "when given a simple-valued description" do
+      let(:description) { "foo" }
 
-      expect(content_item.description).to eq("foo")
-      expect(content_item["description"]).to eq("value" => "foo")
+      it "wraps the description as a hash" do
+        content_item = FactoryBot.create(:content_item, description:)
+
+        expect(content_item.description).to eq("foo")
+        expect(content_item["description"]).to eq("value" => "foo")
+      end
+    end
+
+    context "when given a description that is already a Hash" do
+      let(:description) { { "value" => "foo" } }
+
+      it "does not wrap the description hash in another hash" do
+        content_item = FactoryBot.create(:content_item, description:)
+
+        expect(content_item.description).to eq("foo")
+        expect(content_item["description"]).to eq("value" => "foo")
+      end
     end
   end
 


### PR DESCRIPTION
The existing code wraps all given `description` values in a hash, even when given a description that is already a Hash.
We got away with this on Mongo because of the different way setters & getters are overridden between Mongoid & ActiveRecord, but on PostgreSQL we need to detect & handle this case explicitly.

This issue was originally fixed on the `port-to-postgresql` branch around 10th July, but appears to have been lost in the giant rebase-gone-wrong. This PR re-fixes the issue. 

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
