### PR TITLE
Update cache format version for Rails 7.1

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -30,7 +30,7 @@ module ContentStore
     # Once this application is fully deployed to Rails 7.1 and you have no plans to rollback
     # replace the line below with config.active_support.cache_format_version = 7.1
     # This will mean that we can revert back to rails 7.0 if there is an issue
-    config.active_support.cache_format_version = 7.0
+    config.active_support.cache_format_version = 7.1
 
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.


### PR DESCRIPTION
This application has been using Rails 7.1 for many months now, so it is safe to migrate the cache format version to the default for 7.1, since we won't be rolling back to 7.0.

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

[Trello card](https://trello.com/c/KtQiL6h1)