### PR TITLE
Log 409 errors in Sentry

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -62,6 +62,12 @@ class ContentItem < ApplicationRecord
     item.errors.add(:base, e.message)
     [false, item]
   rescue OutOfOrderTransmissionError => e
+    GovukError.notify(
+      e,
+      level: "error",
+      extra: { error_message: e.message },
+    )
+
     [
       :conflict,
       OpenStruct.new(

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -88,7 +88,15 @@ describe ContentItem, type: :model do
             .and_raise(OutOfOrderTransmissionError, "Booyah")
         end
 
-        it "returns a result of :conflict" do
+        it "sends an alert to GovukError and returns a result of :conflict" do
+          expect(GovukError)
+            .to receive(:notify)
+            .with(
+              an_instance_of(OutOfOrderTransmissionError),
+              level: "error",
+              extra: { error_message: "Booyah" },
+            )
+
           result, item = ContentItem.create_or_replace(@item.base_path, {}, nil)
 
           expect(result).to eq(:conflict)


### PR DESCRIPTION
[Trello](https://trello.com/c/MMHFFEwZ/1219-have-sentry-capture-409s-from-content-store)

We're exploring a potential race conditions issue which is leading the Publishing API not to reflect what's in the Content Store. We believe that logging 409 errors in Sentry might help provide greater visibility on this issue

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
