### PR TITLE
Add migration to delete worldwide offices

### DIFF
--- a/db/migrate/20240220151333_remove_worldwide_offices.rb
+++ b/db/migrate/20240220151333_remove_worldwide_offices.rb
@@ -1,0 +1,5 @@
+class RemoveWorldwideOffices < ActiveRecord::Migration[7.1]
+  def up
+    ContentItem.where(document_type: "worldwide_office").destroy_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_16_112610) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_20_151333) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"


### PR DESCRIPTION
Worldwide Offices are now represented within the Worldwide Organisation content item.

Therefore we no longer need these content items.

We cannot use the standard means of removing these items (e.g. marking them as gone), as the route has been re-registered by the Worldwide Organisation in https://github.com/alphagov/whitehall/pull/8853.

Depends on: https://github.com/alphagov/whitehall/pull/8859.

[Trello card](https://trello.com/c/9ivR4TGQ)