### PR TITLE
add note about how to deploy into the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ For most of 2023, Publishing Platform team have been working on migrating Conten
 
 * The `main` branch is currently _not in use by any deployed application_
 * The `content-store` and `draft-content-store` applications in all environments are using a container name of `content-store`, but that must be manually built from the `port-to-postgresql` branch
+* There is no automatic build promotion - deployments must be manually done for each environment.
 
 If you need to deploy Content Store, make sure that you:
 * base any pull requests off the `port-to-postgresql` branch (see PR #1085)
 * merge any pull requests into the `port-to-postgresql` branch
-* deploy by running the [Deploy workflow](https://github.com/alphagov/content-store/actions/workflows/deploy.yml)
+* deploy to each environment by running the [Deploy workflow](https://github.com/alphagov/content-store/actions/workflows/deploy.yml)
 * specify `port-to-postgresql` as the "Commit, tag or branch name to deploy"
 * specify `content-store` as the "ECR repo name to push image to"
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,23 @@
 # Content Store
 
-The Content Store is a MongoDB database of almost all published content on GOV.UK.
+The Content Store is a database of almost all published content on GOV.UK.
 See the [Content Store API](./docs/content-store-api.md) for basic usage.
+
+## Deployment in current transitional state
+
+For most of 2023, Publishing Platform team have been working on migrating Content Store from MongoDB to PostgreSQL on Amazon's RDS service. This work is nearing completion, but at the moment there is a non-standard setup for deploying any changes.
+
+* The `main` branch is currently _not in use by any deployed application_
+* The `content-store` and `draft-content-store` applications in all environments are using a container name of `content-store`, but that must be manually built from the `port-to-postgresql` branch
+
+If you need to deploy Content Store, make sure that you:
+* base any pull requests off the `port-to-postgresql` branch (see PR #1085)
+* merge any pull requests into the `port-to-postgresql` branch
+* deploy by running the [Deploy workflow](https://github.com/alphagov/content-store/actions/workflows/deploy.yml)
+* specify `port-to-postgresql` as the "Commit, tag or branch name to deploy"
+* specify `content-store` as the "ECR repo name to push image to"
+
+
 
 ## Technical documentation
 


### PR DESCRIPTION
Merging the very long-running `port-to-postgresql` branch back into main is going to take longer than originally thought, to make sure that the commit history ends up reasonably comprehensible and manageable. 

Until we finish this, deployment will remain a non-standard task that requires specific knowledge. So for the benefit of anyone who needs to make an urgent change when I'm not around, I've added this note into the README. 

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
