### PR TITLE
Add CodeQL (SAST) scan and Dependency Review (SCA) scan to CI pipeline (for `port-to-postgresql` branch)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,16 @@ on:
   pull_request:
 
 jobs:
+  codeql-sast:
+    name: CodeQL SAST scan
+    uses: alphagov/govuk-infrastructure/.github/workflows/codeql-analysis.yml@main
+    permissions:
+      security-events: write
+
+  dependency-review:
+    name: Dependency Review scan
+    uses: alphagov/govuk-infrastructure/.github/workflows/dependency-review.yml@main
+  
   security-analysis:
     name: Security Analysis
     uses: alphagov/govuk-infrastructure/.github/workflows/brakeman.yml@main


### PR DESCRIPTION
This is a clone of https://github.com/alphagov/content-store/pull/1183 but that was targetting `main` and this is targetting the `port-to-postgresql` branch