### PR TITLE
Switch the /healthcheck/ready endpoint to check ActiveRecord

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,6 @@ Rails.application.routes.draw do
 
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
-    GovukHealthcheck::Mongoid,
+    GovukHealthcheck::ActiveRecord,
   )
 end


### PR DESCRIPTION
The healthcheck endpoint was still checking Mongoid - this needs* switching to ActiveRecord.

[Trello card](https://trello.com/c/dggI2ttX/988-remove-any-now-redundant-mongo-related-code-from-content-store)

*One for later - as this has been reporting a critical status for weeks but no-one noticed - is this endpoint even used anymore? 

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
