### PR TITLE
Add document_type and Schema_name to prometheus labels

### DIFF
--- a/spec/integration/fetching_content_item_spec.rb
+++ b/spec/integration/fetching_content_item_spec.rb
@@ -73,6 +73,11 @@ describe "Fetching content items", type: :request do
       )
     end
 
+    it "sets document_type and schema_type as prometheus labels" do
+      expect(request.env["govuk.prometheus_labels"][:document_type]).to eq(content_item.document_type)
+      expect(request.env["govuk.prometheus_labels"][:schema_name]).to eq(content_item.schema_name)
+    end
+
     it "outputs the timestamp fields correctly" do
       data = JSON.parse(response.body)
       expect(data["public_updated_at"]).to eq(content_item.public_updated_at.iso8601.as_json)


### PR DESCRIPTION
This allows us to look at the performance of retrieving individual document types from content_store. Currently the monitoring does not distinquish between types.

Done as part of the graphql work so we can compare performance of document types between graphl and regular content-store.

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
