### PR TITLE
Fix issue with former redirects being unable to be unpublished

### DIFF
--- a/app/models/route_set.rb
+++ b/app/models/route_set.rb
@@ -27,7 +27,7 @@ class RouteSet < OpenStruct
       routes = item.routes.map(&:to_h).map(&:deep_symbolize_keys)
     end
 
-    redirects = item.redirects.map(&:to_h).map(&:deep_symbolize_keys)
+    redirects = Array(item.redirects).map(&:to_h).map(&:deep_symbolize_keys)
 
     new(
       routes:,

--- a/spec/models/route_set_spec.rb
+++ b/spec/models/route_set_spec.rb
@@ -49,6 +49,28 @@ describe RouteSet, type: :model do
       ]
 
       route_set = RouteSet.from_content_item(item)
+
+      expect(route_set.is_gone).to eq(true)
+      expected_routes = [
+        { path: "/path", type: "exact" },
+        { path: "/path.json", type: "exact" },
+        { path: "/path/subpath", type: "prefix" },
+      ]
+      expect(route_set.routes).to eq([])
+      expect(route_set.gone_routes).to match_array(expected_routes)
+      expect(route_set.redirects).to eq([])
+    end
+
+    it "constructs a route set from a gone content item with nil redirects" do
+      item = build(:gone_content_item, base_path: "/path", redirects: nil)
+      item.routes = [
+        { "path" => "/path", "type" => "exact" },
+        { "path" => "/path.json", "type" => "exact" },
+        { "path" => "/path/subpath", "type" => "prefix" },
+      ]
+
+      route_set = RouteSet.from_content_item(item)
+
       expect(route_set.is_gone).to eq(true)
       expected_routes = [
         { path: "/path", type: "exact" },


### PR DESCRIPTION
`items.redirects` can sometimes be `nil`. Therefore we need to convert it to an array (even if empty) before doing `map`, else we get an error as `nil` does not have a `map` method.

This will resolve an issue in production where we are unable to unpublish former redirects.

[Trello card](https://trello.com/c/04oigyvM)