### PR TITLE
FIx silent failure in mongoexport call

### DIFF
--- a/app/lib/mongo_exporter.rb
+++ b/app/lib/mongo_exporter.rb
@@ -21,7 +21,7 @@ class MongoExporter
     end
   end
 
-  def self.execute(cmd, *args)
-    system cmd, *args
+  def self.execute(*args)
+    `#{args.join(" ")}`
   end
 end

--- a/spec/lib/mongo_exporter_spec.rb
+++ b/spec/lib/mongo_exporter_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe MongoExporter do
   before do
-    allow(MongoExporter).to receive(:execute).and_return(true)
+    allow(MongoExporter).to receive(:execute_piped).and_return(true)
     allow(FileUtils).to receive(:mkdir_p)
   end
 
@@ -24,18 +24,21 @@ describe MongoExporter do
       described_class.export(collection: "my_collection", path: "/my/path")
     end
 
-    it "executes mongoexport" do
-      expect(described_class).to receive(:execute).with("mongoexport", any_args)
+    it "executes mongoexport with the correct arguments" do
+      expect(described_class).to receive(:execute_piped).with(
+        ["mongoexport",
+         "--uri=#{ENV['MONGODB_URI']}",
+         "--collection=my_collection",
+         "--type=json"],
+        anything,
+      )
       described_class.export(collection: "my_collection", path: "/my/path")
     end
 
-    it "passes the correct mongoexport arguments" do
-      expect(described_class).to receive(:execute).with(
+    it "pipes the mongoexport output to gzip" do
+      expect(described_class).to receive(:execute_piped).with(
         anything,
-        "--uri=#{ENV['MONGODB_URI']}",
-        "--collection=my_collection",
-        "--type=json",
-        " | gzip > /my/path/my_collection.json.gz",
+        ["gzip > /my/path/my_collection.json.gz"],
       )
       described_class.export(collection: "my_collection", path: "/my/path")
     end


### PR DESCRIPTION
Since adding a pipe through gzip to the mongo export task in #1138, although the CronJob has been completing without errors, it has not actually been exporting anything. Investigation reveals that the way we're executing the command (with Kernel.system) doesn't like the pipe, and this results in the `mongoexport` command failing, but the error is caught by the `system` call and not bubbled out (it just returns a `nil` value).

[Trello card](https://trello.com/c/sxWnwtoO/822-fix-silent-failure-in-content-store-mongo-export)

This PR changes the way we execute the command to use backticks around a plain string, which 

a) works well in local tests under govuk-docker, and
b) raises an exception if the command returns an error status

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
