### PR TITLE
Remove README note about deployment in transitional state

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,23 +3,6 @@
 The Content Store is a database of almost all published content on GOV.UK.
 See the [Content Store API](./docs/content-store-api.md) for basic usage.
 
-## Deployment in current transitional state
-
-For most of 2023, Publishing Platform team have been working on migrating Content Store from MongoDB to PostgreSQL on Amazon's RDS service. This work is nearing completion, but at the moment there is a non-standard setup for deploying any changes.
-
-* The `main` branch is currently _not in use by any deployed application_
-* The `content-store` and `draft-content-store` applications in all environments are using a container name of `content-store`, but that must be manually built from the `port-to-postgresql` branch
-* There is no automatic build promotion - deployments must be manually done for each environment.
-
-If you need to deploy Content Store, make sure that you:
-* base any pull requests off the `port-to-postgresql` branch (see PR #1085)
-* merge any pull requests into the `port-to-postgresql` branch
-* deploy to each environment by running the [Deploy workflow](https://github.com/alphagov/content-store/actions/workflows/deploy.yml)
-* specify `port-to-postgresql` as the "Commit, tag or branch name to deploy"
-* specify `content-store` as the "ECR repo name to push image to"
-
-
-
 ## Technical documentation
 
 This is a Ruby on Rails app, and should follow [our Rails app conventions](https://docs.publishing.service.gov.uk/manual/conventions-for-rails-applications.html).


### PR DESCRIPTION
Remove the temporary note added in #1194 about how to deploy while we were in a transitional, non-main state.
Since merging #1085 this note is no longer needed or wanted.

[Trello card](https://trello.com/c/sQIA1Q7d/977-update-all-content-store-documentation-relevant-to-mongo-postgres-switch)

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
