### PR TITLE
Bump govuk_app_config to 9.23.11

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,7 +170,7 @@ GEM
       rake (~> 13.3)
     googleapis-common-protos-types (1.22.0)
       google-protobuf (~> 4.26)
-    govuk_app_config (9.23.9)
+    govuk_app_config (9.23.11)
       connection_pool (< 3)
       logstasher (~> 2.1)
       opentelemetry-exporter-otlp (>= 0.25, < 0.34)


### PR DESCRIPTION
This fixes a double-logging issue affecting content store's rails request logs.

https://github.com/alphagov/govuk_app_config/pull/599

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
