### PR TITLE
Remove `simplecov-rcov` gem dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ group :development, :test do
   gem "rspec-rails"
   gem "rubocop-govuk"
   gem "simplecov", require: false
-  gem "simplecov-rcov", require: false
   gem "timecop"
   gem "webmock", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -621,8 +621,6 @@ GEM
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
-    simplecov-rcov (0.3.7)
-      simplecov (>= 0.4.1)
     simplecov_json_formatter (0.1.4)
     snaky_hash (2.0.1)
       hashie
@@ -690,7 +688,6 @@ DEPENDENCIES
   rspec-rails
   rubocop-govuk
   simplecov
-  simplecov-rcov
   timecop
   uuidtools
   webmock


### PR DESCRIPTION
This gem is not being initialised in the `test_helper.rb` file, so therefore is not being used and can be removed.