### PR TITLE
[DO NOT MERGE] Proof of concept for Content Store operating as publishing router

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -1,9 +1,19 @@
+require 'plek'
+
 class ContentItemsController < ApplicationController
   skip_before_action :authenticate_user!, only: [:show]
   before_action :parse_json_request, only: [:update]
   before_action :set_cors_headers, only: [:show]
 
   def show
+    # TODO: make sure we don't intercept requests for Content Publisher items
+    if encoded_request_path.start_with?("/government/news")
+      client = WhitehallApi.new(Plek.find('whitehall-admin'))
+      res = client.content_item(encoded_request_path)
+      return error_404 unless res
+      return render json: res.to_h
+    end
+
     item = GovukStatsd.time("show.find_content_item") do
       ContentItem.find_by_path(encoded_request_path)
     end

--- a/app/services/whitehall_api.rb
+++ b/app/services/whitehall_api.rb
@@ -1,0 +1,11 @@
+class WhitehallApi < GdsApi::Base
+
+  def content_item(path)
+    get_json "#{base_url}#{path}"
+  end
+
+private
+  def base_url
+    "#{endpoint}/api"
+  end
+end


### PR DESCRIPTION
I've been thinking about how we might simplify publishing documents from Whitehall, so that we aren't consistently experiencing distributed transaction failures between Whitehall (and other publishing apps) and GOV.UK frontend.

One way we could solve this problem is to serve the content directly from the Publishing application. This would solve our distributed transaction failures, but lead to other problems such as performance, authorisation and routing. I think the latter set of problems are probably easier to solve.

This proof of concept shows a rough way we could use content store as a proxy to Whitehall for news articles. In reality we would need to be very careful about how we deliver this, probably making use of the [scientist](https://github.com/github/scientist) gem to ensure performance is satisfactory. Caching could easily be done much closer to Whitehall though to the cache easier to invalidate than it is via Publishing API.

The nice thing about this is that it can be implemented content type by content type and doesn't require the introduction of any new services or technologies into our system.
