### PR TITLE
[PNP-10124] Add data migration to remove content blocks

### DIFF
--- a/db/migrate/20260812104629_remove_content_blocks.rb
+++ b/db/migrate/20260812104629_remove_content_blocks.rb
@@ -1,0 +1,5 @@
+class RemoveContentBlocks < ActiveRecord::Migration[8.1]
+  def up
+    ContentItem.where(publishing_app: "content-block-manager").destroy_all
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -454,6 +454,7 @@ CREATE TRIGGER publish_intent_change_trigger AFTER INSERT OR DELETE OR UPDATE ON
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260812104629'),
 ('20251120155243'),
 ('20241209132444'),
 ('20241105135438'),


### PR DESCRIPTION
- Content Blocks are now [published without base_paths](https://gov-uk.atlassian.net/browse/CR-37), which means they exist in publishing-api but don't get pushed to content-store. This migration tidies up the old blocks that have already been pushed.

https://gov-uk.atlassian.net/browse/PNP-10124

This application is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
