### PR TITLE
Add temporary rake task to cleanup Whitehall Frontend documents

### DIFF
--- a/lib/tasks/temp_cleanup_whitehall_frontend.rake
+++ b/lib/tasks/temp_cleanup_whitehall_frontend.rake
@@ -1,0 +1,4 @@
+desc "Removes all legacy content items that were rendered by Whitehall Frontend"
+task cleanup_whitehall_frontend: :environment do
+  ContentItem.where(rendering_app: "whitehall-frontend").delete_all
+end


### PR DESCRIPTION
All public rendering has been removed from Whitehall, therefore no content items should exist that believe they should be rendered by Whitehall Frontend.

A mismatch currently occurs where router believes these items of content should be redirected, but Content Store has a content item for them (e.g. policy areas).

Presumably a temporary rake task or something on a console was run at some distant point in the past to implement the redirects in router, but the content items were never removed.

Three issues were caused:
- users can access the content items still, even though the content has been changed/withdrawn/moved
- running the `register:routes` rake task in Content Store will result in `whitehall-frontend` being registered with router, even though it no longer exists
- it's causing us to believe Whitehall Frontend still renders things when updating [these pages](https://docs.publishing.service.gov.uk/document-types.html) in the dev docs

This completes that clean-up and retains the redirects that were implement in router.

[Trello card](https://trello.com/c/2wA7AA8J)

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
