### PR TITLE
Fix logger custom field config

### DIFF
--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -1,5 +1,7 @@
-if Object.const_defined?("LogStasher") && LogStasher.enabled
-  LogStasher.add_custom_fields do |fields|
-    fields[:govuk_dependency_resolution_source_content_id] = request.headers["GOVUK-Dependency-Resolution-Source-Content-Id"]
+unless Rails.env.test?
+  GovukJsonLogging.configure do
+    add_custom_fields do |fields|
+      fields[:govuk_dependency_resolution_source_content_id] = request.headers["GOVUK-Dependency-Resolution-Source-Content-Id"]
+    end
   end
 end


### PR DESCRIPTION
https://trello.com/c/jDSDGNyn/814-measure-and-record-our-publishing-latency-sli

It turns out that you can't call `LogStasher.add_custom_fields` twice. Because Content Store's custom fields config was being run after the govuk_app_config gem's own custom fields config, the gem's config was being overwritten. So, fields like `govuk_request_id` and `varnish_id` weren't appearing in Content Store's controller request logs (but `govuk_dependency_resolution_source_content_id` was).

The gem (version 9.7.0) now provides a mechanism for setting custom fields that doesn't overwrite the gem's own settings https://docs.publishing.service.gov.uk/repos/govuk_app_config.html#logger-configuration:

```
GovukJsonLogging.configure do
  add_custom_fields do |fields|
    fields[:govuk_custom_field] = request.headers["GOVUK-Custom-Header"]
  end
end
```