### PR TITLE
Remove unnecessary flaky assertion

### DIFF
--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -78,7 +78,6 @@ describe "Fetching content items", type: :request do
 
       data = JSON.parse(response.body)
       expect(data["public_updated_at"]).to eq(content_item.public_updated_at.iso8601.as_json)
-      expect(Time.zone.parse(data["updated_at"])).to be_within(1.second).of(Time.zone.now.utc)
     end
 
     it "sets cache headers to expire in the default TTL" do

--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -74,8 +74,6 @@ describe "Fetching content items", type: :request do
     end
 
     it "outputs the timestamp fields correctly" do
-      content_item.reload # reload to pick up any time rounding in the database.
-
       data = JSON.parse(response.body)
       expect(data["public_updated_at"]).to eq(content_item.public_updated_at.iso8601.as_json)
     end


### PR DESCRIPTION
This test (which simply makes a GET request on the content item endpoint) was testing whether the returned content item included a `public_updated_at` time that was within one second of now.

This relied on the record being created within 1 second of the GET request being made by the test, therefore sometimes failing.

However we are not testing the creation of the record here, so it is not required to check the timestamp.