### PR TITLE
Remove references to placeholder items

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Example API requests and corresponding responses can be found in the
 - [Access-limited content items](./docs/access-limited-content-items.md)
 - [Gone items](./docs/gone_item.md)
 - [Redirect items](./docs/redirect_item.md)
-- [Placeholder items](./docs/placeholder_item.md)
 
 ## Licence
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -433,7 +433,7 @@ components:
           document_type: organisation
           locale: en
           public_updated_at: '2015-05-13T10:09:06Z'
-          schema_name: placeholder
+          schema_name: organisation
           title: HM Revenue & Customs
           withdrawn: false
           details:


### PR DESCRIPTION
Placeholder items were removed in bbe2fda, but these references to them remained

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
