### PR TITLE
Revert "Add temporary rake task to cleanup Whitehall Frontend documents"

### DIFF
--- a/lib/tasks/temp_cleanup_whitehall_frontend.rake
+++ b/lib/tasks/temp_cleanup_whitehall_frontend.rake
@@ -1,4 +1,0 @@
-desc "Removes all legacy content items that were rendered by Whitehall Frontend"
-task cleanup_whitehall_frontend: :environment do
-  ContentItem.where(rendering_app: "whitehall-frontend").delete_all
-end


### PR DESCRIPTION
This task has now been run in production, so can be deleted.

Reverts alphagov/content-store#1128

[Trello card](https://trello.com/c/2wA7AA8J)