### PR TITLE
[PP-7685] Update Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@ updates:
   - package-ecosystem: bundler
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      day: tuesday
+      time: "07:00"
     ignore:
       - dependency-name: pact
         versions: [ ">=2.0.0" ]
@@ -27,6 +29,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+      day: tuesday
+      time: "07:00"
     ignore:
       - dependency-name: ruby
     cooldown:
@@ -34,6 +38,8 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      day: tuesday
+      time: "07:00"
     cooldown:
       default-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
         versions: [ ">=2.0.0" ]
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25
     groups:
       test:
         patterns:
@@ -35,6 +36,8 @@ updates:
       - dependency-name: ruby
     cooldown:
       default-days: 7
+    open-pull-requests-limit: 25
+
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -43,3 +46,4 @@ updates:
       time: "07:00"
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: weekly
       day: tuesday
       time: "07:00"
+    allow:
+      - dependency-type: direct
     ignore:
       - dependency-name: pact
         versions: [ ">=2.0.0" ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,19 @@ updates:
     ignore:
       - dependency-name: pact
         versions: [ ">=2.0.0" ]
+    cooldown:
+      default-days: 3
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
     ignore:
       - dependency-name: ruby
+    cooldown:
+      default-days: 7
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,21 @@ updates:
           - "timecop"
           - "webmock"
 
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "07:00"
+    cooldown:
+      default-days: 3
+    open-pull-requests-limit: 25
+
+  # Ruby needs to be upgraded manually in multiple places, so cannot
+  # be upgraded by Dependabot. That effectively makes the below
+  # config redundant, as ruby is the only updatable thing in the
+  # Dockerfile, although this may change in the future. We hope this
+  # config will save a dev from trying to upgrade ruby via Dependabot.
   - package-ecosystem: docker
     directory: /
     schedule:
@@ -38,14 +53,4 @@ updates:
       - dependency-name: ruby
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 25
-
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly
-      day: tuesday
-      time: "07:00"
-    cooldown:
-      default-days: 3
     open-pull-requests-limit: 25

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,20 @@ updates:
         versions: [ ">=2.0.0" ]
     cooldown:
       default-days: 3
+    groups:
+      test:
+        patterns:
+          - "*rspec"
+          - "climate_control"
+          - "database_cleaner-*"
+          - "factory_bot*"
+          - "govuk_test"
+          - "pact"
+          - "rspec-*"
+          - "simplecov"
+          - "timecop"
+          - "webmock"
+
   - package-ecosystem: docker
     directory: /
     schedule:


### PR DESCRIPTION
This PR refines Dependabot configuration to reduce noise and improve update safety. It adds Docker support (while ignoring Ruby, which must be upgraded manually), introduces cooldown periods to avoid unstable releases, groups related Bundler updates and switches to a weekly Tuesday 7:00 UTC schedule.

It also increases the open PR limit to 25 to support batching, and restricts updates to direct dependencies only for more relevant, manageable changes. 

Security updates remain unaffected and continue to be raised immediately.