### PR TITLE
Fix OpenAPI 3.0 definition

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :development, :test do
   gem "factory_bot"
   gem "govuk_schemas"
   gem "govuk_test"
+  gem "openapi3_parser", "~> 0.9.0" # This should be the same version as used in the tech-docs-gem
   gem "pact"
   gem "pry-byebug"
   gem "rspec-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,7 @@ GEM
       rspec (>= 2.14, < 4)
     climate_control (1.2.0)
     coderay (1.1.3)
+    commonmarker (0.23.11)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     crack (1.0.0)
@@ -273,6 +274,8 @@ GEM
     omniauth-oauth2 (1.8.0)
       oauth2 (>= 1.4, < 3)
       omniauth (~> 2.0)
+    openapi3_parser (0.9.2)
+      commonmarker (~> 0.17)
     opentelemetry-api (1.4.0)
     opentelemetry-common (0.21.0)
       opentelemetry-api (~> 1.0)
@@ -710,6 +713,7 @@ DEPENDENCIES
   govuk_schemas
   govuk_test
   listen
+  openapi3_parser (~> 0.9.0)
   pact
   pg
   plek

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -54,8 +54,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ContentItem'
-              example:
-                $ref: '#/components/examples/ContentItemExample'
         303:
           description: A content item at a different location is responsible for the content at this path. [Learn more](https://content-api.publishing.service.gov.uk/getting-started.html#content-that-spans-multiple-pages).
         404:
@@ -164,7 +162,6 @@ components:
           description: Used to distinguish pages used mainly for navigation (finding) from content pages (thing).
         withdrawn_notice:
           $ref: '#/components/schemas/WithdrawnNotice'
-          description: If the edition is withdrawn, this will contain the information about when and why it was withdrawn.
       example:
         $ref: '#/components/examples/ContentItemExample'
 
@@ -277,247 +274,248 @@ components:
         withdrawn_at: '2016-07-11T15:08:02Z'
   examples:
     ContentItemExample:
-      analytics_identifier:
-      base_path: /vat-rates
-      content_id: f838c22a-b2aa-49be-bd95-153f593293a3
-      document_type: answer
-      email_document_supertype: other
-      first_published_at: '2016-02-29T09:24:10.000+00:00'
-      government_document_supertype: other
-      locale: en
-      navigation_document_supertype: guidance
-      phase: live
-      public_updated_at: '2014-12-12T14:55:23.000+00:00'
-      publishing_app: publisher
-      rendering_app: government-frontend
-      schema_name: answer
-      title: VAT rates
-      updated_at: '2017-08-31T11:35:14.024Z'
-      user_journey_document_supertype: thing
-      withdrawn_notice: {}
-      publishing_request_id: 3592-1504179295.816-10.3.3.1-410
-      links:
-        mainstream_browse_pages:
-        - api_path: /api/content/browse/tax/vat
-          base_path: /browse/tax/vat
-          content_id: 895d337a-fa68-4c83-ab79-1c08016afe87
-          description: Includes online returns, rates, charging and record keeping
-          document_type: mainstream_browse_page
-          locale: en
-          public_updated_at: '2015-06-24T13:56:39Z'
-          schema_name: mainstream_browse_page
-          title: VAT
-          withdrawn: false
-          links: {}
-          api_url: https://www.gov.uk/api/content/browse/tax/vat
-          web_url: https://www.gov.uk/browse/tax/vat
-        ordered_related_items:
-        - api_path: /api/content/tax-on-shopping
-          base_path: /tax-on-shopping
-          content_id: ca839010-1a5e-4049-93b5-577a40286701
-          description: VAT and other taxes on shopping and services, including tax-free
-            shopping, energy-saving equipment and mobility aids
-          document_type: guide
-          locale: en
-          public_updated_at: '2014-12-18T14:31:58Z'
-          schema_name: guide
-          title: Tax on shopping and services
-          withdrawn: false
-          links:
-            mainstream_browse_pages:
-            - api_path: /api/content/browse/tax/vat
-              base_path: /browse/tax/vat
-              content_id: 895d337a-fa68-4c83-ab79-1c08016afe87
-              description: Includes online returns, rates, charging and record keeping
-              document_type: mainstream_browse_page
-              locale: en
-              public_updated_at: '2015-06-24T13:56:39Z'
-              schema_name: mainstream_browse_page
-              title: VAT
-              withdrawn: false
-              links:
-                parent:
-                - api_path: /api/content/browse/tax
-                  base_path: /browse/tax
-                  content_id: 71255733-af6c-4887-9991-9b288d8d431f
-                  description: Includes VAT, debt and inheritance tax
-                  document_type: mainstream_browse_page
-                  locale: en
-                  public_updated_at: '2015-04-08T10:48:40Z'
-                  schema_name: mainstream_browse_page
-                  title: Money and tax
-                  withdrawn: false
-                  links: {}
-                  api_url: https://www.gov.uk/api/content/browse/tax
-                  web_url: https://www.gov.uk/browse/tax
-              api_url: https://www.gov.uk/api/content/browse/tax/vat
-              web_url: https://www.gov.uk/browse/tax/vat
-          api_url: https://www.gov.uk/api/content/tax-on-shopping
-          web_url: https://www.gov.uk/tax-on-shopping
-        - api_path: /api/content/vat-businesses
-          base_path: /vat-businesses
-          content_id: 727e4b52-b760-4bd6-844d-48d8df888e32
-          description: VAT for business - VAT rates, exempt and zero-rated items, when to
-            charge VAT, credit and debit notes, discounts and VAT on offers
-          document_type: guide
-          locale: en
-          public_updated_at: '2014-12-19T15:27:25Z'
-          schema_name: guide
-          title: Businesses and charging VAT
-          withdrawn: false
-          links:
-            mainstream_browse_pages:
-            - api_path: /api/content/browse/business/business-tax
-              base_path: /browse/business/business-tax
-              content_id: b7d6588c-a056-47fc-9528-0b9ff42c3866
-              description: Includes Corporation Tax, Capital Gains Tax, Construction Industry
-                Scheme (CIS) and VAT
-              document_type: mainstream_browse_page
-              locale: en
-              public_updated_at: '2016-11-18T16:02:29Z'
-              schema_name: mainstream_browse_page
-              title: Business tax
-              withdrawn: false
-              links:
-                parent:
-                - api_path: /api/content/browse/business
-                  base_path: /browse/business
-                  content_id: 2e47e500-8d91-4747-b6d8-cf6524d570f1
-                  description: Information about starting up and running a business in the
-                    UK, including help if you're self employed or a sole trader.
-                  document_type: mainstream_browse_page
-                  locale: en
-                  public_updated_at: '2016-11-18T16:02:29Z'
-                  schema_name: mainstream_browse_page
-                  title: Business and self-employed
-                  withdrawn: false
-                  links: {}
-                  api_url: https://www.gov.uk/api/content/browse/business
-                  web_url: https://www.gov.uk/browse/business
-              api_url: https://www.gov.uk/api/content/browse/business/business-tax
-              web_url: https://www.gov.uk/browse/business/business-tax
-            - api_path: /api/content/browse/tax/vat
-              base_path: /browse/tax/vat
-              content_id: 895d337a-fa68-4c83-ab79-1c08016afe87
-              description: Includes online returns, rates, charging and record keeping
-              document_type: mainstream_browse_page
-              locale: en
-              public_updated_at: '2015-06-24T13:56:39Z'
-              schema_name: mainstream_browse_page
-              title: VAT
-              withdrawn: false
-              links:
-                parent:
-                - api_path: /api/content/browse/tax
-                  base_path: /browse/tax
-                  content_id: 71255733-af6c-4887-9991-9b288d8d431f
-                  description: Includes VAT, debt and inheritance tax
-                  document_type: mainstream_browse_page
-                  locale: en
-                  public_updated_at: '2015-04-08T10:48:40Z'
-                  schema_name: mainstream_browse_page
-                  title: Money and tax
-                  withdrawn: false
-                  links: {}
-                  api_url: https://www.gov.uk/api/content/browse/tax
-                  web_url: https://www.gov.uk/browse/tax
-              api_url: https://www.gov.uk/api/content/browse/tax/vat
-              web_url: https://www.gov.uk/browse/tax/vat
-          api_url: https://www.gov.uk/api/content/vat-businesses
-          web_url: https://www.gov.uk/vat-businesses
-        organisations:
-        - analytics_identifier: D25
-          api_path: /api/content/government/organisations/hm-revenue-customs
-          base_path: /government/organisations/hm-revenue-customs
-          content_id: 6667cce2-e809-4e21-ae09-cb0bdc1ddda3
-          document_type: organisation
-          locale: en
-          public_updated_at: '2015-05-13T10:09:06Z'
-          schema_name: organisation
-          title: HM Revenue & Customs
-          withdrawn: false
-          details:
-            brand: hm-revenue-customs
-            logo:
-              formatted_title: HM Revenue<br/>&amp; Customs
-              crest: hmrc
-          links: {}
-          api_url: https://www.gov.uk/api/content/government/organisations/hm-revenue-customs
-          web_url: https://www.gov.uk/government/organisations/hm-revenue-customs
-        parent:
-        - api_path: /api/content/browse/tax/vat
-          base_path: /browse/tax/vat
-          content_id: 895d337a-fa68-4c83-ab79-1c08016afe87
-          description: Includes online returns, rates, charging and record keeping
-          document_type: mainstream_browse_page
-          locale: en
-          public_updated_at: '2015-06-24T13:56:39Z'
-          schema_name: mainstream_browse_page
-          title: VAT
-          withdrawn: false
-          links:
-            parent:
-            - api_path: /api/content/browse/tax
-              base_path: /browse/tax
-              content_id: 71255733-af6c-4887-9991-9b288d8d431f
-              description: Includes VAT, debt and inheritance tax
-              document_type: mainstream_browse_page
-              locale: en
-              public_updated_at: '2015-04-08T10:48:40Z'
-              schema_name: mainstream_browse_page
-              title: Money and tax
-              withdrawn: false
-              links: {}
-              api_url: https://www.gov.uk/api/content/browse/tax
-              web_url: https://www.gov.uk/browse/tax
-          api_url: https://www.gov.uk/api/content/browse/tax/vat
-          web_url: https://www.gov.uk/browse/tax/vat
-        topics:
-        - api_path: /api/content/topic/business-tax/vat
-          base_path: /topic/business-tax/vat
-          content_id: 1ddaaacb-0981-4abc-a532-a5111f2bea6b
-          description: List of information about VAT.
-          document_type: topic
-          locale: en
-          public_updated_at: '2016-11-30T14:17:03Z'
-          schema_name: topic
-          title: VAT
-          withdrawn: false
-          links: {}
-          api_url: https://www.gov.uk/api/content/topic/business-tax/vat
-          web_url: https://www.gov.uk/topic/business-tax/vat
-        available_translations:
-        - title: VAT rates
-          public_updated_at: '2014-12-12T14:55:23Z'
-          document_type: answer
-          schema_name: answer
-          base_path: /vat-rates
-          description: Current VAT rates - standard 20% and rates for reduced rate and zero-rated
-            items
-          api_path: /api/content/vat-rates
-          withdrawn: false
-          content_id: f838c22a-b2aa-49be-bd95-153f593293a3
-          locale: en
-          api_url: https://www.gov.uk/api/content/vat-rates
-          web_url: https://www.gov.uk/vat-rates
-          links: {}
-      description: Current VAT rates - standard 20% and rates for reduced rate and zero-rated
-        items
-      details:
-        body: ! "\n<div class=\"highlight-answer\">\n<p>The standard <abbr title=\"Value
-          Added Tax\">VAT</abbr> rate is <em>20%</em></p>\n</div>\n\n<h2 id=\"vat-rates-for-goods-and-services\">\n<abbr
-          title=\"Value Added Tax\">VAT</abbr> rates for goods and services</h2>\n\n<table>\n
-          \ <thead>\n    <tr>\n      <th>Rate</th>\n      <th>% of <abbr title=\"Value Added
-          Tax\">VAT</abbr>\n</th>\n      <th>What the rate applies to</th>\n    </tr>\n
-          \ </thead>\n  <tbody>\n    <tr>\n      <td>Standard</td>\n      <td>20%</td>\n
-          \     <td>Most goods and services</td>\n    </tr>\n    <tr>\n      <td>Reduced
-          rate</td>\n      <td>5%</td>\n      <td>Some goods and services, eg children’s
-          car seats and home energy</td>\n    </tr>\n    <tr>\n      <td>Zero rate</td>\n
-          \     <td>0%</td>\n      <td>Zero-rated goods and services, eg most food and children’s
-          clothes</td>\n    </tr>\n  </tbody>\n</table>\n\n<p>The standard rate of <abbr
-          title=\"Value Added Tax\">VAT</abbr> increased to 20% on 4 January 2011 (from
-          17.5%).</p>\n\n<p>Some things are exempt from <abbr title=\"Value Added Tax\">VAT</abbr>,
-          eg postage stamps, financial and property transactions.</p>\n\n<p>The <a href=\"/vat-businesses/vat-rates\"><abbr
-          title=\"Value Added Tax\">VAT</abbr> rate businesses charge</a> depends on their
-          goods and services.</p>\n\n<p>Check the <a href=\"https://www.gov.uk/rates-of-vat-on-different-goods-and-services\">rates
-          of <abbr title=\"Value Added Tax\">VAT</abbr></a> on different goods and services.</p>\n\n"
+      value:
+        analytics_identifier:
+        base_path: /vat-rates
+        content_id: f838c22a-b2aa-49be-bd95-153f593293a3
+        document_type: answer
+        email_document_supertype: other
+        first_published_at: '2016-02-29T09:24:10.000+00:00'
+        government_document_supertype: other
+        locale: en
+        navigation_document_supertype: guidance
+        phase: live
+        public_updated_at: '2014-12-12T14:55:23.000+00:00'
+        publishing_app: publisher
+        rendering_app: government-frontend
+        schema_name: answer
+        title: VAT rates
+        updated_at: '2017-08-31T11:35:14.024Z'
+        user_journey_document_supertype: thing
+        withdrawn_notice: {}
+        publishing_request_id: 3592-1504179295.816-10.3.3.1-410
+        links:
+          mainstream_browse_pages:
+          - api_path: /api/content/browse/tax/vat
+            base_path: /browse/tax/vat
+            content_id: 895d337a-fa68-4c83-ab79-1c08016afe87
+            description: Includes online returns, rates, charging and record keeping
+            document_type: mainstream_browse_page
+            locale: en
+            public_updated_at: '2015-06-24T13:56:39Z'
+            schema_name: mainstream_browse_page
+            title: VAT
+            withdrawn: false
+            links: {}
+            api_url: https://www.gov.uk/api/content/browse/tax/vat
+            web_url: https://www.gov.uk/browse/tax/vat
+          ordered_related_items:
+          - api_path: /api/content/tax-on-shopping
+            base_path: /tax-on-shopping
+            content_id: ca839010-1a5e-4049-93b5-577a40286701
+            description: VAT and other taxes on shopping and services, including tax-free
+              shopping, energy-saving equipment and mobility aids
+            document_type: guide
+            locale: en
+            public_updated_at: '2014-12-18T14:31:58Z'
+            schema_name: guide
+            title: Tax on shopping and services
+            withdrawn: false
+            links:
+              mainstream_browse_pages:
+              - api_path: /api/content/browse/tax/vat
+                base_path: /browse/tax/vat
+                content_id: 895d337a-fa68-4c83-ab79-1c08016afe87
+                description: Includes online returns, rates, charging and record keeping
+                document_type: mainstream_browse_page
+                locale: en
+                public_updated_at: '2015-06-24T13:56:39Z'
+                schema_name: mainstream_browse_page
+                title: VAT
+                withdrawn: false
+                links:
+                  parent:
+                  - api_path: /api/content/browse/tax
+                    base_path: /browse/tax
+                    content_id: 71255733-af6c-4887-9991-9b288d8d431f
+                    description: Includes VAT, debt and inheritance tax
+                    document_type: mainstream_browse_page
+                    locale: en
+                    public_updated_at: '2015-04-08T10:48:40Z'
+                    schema_name: mainstream_browse_page
+                    title: Money and tax
+                    withdrawn: false
+                    links: {}
+                    api_url: https://www.gov.uk/api/content/browse/tax
+                    web_url: https://www.gov.uk/browse/tax
+                api_url: https://www.gov.uk/api/content/browse/tax/vat
+                web_url: https://www.gov.uk/browse/tax/vat
+            api_url: https://www.gov.uk/api/content/tax-on-shopping
+            web_url: https://www.gov.uk/tax-on-shopping
+          - api_path: /api/content/vat-businesses
+            base_path: /vat-businesses
+            content_id: 727e4b52-b760-4bd6-844d-48d8df888e32
+            description: VAT for business - VAT rates, exempt and zero-rated items, when to
+              charge VAT, credit and debit notes, discounts and VAT on offers
+            document_type: guide
+            locale: en
+            public_updated_at: '2014-12-19T15:27:25Z'
+            schema_name: guide
+            title: Businesses and charging VAT
+            withdrawn: false
+            links:
+              mainstream_browse_pages:
+              - api_path: /api/content/browse/business/business-tax
+                base_path: /browse/business/business-tax
+                content_id: b7d6588c-a056-47fc-9528-0b9ff42c3866
+                description: Includes Corporation Tax, Capital Gains Tax, Construction Industry
+                  Scheme (CIS) and VAT
+                document_type: mainstream_browse_page
+                locale: en
+                public_updated_at: '2016-11-18T16:02:29Z'
+                schema_name: mainstream_browse_page
+                title: Business tax
+                withdrawn: false
+                links:
+                  parent:
+                  - api_path: /api/content/browse/business
+                    base_path: /browse/business
+                    content_id: 2e47e500-8d91-4747-b6d8-cf6524d570f1
+                    description: Information about starting up and running a business in the
+                      UK, including help if you're self employed or a sole trader.
+                    document_type: mainstream_browse_page
+                    locale: en
+                    public_updated_at: '2016-11-18T16:02:29Z'
+                    schema_name: mainstream_browse_page
+                    title: Business and self-employed
+                    withdrawn: false
+                    links: {}
+                    api_url: https://www.gov.uk/api/content/browse/business
+                    web_url: https://www.gov.uk/browse/business
+                api_url: https://www.gov.uk/api/content/browse/business/business-tax
+                web_url: https://www.gov.uk/browse/business/business-tax
+              - api_path: /api/content/browse/tax/vat
+                base_path: /browse/tax/vat
+                content_id: 895d337a-fa68-4c83-ab79-1c08016afe87
+                description: Includes online returns, rates, charging and record keeping
+                document_type: mainstream_browse_page
+                locale: en
+                public_updated_at: '2015-06-24T13:56:39Z'
+                schema_name: mainstream_browse_page
+                title: VAT
+                withdrawn: false
+                links:
+                  parent:
+                  - api_path: /api/content/browse/tax
+                    base_path: /browse/tax
+                    content_id: 71255733-af6c-4887-9991-9b288d8d431f
+                    description: Includes VAT, debt and inheritance tax
+                    document_type: mainstream_browse_page
+                    locale: en
+                    public_updated_at: '2015-04-08T10:48:40Z'
+                    schema_name: mainstream_browse_page
+                    title: Money and tax
+                    withdrawn: false
+                    links: {}
+                    api_url: https://www.gov.uk/api/content/browse/tax
+                    web_url: https://www.gov.uk/browse/tax
+                api_url: https://www.gov.uk/api/content/browse/tax/vat
+                web_url: https://www.gov.uk/browse/tax/vat
+            api_url: https://www.gov.uk/api/content/vat-businesses
+            web_url: https://www.gov.uk/vat-businesses
+          organisations:
+          - analytics_identifier: D25
+            api_path: /api/content/government/organisations/hm-revenue-customs
+            base_path: /government/organisations/hm-revenue-customs
+            content_id: 6667cce2-e809-4e21-ae09-cb0bdc1ddda3
+            document_type: organisation
+            locale: en
+            public_updated_at: '2015-05-13T10:09:06Z'
+            schema_name: placeholder
+            title: HM Revenue & Customs
+            withdrawn: false
+            details:
+              brand: hm-revenue-customs
+              logo:
+                formatted_title: HM Revenue<br/>&amp; Customs
+                crest: hmrc
+            links: {}
+            api_url: https://www.gov.uk/api/content/government/organisations/hm-revenue-customs
+            web_url: https://www.gov.uk/government/organisations/hm-revenue-customs
+          parent:
+          - api_path: /api/content/browse/tax/vat
+            base_path: /browse/tax/vat
+            content_id: 895d337a-fa68-4c83-ab79-1c08016afe87
+            description: Includes online returns, rates, charging and record keeping
+            document_type: mainstream_browse_page
+            locale: en
+            public_updated_at: '2015-06-24T13:56:39Z'
+            schema_name: mainstream_browse_page
+            title: VAT
+            withdrawn: false
+            links:
+              parent:
+              - api_path: /api/content/browse/tax
+                base_path: /browse/tax
+                content_id: 71255733-af6c-4887-9991-9b288d8d431f
+                description: Includes VAT, debt and inheritance tax
+                document_type: mainstream_browse_page
+                locale: en
+                public_updated_at: '2015-04-08T10:48:40Z'
+                schema_name: mainstream_browse_page
+                title: Money and tax
+                withdrawn: false
+                links: {}
+                api_url: https://www.gov.uk/api/content/browse/tax
+                web_url: https://www.gov.uk/browse/tax
+            api_url: https://www.gov.uk/api/content/browse/tax/vat
+            web_url: https://www.gov.uk/browse/tax/vat
+          topics:
+          - api_path: /api/content/topic/business-tax/vat
+            base_path: /topic/business-tax/vat
+            content_id: 1ddaaacb-0981-4abc-a532-a5111f2bea6b
+            description: List of information about VAT.
+            document_type: topic
+            locale: en
+            public_updated_at: '2016-11-30T14:17:03Z'
+            schema_name: topic
+            title: VAT
+            withdrawn: false
+            links: {}
+            api_url: https://www.gov.uk/api/content/topic/business-tax/vat
+            web_url: https://www.gov.uk/topic/business-tax/vat
+          available_translations:
+          - title: VAT rates
+            public_updated_at: '2014-12-12T14:55:23Z'
+            document_type: answer
+            schema_name: answer
+            base_path: /vat-rates
+            description: Current VAT rates - standard 20% and rates for reduced rate and zero-rated
+              items
+            api_path: /api/content/vat-rates
+            withdrawn: false
+            content_id: f838c22a-b2aa-49be-bd95-153f593293a3
+            locale: en
+            api_url: https://www.gov.uk/api/content/vat-rates
+            web_url: https://www.gov.uk/vat-rates
+            links: {}
+        description: Current VAT rates - standard 20% and rates for reduced rate and zero-rated
+          items
+        details:
+          body: ! "\n<div class=\"highlight-answer\">\n<p>The standard <abbr title=\"Value
+            Added Tax\">VAT</abbr> rate is <em>20%</em></p>\n</div>\n\n<h2 id=\"vat-rates-for-goods-and-services\">\n<abbr
+            title=\"Value Added Tax\">VAT</abbr> rates for goods and services</h2>\n\n<table>\n
+            \ <thead>\n    <tr>\n      <th>Rate</th>\n      <th>% of <abbr title=\"Value Added
+            Tax\">VAT</abbr>\n</th>\n      <th>What the rate applies to</th>\n    </tr>\n
+            \ </thead>\n  <tbody>\n    <tr>\n      <td>Standard</td>\n      <td>20%</td>\n
+            \     <td>Most goods and services</td>\n    </tr>\n    <tr>\n      <td>Reduced
+            rate</td>\n      <td>5%</td>\n      <td>Some goods and services, eg children’s
+            car seats and home energy</td>\n    </tr>\n    <tr>\n      <td>Zero rate</td>\n
+            \     <td>0%</td>\n      <td>Zero-rated goods and services, eg most food and children’s
+            clothes</td>\n    </tr>\n  </tbody>\n</table>\n\n<p>The standard rate of <abbr
+            title=\"Value Added Tax\">VAT</abbr> increased to 20% on 4 January 2011 (from
+            17.5%).</p>\n\n<p>Some things are exempt from <abbr title=\"Value Added Tax\">VAT</abbr>,
+            eg postage stamps, financial and property transactions.</p>\n\n<p>The <a href=\"/vat-businesses/vat-rates\"><abbr
+            title=\"Value Added Tax\">VAT</abbr> rate businesses charge</a> depends on their
+            goods and services.</p>\n\n<p>Check the <a href=\"https://www.gov.uk/rates-of-vat-on-different-goods-and-services\">rates
+            of <abbr title=\"Value Added Tax\">VAT</abbr></a> on different goods and services.</p>\n\n"

--- a/spec/lib/validate_openapi3_definition_spec.rb
+++ b/spec/lib/validate_openapi3_definition_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+describe "Validate OpenAPI 3.0 definition" do
+  it "the definition contains no errors" do
+    parser = Openapi3Parser.load_file("openapi.yaml")
+
+    expect(parser).to be_valid
+  end
+end


### PR DESCRIPTION
The OpenAPI 3.0 definition was invalid. This can be confirmed by using tools such as the [Swagger Editor](https://editor.swagger.io/) or by looking at an example of where this data was consumed (e.g. [GOV.UK Content API docs](https://content-api.publishing.service.gov.uk/reference.html#contentitem)).

![Screenshot of the definition being consumed by the GOV.UK Content API docs.  The example contains the code that refers to the example block, rather than the example itself.](https://github.com/user-attachments/assets/1d730c5f-9a9d-429a-9c23-4ad782c629f4)

Updating to make this definition valid and adding a test so we don't accidentally make the definition invalid in the future.

[Trello card](https://trello.com/c/7LqhcraV)