### PR TITLE
Fix error when auth_bypass_ids is nil

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -129,7 +129,7 @@ class ContentItem < ApplicationRecord
 
   def valid_auth_bypass_id?(auth_bypass_id)
     return false unless auth_bypass_id
-    return true if auth_bypass_ids.include?(auth_bypass_id)
+    return true if auth_bypass_ids&.include?(auth_bypass_id)
     return false if access_limited?
 
     # check for linked auth_bypass_id in top level expanded links

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -449,6 +449,22 @@ describe ContentItem, type: :model do
         expect(content_item.valid_auth_bypass_id?(auth_bypass_id)).to be(false)
       end
     end
+
+    context "when auth_bypass_ids is nil" do
+      let(:content_item) { build(:content_item, auth_bypass_ids: nil) }
+
+      context "given an auth_bypass_id" do
+        let(:auth_bypass_id) { SecureRandom.uuid }
+
+        it "does not raise an error" do
+          expect { content_item.valid_auth_bypass_id?(auth_bypass_id) }.not_to raise_error
+        end
+
+        it "returns false" do
+          expect(content_item.valid_auth_bypass_id?(auth_bypass_id)).to eq(false)
+        end
+      end
+    end
   end
 
   describe "description" do


### PR DESCRIPTION
Fixes a [Sentry alert](https://govuk.sentry.io/issues/4561495999/?referrer=slack&notification_uuid=bbcde914-f9b6-4870-86e2-fb3994322648&alert_rule_id=9402830&alert_type=issue) from the draft-content-store-postgresql-branch in production:

```
NoMethodError
undefined method `include?' for nil:NilClass
   return true if auth_bypass_ids.include?(auth_bypass_id)
                                 ^^^^^^^^^
```

Details in [this Trello card](https://trello.com/c/Qb5DI23q/915-fix-undefined-method-include-for-nil-in-content-store-postgresql-branch)

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
