### PR TITLE
Add introduction to 'Content API' in the API documentation

### DIFF
--- a/docs/content-store-api.md
+++ b/docs/content-store-api.md
@@ -8,10 +8,10 @@
 
 Content is written by the [Publishing API](https://docs.publishing.service.gov.uk/apps/publishing-api.html), which is used by back-end publishing apps such as Travel Advice Publisher.
 
-To add or update a piece of content in the content store, make a PUT request:
+Within our infrastructure, to add or update a piece of content in the content store, make a PUT request:
 
 ``` sh
-curl https://content-store.publishing.service.gov.uk/content<base_path> -X PUT \
+curl http://content-store/content<base_path> -X PUT \
     -H 'Content-type: application/json' \
     -d '<content_item_json>'
 ```
@@ -20,14 +20,14 @@ where `<base_path>` is the path on GOV.UK where the content lives (for example `
 
 ## Reading content from the content store
 
-Content is retrieved from the Content Store via the [Content Store](https://content-store.publishing.service.gov.uk/), which takes a path and responds with a JSON representation of the content that should be displayed on that path.
+Content is retrieved using the `content` endpoint, which takes a path and responds with a JSON representation of the content that should be displayed on that path.
 
-This API is used by front-end apps but is also exposed externally at `/api/content/<path>`, such as [https://www.gov.uk/api/content/take-pet-abroad](https://www.gov.uk/api/content/take-pet-abroad). When used by the public, this is known as 'Content API' and has [its own documentation](https://content-api.publishing.service.gov.uk/).
+This API is used by front-end apps but is also exposed externally at `https://www.gov.uk/api/content/<path>`, such as [https://www.gov.uk/api/content/take-pet-abroad](https://www.gov.uk/api/content/take-pet-abroad). When used by the public, this is known as 'Content API' and has [its own documentation](https://content-api.publishing.service.gov.uk/).
 
-To retrieve content from the Content Store, make a GET request:
+Within our infrastructure, to retrieve content from the Content Store, make a GET request:
 
 ``` sh
-  curl https://content-store.publishing.service.gov.uk/content<path>
+  curl http://content-store/content<path>
 ```
 
 If the `path` matches a `base_path` content will be returned, whereas if the `path` matches a route a 303 redirect will be returned to the content at the `base_path`.

--- a/docs/content-store-api.md
+++ b/docs/content-store-api.md
@@ -2,8 +2,7 @@
 
 ## Content items
 
-`ContentItem` is the base unit of content in the content store. They have both a
-private and public-facing JSON representation.
+`ContentItem` is the base unit of content in the content store. They have both a private and public-facing JSON representation.
 
 ## Writing content items to the content store
 
@@ -17,8 +16,7 @@ curl https://content-store.publishing.service.gov.uk/content<base_path> -X PUT \
     -d '<content_item_json>'
 ```
 
-where `<base_path>` is the path on GOV.UK where the content lives (for example
-`/vat-rates`) and `<content_item_json>` is the JSON for the content item.
+where `<base_path>` is the path on GOV.UK where the content lives (for example `/vat-rates`) and `<content_item_json>` is the JSON for the content item.
 
 ## Reading content from the content store
 
@@ -32,8 +30,6 @@ To retrieve content from the Content Store, make a GET request:
   curl https://content-store.publishing.service.gov.uk/content<path>
 ```
 
-If the `path` matches a `base_path` content will be returned, whereas if the
-`path` matches a route a 303 redirect will be returned to the content at the
-`base_path`.
+If the `path` matches a `base_path` content will be returned, whereas if the `path` matches a route a 303 redirect will be returned to the content at the `base_path`.
 
 Not all content exists as a standalone page like the `/take-pet-abroad` example. Some content exists as a collection that references other pieces of content, and some content exists as meta content designed to describe a wider whole. We use [content-schemas defined in Publishing API](https://github.com/alphagov/publishing-api/tree/main/content_schemas) to describe all these different content types. The Content API itself is not prescriptive about this; it takes any JSON structure.

--- a/docs/content-store-api.md
+++ b/docs/content-store-api.md
@@ -22,7 +22,9 @@ where `<base_path>` is the path on GOV.UK where the content lives (for example
 
 ## Reading content from the content store
 
-Content is retrieved from the content store via the [content store](https://content-store.publishing.service.gov.uk/), which takes a path and responds with a JSON representation of the content that should be displayed on that path. This API is used by front-end apps but is also exposed externally at `/api/content/<path>`, such as https://www.gov.uk/api/content/take-pet-abroad
+Content is retrieved from the content store via the [content store](https://content-store.publishing.service.gov.uk/), which takes a path and responds with a JSON representation of the content that should be displayed on that path.
+
+This API is used by front-end apps but is also exposed externally at `/api/content/<path>`, such as [https://www.gov.uk/api/content/take-pet-abroad](https://www.gov.uk/api/content/take-pet-abroad). When used by the public, this is known as 'Content API' and has [its own documentation](https://content-api.publishing.service.gov.uk/).
 
 To retrieve content from the content store, make a GET request:
 

--- a/docs/content-store-api.md
+++ b/docs/content-store-api.md
@@ -7,7 +7,7 @@ private and public-facing JSON representation.
 
 ## Writing content items to the content store
 
-Content is written by the [publishing API](https://docs.publishing.service.gov.uk/apps/publishing-api.html), which is used by back-end publishing apps such as Travel Advice Publisher.
+Content is written by the [Publishing API](https://docs.publishing.service.gov.uk/apps/publishing-api.html), which is used by back-end publishing apps such as Travel Advice Publisher.
 
 To add or update a piece of content in the content store, make a PUT request:
 
@@ -22,11 +22,11 @@ where `<base_path>` is the path on GOV.UK where the content lives (for example
 
 ## Reading content from the content store
 
-Content is retrieved from the content store via the [content store](https://content-store.publishing.service.gov.uk/), which takes a path and responds with a JSON representation of the content that should be displayed on that path.
+Content is retrieved from the Content Store via the [Content Store](https://content-store.publishing.service.gov.uk/), which takes a path and responds with a JSON representation of the content that should be displayed on that path.
 
 This API is used by front-end apps but is also exposed externally at `/api/content/<path>`, such as [https://www.gov.uk/api/content/take-pet-abroad](https://www.gov.uk/api/content/take-pet-abroad). When used by the public, this is known as 'Content API' and has [its own documentation](https://content-api.publishing.service.gov.uk/).
 
-To retrieve content from the content store, make a GET request:
+To retrieve content from the Content Store, make a GET request:
 
 ``` sh
   curl https://content-store.publishing.service.gov.uk/content<path>
@@ -36,4 +36,4 @@ If the `path` matches a `base_path` content will be returned, whereas if the
 `path` matches a route a 303 redirect will be returned to the content at the
 `base_path`.
 
-Not all content exists as a standalone page like the `/take-pet-abroad` example. Some content exists as a collection that references other pieces of content, and some content exists as meta content designed to describe a wider whole. We use [content-schemas defined in publishing api](https://github.com/alphagov/publishing-api/tree/main/content_schemas) to describe all these different content types. The content API itself is not prescriptive about this; it takes any JSON structure.
+Not all content exists as a standalone page like the `/take-pet-abroad` example. Some content exists as a collection that references other pieces of content, and some content exists as meta content designed to describe a wider whole. We use [content-schemas defined in Publishing API](https://github.com/alphagov/publishing-api/tree/main/content_schemas) to describe all these different content types. The Content API itself is not prescriptive about this; it takes any JSON structure.


### PR DESCRIPTION
This is referenced in the final paragraph, but is never introduced and relies on the reader knowing what 'Content API' actually is.

Also makes a few other changes to the internal API documentation, to tidy the document and fix some incorrect information.