### PR TITLE
Rework column type change migration to minimise locks

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,4 +67,7 @@ Rails.application.configure do
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end
+
+  # don't dump the schema after running migrations
+  config.active_record.dump_schema_after_migration = false
 end

--- a/db/migrate/20231016112610_change_scheduled_publishing_delay_seconds_to_bigint.rb
+++ b/db/migrate/20231016112610_change_scheduled_publishing_delay_seconds_to_bigint.rb
@@ -7,20 +7,19 @@ class ChangeScheduledPublishingDelaySecondsToBigint < ActiveRecord::Migration[7.
 
     # populate temporary column in small batches, non-transactionally, to minimise locks
     done = false
-    rows_updated = 0
     until done == true
       rows_updated = ContentItem.connection.update <<-SQL
-        UPDATE content_items SET scheduled_publishing_delay_seconds_bigint = scheduled_publishing_delay_seconds 
+        UPDATE content_items SET scheduled_publishing_delay_seconds_bigint = scheduled_publishing_delay_seconds
         WHERE id IN (
-          SELECT id FROM content_items ci2 
-          WHERE ci2.scheduled_publishing_delay_seconds IS NOT NULL 
+          SELECT id FROM content_items ci2
+          WHERE ci2.scheduled_publishing_delay_seconds IS NOT NULL
             AND ci2.scheduled_publishing_delay_seconds_bigint IS NULL
           LIMIT 5000
         );
       SQL
       remaining = ContentItem.where("scheduled_publishing_delay_seconds IS NOT NULL AND scheduled_publishing_delay_seconds_bigint IS NULL").count
-      puts "#{rows_updated} rows updated, #{remaining} remaining"
-      done = (remaining == 0)
+      Rails.logger.debug "#{rows_updated} rows updated, #{remaining} remaining"
+      done = remaining.zero?
     end
 
     ContentItem.transaction do
@@ -35,20 +34,19 @@ class ChangeScheduledPublishingDelaySecondsToBigint < ActiveRecord::Migration[7.
 
     # populate temporary column in small batches, non-transactionally, to minimise locks
     done = false
-    rows_updated = 0
     until done == true
       rows_updated = ContentItem.connection.update <<-SQL
-        UPDATE content_items SET scheduled_publishing_delay_seconds_int = scheduled_publishing_delay_seconds 
+        UPDATE content_items SET scheduled_publishing_delay_seconds_int = scheduled_publishing_delay_seconds
         WHERE id IN (
-          SELECT id FROM content_items ci2 
+          SELECT id FROM content_items ci2
           WHERE ci2.scheduled_publishing_delay_seconds IS NOT NULL
             AND ci2.scheduled_publishing_delay_seconds_int IS NULL
           LIMIT 5000
         );
       SQL
       remaining = ContentItem.where("scheduled_publishing_delay_seconds IS NOT NULL AND scheduled_publishing_delay_seconds_int IS NULL").count
-      puts "#{rows_updated} rows updated, #{remaining} remaining"
-      done = (remaining == 0)
+      Rails.logger.debug "#{rows_updated} rows updated, #{remaining} remaining"
+      done = remaining.zero?
     end
 
     ContentItem.transaction do

--- a/db/migrate/20231016112610_change_scheduled_publishing_delay_seconds_to_bigint.rb
+++ b/db/migrate/20231016112610_change_scheduled_publishing_delay_seconds_to_bigint.rb
@@ -1,9 +1,60 @@
 class ChangeScheduledPublishingDelaySecondsToBigint < ActiveRecord::Migration[7.0]
+  # we want manual control of transactions to minimise exclusive locks
+  disable_ddl_transaction!
+
   def up
-    change_column :content_items, :scheduled_publishing_delay_seconds, :bigint
+    add_column :content_items, :scheduled_publishing_delay_seconds_bigint, :bigint, null: true
+
+    # populate temporary column in small batches, non-transactionally, to minimise locks
+    done = false
+    rows_updated = 0
+    until done == true
+      rows_updated = ContentItem.connection.update <<-SQL
+        UPDATE content_items SET scheduled_publishing_delay_seconds_bigint = scheduled_publishing_delay_seconds 
+        WHERE id IN (
+          SELECT id FROM content_items ci2 
+          WHERE ci2.scheduled_publishing_delay_seconds IS NOT NULL 
+            AND ci2.scheduled_publishing_delay_seconds_bigint IS NULL
+          LIMIT 5000
+        );
+      SQL
+      remaining = ContentItem.where("scheduled_publishing_delay_seconds IS NOT NULL AND scheduled_publishing_delay_seconds_bigint IS NULL").count
+      puts "#{rows_updated} rows updated, #{remaining} remaining"
+      done = (remaining == 0)
+    end
+
+    ContentItem.transaction do
+      rename_column :content_items, :scheduled_publishing_delay_seconds, :scheduled_publishing_delay_seconds_int
+      rename_column :content_items, :scheduled_publishing_delay_seconds_bigint, :scheduled_publishing_delay_seconds
+      remove_column :content_items, :scheduled_publishing_delay_seconds_int
+    end
   end
 
   def down
-    change_column :content_items, :scheduled_publishing_delay_seconds, :integer
+    add_column :content_items, :scheduled_publishing_delay_seconds_int, :integer, null: true
+
+    # populate temporary column in small batches, non-transactionally, to minimise locks
+    done = false
+    rows_updated = 0
+    until done == true
+      rows_updated = ContentItem.connection.update <<-SQL
+        UPDATE content_items SET scheduled_publishing_delay_seconds_int = scheduled_publishing_delay_seconds 
+        WHERE id IN (
+          SELECT id FROM content_items ci2 
+          WHERE ci2.scheduled_publishing_delay_seconds IS NOT NULL
+            AND ci2.scheduled_publishing_delay_seconds_int IS NULL
+          LIMIT 5000
+        );
+      SQL
+      remaining = ContentItem.where("scheduled_publishing_delay_seconds IS NOT NULL AND scheduled_publishing_delay_seconds_int IS NULL").count
+      puts "#{rows_updated} rows updated, #{remaining} remaining"
+      done = (remaining == 0)
+    end
+
+    ContentItem.transaction do
+      rename_column :content_items, :scheduled_publishing_delay_seconds, :scheduled_publishing_delay_seconds_bigint
+      rename_column :content_items, :scheduled_publishing_delay_seconds_int, :scheduled_publishing_delay_seconds
+      remove_column :content_items, :scheduled_publishing_delay_seconds_bigint
+    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,7 +35,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_16_112610) do
     t.datetime "first_published_at"
     t.datetime "public_updated_at"
     t.datetime "publishing_scheduled_at"
-    t.bigint "scheduled_publishing_delay_seconds"
     t.jsonb "details", default: {}
     t.string "publishing_app"
     t.string "rendering_app"
@@ -52,6 +51,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_16_112610) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "_id"
+    t.bigint "scheduled_publishing_delay_seconds"
     t.index ["base_path"], name: "index_content_items_on_base_path", unique: true
     t.index ["content_id"], name: "index_content_items_on_content_id"
     t.index ["created_at"], name: "index_content_items_on_created_at"


### PR DESCRIPTION
When deploying the migration in #1165 to staging, we found two problems:

1. After running the migration, Rails tried to dump the schema and threw an error with `read-only filesystem - db/schema.rb`
2. While running the migration, PostgreSQL held an exclusive lock for the duration, which was over a minute and a half. This blocked all reads, meaning no requests could go through while the migration was running. This is unacceptable for production.

So this PR:

1. adds the missing `config.dump_schema_after_migration = false` line to production.rb  - it was not needed for the Mongoid application on `main`, but is needed for this ActiveRecord port
2. reworks the migration to minimise table locks, by adding separate steps to add a new column, populate it in small batches,  rename the existing column , rename the new column to the old name, and drop the old column. Testing locally on a content-store with near-production size (736k content-items, vs 895k for prod) shows that this does _not_ lock the table for any noticable time. 

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
