### PR TITLE
Gzip Mongo exports

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,3 +17,4 @@ spec
 test
 tmp
 vendor
+db/mongo-dumps

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 # Ignore the default SQLite database.
 /db/*.sqlite3
 
+# Ignore mongo DB dumps
+/db/mongo-dumps
+
 # Ignore all logfiles and tempfiles.
 /log/*.log
 /tmp

--- a/app/lib/mongo_exporter.rb
+++ b/app/lib/mongo_exporter.rb
@@ -5,12 +5,13 @@ class MongoExporter
 
   def self.export(collection:, path:)
     FileUtils.mkdir_p(path)
+    zipped_file_path = File.join(path, [collection, "json", "gz"].join("."))
     execute(
       "mongoexport",
       "--uri=#{ENV['MONGODB_URI']}",
       "--collection=#{collection}",
-      "--out=#{File.join(path, [collection, 'json'].join('.'))}",
       "--type=json",
+      " | gzip > #{zipped_file_path}",
     )
   end
 

--- a/spec/lib/mongo_exporter_spec.rb
+++ b/spec/lib/mongo_exporter_spec.rb
@@ -34,8 +34,8 @@ describe MongoExporter do
         anything,
         "--uri=#{ENV['MONGODB_URI']}",
         "--collection=my_collection",
-        "--out=/my/path/my_collection.json",
         "--type=json",
+        " | gzip > /my/path/my_collection.json.gz",
       )
       described_class.export(collection: "my_collection", path: "/my/path")
     end


### PR DESCRIPTION
In staging, when run as part of the Kubernetes CronJob [content-store-mongo-to-postgres-cron](https://github.com/alphagov/govuk-helm-charts/blob/main/charts/govuk-jobs/templates/content-store-mongo-to-postgres-cronjob.yaml) the job fails with this error -
`'The node was low on resource: ephemeral-storage. '`

- i.e. the node it was running on, ran out of storage space (see [discussion on slack](https://gds.slack.com/archives/C013F737737/p1693301007257509))

This PR pipes all files produced by the  `mongo:export` rake tasks through gzip, which produces pretty good compression on the largest collections (content_items particularly) and should drastically cut down the amount of ephemeral storage it needs.

[Trello card](https://trello.com/c/U4kiudWW/820-fix) , see also #1139

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
