### PR TITLE
Add rake task to remove old publishing intents

### DIFF
--- a/app/models/publish_intent.rb
+++ b/app/models/publish_intent.rb
@@ -47,6 +47,11 @@ class PublishIntent < ApplicationRecord
     ContentItem.where(base_path:).first
   end
 
+  # Called nightly from a cron job
+  def self.cleanup_expired
+    where("publish_time < ?", PUBLISH_TIME_LEEWAY.ago).delete_all
+  end
+
   def base_path_without_root
     base_path&.sub(%r{^/}, "")
   end

--- a/lib/tasks/housekeeping.rake
+++ b/lib/tasks/housekeeping.rake
@@ -1,0 +1,6 @@
+namespace :housekeeping do
+  desc "Delete any publish intents in the past"
+  task cleanup_publish_intents: :environment do
+    PublishIntent.cleanup_expired
+  end
+end

--- a/spec/models/publish_intent_spec.rb
+++ b/spec/models/publish_intent_spec.rb
@@ -155,4 +155,31 @@ describe PublishIntent, type: :model do
       )
     end
   end
+
+  describe ".cleanup_expired" do
+    before :each do
+      create(:publish_intent, publish_time: 3.days.ago)
+      create(:publish_intent, publish_time: 2.days.ago)
+      create(:publish_intent, publish_time: 1.hour.ago)
+      create(:publish_intent, publish_time: 10.minutes.from_now)
+      create(:publish_intent, publish_time: 10.days.from_now)
+      create(:publish_intent, publish_time: 1.year.from_now)
+    end
+
+    it "deletes all publish_intents with publish_at in the past" do
+      PublishIntent.cleanup_expired
+
+      expect(PublishIntent.count).to eq(3)
+      expect(PublishIntent.where(publish_time: Time.zone.now..).count).to eq(3)
+    end
+
+    it "does not delete very recently passed intents" do
+      recent = create(:publish_intent, publish_time: 30.seconds.ago)
+
+      PublishIntent.cleanup_expired
+
+      expect(PublishIntent.where(base_path: recent.base_path).first).to be
+      expect(PublishIntent.count).to eq(4)
+    end
+  end
 end


### PR DESCRIPTION
We use publish intents for schedule publishing to reduce the cache time ahead of publication. However, once the associated content items is published we don’t need the intent anymore.

Looks like from the [code we only delete intents if we unschedule something](https://github.com/search?q=org%3Aalphagov+destroy_intent++NOT+is%3Aarchived+NOT+path%3A%2F%5Etest%5C%2F%2F+NOT+path%3A%2F%5Espec%5C%2F%2F&type=code) - but we should also be delete them them when we publish the content item.

The number of Publish Intents has impact on the performance for route reloading in Router. Currently we have t[o scan (do an anti-join)](https://github.com/alphagov/router/blob/42a55aba7060bee3b0edb80f1b2602ccb0bc5d70/lib/sql/routes.sql#L30) through all the publish intents for routes - obviously that’d be far quicker if table had a 100s vs 10000s of rows.

Previously there used to be a [cronjob that periodically cleaned up old publish intents](https://github.com/alphagov/content-store/pull/461) (this is based on that). 

However, I can't see the replacement functionality to delete publish intents once the document is published.

Adding this rake task to allow us to clean up the existing accumulation of Publish Intent.

