### PR TITLE
Don't override default attributes with nil

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -25,7 +25,8 @@ class ContentItem
     item.assign_attributes(
       attributes
         .merge(scheduled_publication_details(log_entry))
-        .merge(created_at:),
+        .merge(created_at:)
+        .compact,
     )
 
     if item.upsert

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -21,6 +21,11 @@ describe ContentItem, type: :model do
       expect(item.reload.created_at).to eq(@item.reload.created_at)
     end
 
+    it "does not overwrite default attribute values if called with nil attributes" do
+      _, item = ContentItem.create_or_replace(@item.base_path, { schema_name: "redirect", redirects: nil }, nil)
+      expect(item.redirects).to eq([])
+    end
+
     describe "exceptions" do
       context "when unknown attributes are provided" do
         let(:attributes) { { "foo" => "foo", "bar" => "bar" } }


### PR DESCRIPTION
This fixes a bug where unpublished redirects in short URL manager aren't removed from the content store (so continue to work on the website).

Users of the content-store API (i.e. publishing-api) might make API calls with values they want to reset provided as `nil`. For example, if you wanted to clear some redirects on a content item, you might do something like:

```
PUT /content/some-made-up-url

{
  ...
  "redirects": nil
  ...
}
```

The intent of the user of the API is clear here - they want no redirects.

However, ContentItem has a default value for redirects:

```
  field :redirects, type: Array, default: []
```

And the rest of the content-store expects this value to be an Array, not to be nil.

By passing in potentially nil values in  assign_attributes we allow a situation where fields that content-store expects not to be nil (because they have defaults), can be nil. This tends to result in NoMethodErrors, such as this one:

```
	NoMethodError
undefined method `map' for nil:NilClass

    redirects = item.redirects.map(&:to_h).map(&:deep_symbolize_keys)
                              ^^^^
/app/app/models/route_set.rb:30:in `from_content_item'
/app/app/models/content_item.rb:215:in `route_set'
/app/app/models/content_item.rb:225:in `should_register_routes?'
/app/app/models/content_item.rb:193:in `register_routes'
/app/app/models/content_item.rb:33:in `create_or_replace'
/app/app/controllers/content_items_controller.rb:32:in `block in update'
```

I can't think of any valid reason for overriding default attributes with nils, so it feels like calling .compact is the right thing to do here.

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
