### PR TITLE
Fix postgresql pact tests

### DIFF
--- a/.github/workflows/verify-pact.yml
+++ b/.github/workflows/verify-pact.yml
@@ -50,6 +50,7 @@ jobs:
         if: inputs.pact_artifact == ''
         env:
           PACT_CONSUMER_VERSION: ${{ inputs.pact_consumer_version }}
+          TEST_DATABASE_URL: ${{ steps.setup-postgres.outputs.db-url }}
         run: bundle exec rake pact:verify
 
       - name: Download pact artifact
@@ -62,3 +63,5 @@ jobs:
       - name: Verify pact artifact
         if: inputs.pact_artifact != ''
         run: bundle exec rake pact:verify:at[tmp/pacts/publishing_api-content_store.json]
+        env: 
+          TEST_DATABASE_URL: ${{ steps.setup-postgres.outputs.db-url }}


### PR DESCRIPTION
On the `port-to-postgresql` branch, pact tests were incorrectly reported as successful in CI, even though [no pact tests were actually being run](https://github.com/alphagov/content-store/actions/runs/6878685214/job/18708888824?pr=1173#step:6:25). Errors indicated that this was because they [could not connect to the database](https://github.com/alphagov/content-store/actions/runs/6878685214/job/18708888824?pr=1173#step:6:32).

[Trello card](https://trello.com/c/qA4Xn1jO/935-actually-verify-pacts-in-content-store-ci)

After investigation, it looks like the `setup-postgres` step was [creating a database called `test`](https://github.com/alphagov/content-store/actions/runs/6878685214/job/18708888824?pr=1173#step:2:69), but the pact tests were expecting a database called [`content_store_test`](https://github.com/alphagov/content-store/blob/fix-postgresql-pact-tests-attempt-2/config/database.yml#L14).

Explicitly supplying a `TEST_DATABASE_URL` to both pact:verify steps fixes this problem.

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
