### PR TITLE
Remove all content items rendered by Whitehall Frontend

### DIFF
--- a/db/migrate/20240312132747_remove_whitehall_frontend.rb
+++ b/db/migrate/20240312132747_remove_whitehall_frontend.rb
@@ -1,0 +1,5 @@
+class RemoveWhitehallFrontend < ActiveRecord::Migration[7.1]
+  def up
+    ContentItem.where(rendering_app: "whitehall-frontend").delete_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_20_151333) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_12_132747) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"


### PR DESCRIPTION
Whitehall Frontend was switched off in 2023. However, as a result of [a bug](https://trello.com/c/z5pHDAXC) where some documents were missed when they were bulk republished, a small number (approximately 65) of documents remained in the Content Store database with a rendering app of `whitehall-frontend` and a schema name of `placeholder`.

The logic to deal with placeholders was removed in https://github.com/alphagov/content-store/pull/1152, therefore the routes were never registered for these content items (and never will be, as Content Store assumes they have already been rendered).

Since the public versions of these page already return a 404 or 500 error (or in some cases, have a redirect implemented directly in Router), it is safe to remove them and republish the affected pages from Whitehall to correctly register the routes and make these pages available again to users.

[Trello card](https://trello.com/c/UdAr5zOb)