### PR TITLE
Remove import of (deprecated) gds_api/router

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -20,7 +20,6 @@ require "active_support/core_ext/integer/time"
 Bundler.require(*Rails.groups)
 
 require "plek"
-require "gds_api/router"
 
 module ContentStore
   class Application < Rails::Application


### PR DESCRIPTION
References to Router API have actually been removed from version 98.0.0 of GDS API Adapters.

The uses of Router API were recently removed from this codebase, but I guess this was overlooked.