### PR TITLE
Remove whenever gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem "pg"
 gem "plek"
 gem "rack-cache"
 gem "uuidtools"
-gem "whenever", require: false
 
 group :development, :test do
   gem "ci_reporter_rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    chronic (0.10.2)
     ci_reporter (2.0.0)
       builder (>= 2.1.2)
     ci_reporter_rspec (1.0.0)
@@ -667,8 +666,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    whenever (1.0.0)
-      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.7.1)
@@ -704,7 +701,6 @@ DEPENDENCIES
   timecop
   uuidtools
   webmock
-  whenever
 
 BUNDLED WITH
    2.3.22


### PR DESCRIPTION
[Trello](https://trello.com/c/XaoSL3oM/1465-remove-whenever-gem-from-our-apps)

This was [added][1] when scheduling a Rake task to run every minute, and evolved over time. However, all scheduling has since been [removed from the Content Store code][2] but the gem was left behind

[1]: https://github.com/alphagov/content-store/commit/796f2179ff5406cb4df1096ac2dd3c2c95f8d6c4
[2]: https://github.com/alphagov/content-store/commit/7a136e7b108c8dcb35d99bea0a3f64b7ce6a6b48

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
