### PR TITLE
Don't force incoming HTTP requests to be over SSL

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -35,7 +35,7 @@ Rails.application.configure do
   # config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  # config.force_ssl = true
 
   # Info include generic and useful information about system operation, but avoids logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII). If you


### PR DESCRIPTION
I assume this was accidentally changed during the Rails upgrade (the
latest version bump seemed to want to touch quite a lot of config).

The traffic to the actual Rails app in non-development environments is
internal to our cluster, so it won't be over SSL.