### PR TITLE
(re-)Allow null timestamps on records imported from mongo

### DIFF
--- a/db/migrate/20230830093643_allow_null_timestamps.rb
+++ b/db/migrate/20230830093643_allow_null_timestamps.rb
@@ -1,0 +1,12 @@
+class AllowNullTimestamps < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :content_items, :created_at, true
+    change_column_null :content_items, :updated_at, true
+
+    change_column_null :publish_intents, :created_at, true
+    change_column_null :publish_intents, :updated_at, true
+
+    change_column_null :scheduled_publishing_log_entries, :created_at, true
+    change_column_null :scheduled_publishing_log_entries, :updated_at, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_28_144838) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_30_093643) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -49,8 +49,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_28_144838) do
     t.integer "payload_version"
     t.jsonb "withdrawn_notice", default: {}
     t.string "publishing_request_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string "_id"
     t.index ["base_path"], name: "index_content_items_on_base_path", unique: true
     t.index ["content_id"], name: "index_content_items_on_content_id"
@@ -62,8 +62,84 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_28_144838) do
     t.index ["updated_at"], name: "index_content_items_on_updated_at"
   end
 
-  create_table "content_items_import", id: false, force: :cascade do |t|
-    t.jsonb "data"
+  create_table "offline_import_content_items_8c34c771", id: false, force: :cascade do |t|
+    t.uuid "id"
+    t.string "base_path"
+    t.string "content_id"
+    t.string "title"
+    t.jsonb "description"
+    t.string "document_type"
+    t.string "content_purpose_document_supertype"
+    t.string "content_purpose_subgroup"
+    t.string "content_purpose_supergroup"
+    t.string "email_document_supertype"
+    t.string "government_document_supertype"
+    t.string "navigation_document_supertype"
+    t.string "search_user_need_document_supertype"
+    t.string "user_journey_document_supertype"
+    t.string "schema_name"
+    t.string "locale"
+    t.datetime "first_published_at"
+    t.datetime "public_updated_at"
+    t.datetime "publishing_scheduled_at"
+    t.integer "scheduled_publishing_delay_seconds"
+    t.jsonb "details"
+    t.string "publishing_app"
+    t.string "rendering_app"
+    t.jsonb "routes"
+    t.jsonb "redirects"
+    t.jsonb "expanded_links"
+    t.jsonb "access_limited"
+    t.string "auth_bypass_ids", array: true
+    t.string "phase"
+    t.string "analytics_identifier"
+    t.integer "payload_version"
+    t.jsonb "withdrawn_notice"
+    t.string "publishing_request_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string "_id"
+    t.index ["id"], name: "offline_import_content_items_8c34c771_id_idx", unique: true
+  end
+
+  create_table "offline_import_content_items_df23dab6", id: false, force: :cascade do |t|
+    t.uuid "id"
+    t.string "base_path"
+    t.string "content_id"
+    t.string "title"
+    t.jsonb "description"
+    t.string "document_type"
+    t.string "content_purpose_document_supertype"
+    t.string "content_purpose_subgroup"
+    t.string "content_purpose_supergroup"
+    t.string "email_document_supertype"
+    t.string "government_document_supertype"
+    t.string "navigation_document_supertype"
+    t.string "search_user_need_document_supertype"
+    t.string "user_journey_document_supertype"
+    t.string "schema_name"
+    t.string "locale"
+    t.datetime "first_published_at"
+    t.datetime "public_updated_at"
+    t.datetime "publishing_scheduled_at"
+    t.integer "scheduled_publishing_delay_seconds"
+    t.jsonb "details"
+    t.string "publishing_app"
+    t.string "rendering_app"
+    t.jsonb "routes"
+    t.jsonb "redirects"
+    t.jsonb "expanded_links"
+    t.jsonb "access_limited"
+    t.string "auth_bypass_ids", array: true
+    t.string "phase"
+    t.string "analytics_identifier"
+    t.integer "payload_version"
+    t.jsonb "withdrawn_notice"
+    t.string "publishing_request_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string "_id"
+    t.index ["id"], name: "offline_import_content_items_df23dab6_id_idx", unique: true
   end
 
   create_table "publish_intents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -72,8 +148,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_28_144838) do
     t.string "publishing_app"
     t.string "rendering_app"
     t.jsonb "routes", default: []
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["base_path"], name: "index_publish_intents_on_base_path", unique: true
     t.index ["created_at"], name: "index_publish_intents_on_created_at"
     t.index ["publish_time"], name: "index_publish_intents_on_publish_time"
@@ -87,8 +163,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_28_144838) do
     t.string "document_type"
     t.datetime "scheduled_publication_time"
     t.bigint "delay_in_milliseconds"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string "mongo_id"
     t.index ["base_path"], name: "ix_scheduled_pub_log_base_path"
     t.index ["created_at"], name: "ix_scheduled_pub_log_created"


### PR DESCRIPTION
Addendum to #1140 - adding the migration file this time

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
