### PR TITLE
Re-allow null timestamps on content_items, publish_intents & scheduled_publishing_log_entries

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_28_144838) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_30_093643) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -49,8 +49,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_28_144838) do
     t.integer "payload_version"
     t.jsonb "withdrawn_notice", default: {}
     t.string "publishing_request_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string "_id"
     t.index ["base_path"], name: "index_content_items_on_base_path", unique: true
     t.index ["content_id"], name: "index_content_items_on_content_id"
@@ -62,8 +62,84 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_28_144838) do
     t.index ["updated_at"], name: "index_content_items_on_updated_at"
   end
 
-  create_table "content_items_import", id: false, force: :cascade do |t|
-    t.jsonb "data"
+  create_table "offline_import_content_items_8c34c771", id: false, force: :cascade do |t|
+    t.uuid "id"
+    t.string "base_path"
+    t.string "content_id"
+    t.string "title"
+    t.jsonb "description"
+    t.string "document_type"
+    t.string "content_purpose_document_supertype"
+    t.string "content_purpose_subgroup"
+    t.string "content_purpose_supergroup"
+    t.string "email_document_supertype"
+    t.string "government_document_supertype"
+    t.string "navigation_document_supertype"
+    t.string "search_user_need_document_supertype"
+    t.string "user_journey_document_supertype"
+    t.string "schema_name"
+    t.string "locale"
+    t.datetime "first_published_at"
+    t.datetime "public_updated_at"
+    t.datetime "publishing_scheduled_at"
+    t.integer "scheduled_publishing_delay_seconds"
+    t.jsonb "details"
+    t.string "publishing_app"
+    t.string "rendering_app"
+    t.jsonb "routes"
+    t.jsonb "redirects"
+    t.jsonb "expanded_links"
+    t.jsonb "access_limited"
+    t.string "auth_bypass_ids", array: true
+    t.string "phase"
+    t.string "analytics_identifier"
+    t.integer "payload_version"
+    t.jsonb "withdrawn_notice"
+    t.string "publishing_request_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string "_id"
+    t.index ["id"], name: "offline_import_content_items_8c34c771_id_idx", unique: true
+  end
+
+  create_table "offline_import_content_items_df23dab6", id: false, force: :cascade do |t|
+    t.uuid "id"
+    t.string "base_path"
+    t.string "content_id"
+    t.string "title"
+    t.jsonb "description"
+    t.string "document_type"
+    t.string "content_purpose_document_supertype"
+    t.string "content_purpose_subgroup"
+    t.string "content_purpose_supergroup"
+    t.string "email_document_supertype"
+    t.string "government_document_supertype"
+    t.string "navigation_document_supertype"
+    t.string "search_user_need_document_supertype"
+    t.string "user_journey_document_supertype"
+    t.string "schema_name"
+    t.string "locale"
+    t.datetime "first_published_at"
+    t.datetime "public_updated_at"
+    t.datetime "publishing_scheduled_at"
+    t.integer "scheduled_publishing_delay_seconds"
+    t.jsonb "details"
+    t.string "publishing_app"
+    t.string "rendering_app"
+    t.jsonb "routes"
+    t.jsonb "redirects"
+    t.jsonb "expanded_links"
+    t.jsonb "access_limited"
+    t.string "auth_bypass_ids", array: true
+    t.string "phase"
+    t.string "analytics_identifier"
+    t.integer "payload_version"
+    t.jsonb "withdrawn_notice"
+    t.string "publishing_request_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string "_id"
+    t.index ["id"], name: "offline_import_content_items_df23dab6_id_idx", unique: true
   end
 
   create_table "publish_intents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -72,8 +148,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_28_144838) do
     t.string "publishing_app"
     t.string "rendering_app"
     t.jsonb "routes", default: []
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["base_path"], name: "index_publish_intents_on_base_path", unique: true
     t.index ["created_at"], name: "index_publish_intents_on_created_at"
     t.index ["publish_time"], name: "index_publish_intents_on_publish_time"
@@ -87,8 +163,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_28_144838) do
     t.string "document_type"
     t.datetime "scheduled_publication_time"
     t.bigint "delay_in_milliseconds"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string "mongo_id"
     t.index ["base_path"], name: "ix_scheduled_pub_log_base_path"
     t.index ["created_at"], name: "ix_scheduled_pub_log_created"


### PR DESCRIPTION
Imports from MongoDB in staging are failing with the error:
```
PG::NotNullViolation: ERROR:  null value in column "created_at" of relation "content_items" violates not-null constraint
DETAIL:  Failing row contains (03e5fbb1-b59e-44ca-9f66-62349ecd96bf, /, f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a, GOV.UK homepage, {"value": ""}, homepage, , other, other, other, other, , , finding, homepage, en, 2016-02-26 11:53:52, 2023-06-28 09:32:34, null, null, {}, special-route-publisher, frontend, [{"path": "/", "type": "exact"}], [], {"organisations": [{"links": {}, "title": "Government Digital Se..., {}, {}, live, null, 64696791, {}, 21-1687944754.231-10.13.31.76-382, null, 2023-07-21 14:28:36.562, null).
```
However, the same data can be imported fine on integration. 
On investigation, there were two previous migrations (`20230623082107` and `20230623112332`) which set those timestamps to allow nulls, that have been applied in integration but not on the recently-setup staging & production environments.
These very probably got lost in the rebase-gone-wrong on July 9th. 

This PR re-adds those changes in a single migration, and is a no-op on a database which already has them enabled.    

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
