### PR TITLE
fix Integer field overflow in JsonImporter, to handle extreme values

### DIFF
--- a/db/migrate/20231016112610_change_scheduled_publishing_delay_seconds_to_bigint.rb
+++ b/db/migrate/20231016112610_change_scheduled_publishing_delay_seconds_to_bigint.rb
@@ -1,0 +1,9 @@
+class ChangeScheduledPublishingDelaySecondsToBigint < ActiveRecord::Migration[7.0]
+  def up
+    change_column :content_items, :scheduled_publishing_delay_seconds, :bigint
+  end
+
+  def down
+    change_column :content_items, :scheduled_publishing_delay_seconds, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_30_093643) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_16_112610) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -35,7 +35,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_30_093643) do
     t.datetime "first_published_at"
     t.datetime "public_updated_at"
     t.datetime "publishing_scheduled_at"
-    t.integer "scheduled_publishing_delay_seconds"
+    t.bigint "scheduled_publishing_delay_seconds"
     t.jsonb "details", default: {}
     t.string "publishing_app"
     t.string "rendering_app"


### PR DESCRIPTION
…coming through from Whitehall via MongoDB

The overnight mongo-to-postgresql ETL cron job has been failing. Errors in the logs show that an Integer field is overflowing. 
Investigations ([Trello card](https://trello.com/c/hD0M2vAb/867-investigate-failed-mongo-to-postgres-cronjob-in-staging)) found that at least [one content-item](https://www.gov.uk/api/content/government/statistics/announcements/buinsess-population-estimates-2024) has extreme values in a couple of fields:
```
"publishing_scheduled_at": "0024-10-01T00:00:45Z",
"scheduled_publishing_delay_seconds": 63082666703,
```
.... that would mean it is scheduled for publishing at `4022-10-19 23:18:22`

As a result, the `ContentItem.scheduled_publishing_delay_seconds` field to overflow in import.

This PR adds a migration to extend the field to a BigInt, which fixes the issue.


This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
