### PR TITLE
Update Pact Broker URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,4 @@ jobs:
     name: Run Pact tests
     uses: ./.github/workflows/verify-pact.yml
     with:
-      # Note: As of January 2023 this relies on Jenkins CI to generate
-      # this Pact consumer version. Replatforming does not tag
-      # deployed-to-production and the Publishing API CI build doesn't run
-      # against the tag when one is created.
-      pact_consumer_version: 'branch-deployed-to-production'
+      pact_consumer_version: 'branch-main'

--- a/.github/workflows/verify-pact.yml
+++ b/.github/workflows/verify-pact.yml
@@ -17,7 +17,7 @@ on:
       pact_consumer_version:
         required: false
         type: string
-        default: branch-deployed-to-production
+        default: branch-main
 
 jobs:
   pact_verify:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ node("mongodb-2.4") {
       ),
       stringParam(
         name: "PACT_BROKER_BASE_URL",
-        defaultValue: "https://pact-broker.cloudapps.digital",
+        defaultValue: "https://govuk-pact-broker-6991351eca05.herokuapp.com",
         description: "The Pact Broker to run Pact tests against"
       ),
     ],

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-do
 ### Example API output
 
 Example API requests and corresponding responses can be found in the
-[content store pact-broker documentation](https://pact-broker.cloudapps.digital/pacts/provider/Content%20Store/consumer/Publishing%20API/latest).
+[content store pact-broker documentation](https://govuk-pact-broker-6991351eca05.herokuapp.com/pacts/provider/Content%20Store/consumer/Publishing%20API/latest).
 
 ## Further documentation
 

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -22,7 +22,7 @@ Pact.service_provider "Content Store" do
     else
       base_url = ENV.fetch("PACT_BROKER_BASE_URL", "https://govuk-pact-broker-6991351eca05.herokuapp.com")
       url = "#{base_url}/pacts/provider/#{url_encode(name)}/consumer/#{url_encode(consumer_name)}"
-      version_part = "versions/#{url_encode(ENV.fetch('PACT_CONSUMER_VERSION', 'branch-deployed-to-production'))}"
+      version_part = "versions/#{url_encode(ENV.fetch('PACT_CONSUMER_VERSION', 'branch-main'))}"
 
       pact_uri "#{url}/#{version_part}"
     end

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -20,7 +20,7 @@ Pact.service_provider "Content Store" do
     if ENV["PACT_URI"]
       pact_uri(ENV["PACT_URI"])
     else
-      base_url = ENV.fetch("PACT_BROKER_BASE_URL", "https://pact-broker.cloudapps.digital")
+      base_url = ENV.fetch("PACT_BROKER_BASE_URL", "https://govuk-pact-broker-6991351eca05.herokuapp.com")
       url = "#{base_url}/pacts/provider/#{url_encode(name)}/consumer/#{url_encode(consumer_name)}"
       version_part = "versions/#{url_encode(ENV.fetch('PACT_CONSUMER_VERSION', 'branch-deployed-to-production'))}"
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/7f3F6Xij/3338-migrate-from-the-old-paas-based-pact-broker-to-the-new-instance-on-heroku)

We are currently migrating our Pact Broker instance from PaaS to Heroku. `gds-api-adapters` has already been updated to publish pacts to both instances, now we need to update each of our API providers to fetch from the new instance instead of the old one.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️