### PR TITLE
Add more explicit & verbose logging when the app sends a HTTP 400

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,20 +23,24 @@ private
   def parse_json_request
     # FIXME: base_path in the request body is deprecated and will be considered
     # an error once all clients have been updated.
-    @request_data = JSON.parse(request.body.read).except("base_path")
+    body = request.body.read
+    @request_data = JSON.parse(body).except("base_path")
   rescue JSON::ParserError
+    Rails.logger.warn "error parsing JSON from request body '#{body}'"
     head :bad_request
   end
 
   def encoded_request_path
     Addressable::URI.encode(request_path)
   rescue Addressable::URI::InvalidURIError
+    Rails.logger.warn "Can't encode request_path '#{request_path}'"
     raise InvalidRequest
   end
 
   def encoded_base_path
     Addressable::URI.encode(base_path)
   rescue Addressable::URI::InvalidURIError
+    Rails.logger.warn "Can't encode base_path '#{request_path}'"
     raise InvalidRequest
   end
 


### PR DESCRIPTION
..to try and debug a problem with updates only getting as far as publishing-api ([Trello card](https://trello.com/c/LTCo5fnV/802-travel-advice-alert-status-not-updating))

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
