### PR TITLE
[PP-7422] Update structure.sql for Rails 8.1

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -21,6 +21,8 @@ jobs:
       - name: Setup Postgres
         id: setup-postgres
         uses: alphagov/govuk-infrastructure/.github/actions/setup-postgres@main
+        with:
+          POSTGRES_IMAGE_TAG: 17-alpine
 
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/verify-pact.yml
+++ b/.github/workflows/verify-pact.yml
@@ -29,6 +29,8 @@ jobs:
       - name: Setup Postgres
         id: setup-postgres
         uses: alphagov/govuk-infrastructure/.github/actions/setup-postgres@main
+        with:
+          POSTGRES_IMAGE_TAG: 17-alpine
 
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,6 +1,7 @@
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
+SET transaction_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
@@ -8,13 +9,6 @@ SET check_function_bodies = false;
 SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
-
---
--- Name: public; Type: SCHEMA; Schema: -; Owner: -
---
-
--- *not* creating schema, since initdb creates it
-
 
 --
 -- Name: pgcrypto; Type: EXTENSION; Schema: -; Owner: -
@@ -139,6 +133,15 @@ CREATE TABLE public.content_items (
     updated_at timestamp(6) without time zone,
     _id character varying,
     scheduled_publishing_delay_seconds bigint
+);
+
+
+--
+-- Name: content_items_import; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.content_items_import (
+    data jsonb
 );
 
 


### PR DESCRIPTION
When upgrading to Rails 8.1 I misread the output of `bundle exec rake db:schema:dump` and assumed it had no effect since we're not using a schema.rb file

It actually failed because of mismatch between pg_dump and/or Debian versions. govuk-docker has since been updated to use a newer version of Debian which fixes this issue - the dump now runs successfully

```
pg_dump: error: aborting because of server version mismatch
pg_dump: detail: server version: 17.7 (Debian 17.7-3.pgdg13+1); pg_dump version: 15.16 (Debian 15.16-0+deb12u1)
rake aborted!
failed to execute:
pg_dump --schema-only --no-privileges --no-owner --file /govuk/content-store/db/structure.sql content-store

Please check the output above for any errors and make sure that `pg_dump` is installed in your PATH and has proper permissions.
```

CI passed without the updated structure.sql, but the dbmigrate job in Argo failed. The error message there wasn't useful and didn't hint at much more than "things aren't working properly"

```
NoMethodError: undefined method 'controller_monkey_patch' for #<ContentStore::Application:0x0000ffff67287460> (NoMethodError)
    if (!config.controller_monkey_patch && config.controller_monkey_patch != false) || config.controller_monkey_patch == true
               ^^^^^^^^^^^^^^^^^^^^^^^^
/app/config/environment.rb:5:in '<main>'
```