### PR TITLE
Pass contents read permission to build image workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,7 @@ jobs:
       gitRef: ${{ inputs.gitRef || github.ref_name }}
     permissions:
       id-token: write
+      contents: read
   trigger-deploy:
     name: Trigger deploy to ${{ inputs.environment || 'integration' }}
     needs: build-and-publish-image


### PR DESCRIPTION
This is required as the reusuable workflow no requires that permission to be explicitly passed it. This is so the reusuable workflow can checkout the repository if it private.

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs. 