### PR TITLE
[PP-7839] Add migration to remove orphaned content item

### DIFF
--- a/db/migrate/20260902094642_remove_old_policy_content_item.rb
+++ b/db/migrate/20260902094642_remove_old_policy_content_item.rb
@@ -1,0 +1,5 @@
+class RemoveOldPolicyContentItem < ActiveRecord::Migration[8.1]
+  def up
+    ContentItem.where(base_path: "/government/policies/schools-and-college-qualifications-and-curriculum").destroy_all
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -454,6 +454,7 @@ CREATE TRIGGER publish_intent_change_trigger AFTER INSERT OR DELETE OR UPDATE ON
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260902094642'),
 ('20260812104629'),
 ('20251120155243'),
 ('20241209132444'),


### PR DESCRIPTION
There is a content item present in Content Store that is orphaned:

- it has no editions in Publishing API
- it has a publishing application that no longer exists
- it is not renderable by the named rendering application

The presence of this document results in an error in Content Store when users attempt to visit it, as it lacks a key that is now required in all content items.

It was likely intended to be deleted at some point in the past, but that never happened.

I have confirmed there are no editions in Publishing API with this base path:

```rb
publishing-api(prod):001> Edition.where(base_path: "/government/policies/schools-and-college-qualifications-and-curriculum")
=> []
```

However it is present in Content Store:

```rb
content-store(prod):001> ContentItem.where(base_path: "/government/policies/schools-and-college-qualifications-and-curriculum")
=> 
[#<ContentItem:0x0000ffff6a847640
  id: "11146d81-7f3c-4f9e-bd76-3e3184e56fd5",
  base_path: "/government/policies/schools-and-college-qualifica...",
  content_id: "3c04de88-9e4a-4ebb-bdc9-ef5946db17b9",
  title: "Schools and college qualifications and curriculum",
  description: nil,
  document_type: "placeholder_policy",
  content_purpose_document_supertype: nil,
  content_purpose_subgroup: nil,
  content_purpose_supergroup: nil,
  email_document_supertype: nil,
  government_document_supertype: nil,
  navigation_document_supertype: nil,
  search_user_need_document_supertype: nil,
  user_journey_document_supertype: nil,
  schema_name: "placeholder_policy",
  locale: "en",
  first_published_at: nil,
  public_updated_at: "2015-04-21 11:26:49.154000000 +0100",
  publishing_scheduled_at: nil,
  details: {},
  publishing_app: "policy-publisher",
  rendering_app: "finder-frontend",
  routes: [{"path" => "/government/policies/schools-and-college-qualifications-and-curriculum", "type" => "exact"}],
  redirects: [],
  expanded_links: nil,
  access_limited: nil,
  auth_bypass_ids: nil,
  phase: "live",
  analytics_identifier: nil,
  payload_version: 0,
  withdrawn_notice: nil,
  publishing_request_id: nil,
  created_at: nil,
  updated_at: "2015-04-21 11:26:49.242000000 +0100",
  _id: nil,
  scheduled_publishing_delay_seconds: nil>]
```

I’ve also confirmed there are no other documents of the same document type (which should’ve been removed):

```rb
content-store(prod):002> ContentItem.where(document_type: "placeholder_policy")
=> 
[#<ContentItem:0x0000ffff71f64610
  id: "11146d81-7f3c-4f9e-bd76-3e3184e56fd5",
  base_path: "/government/policies/schools-and-college-qualifica...",
  content_id: "3c04de88-9e4a-4ebb-bdc9-ef5946db17b9",
  title: "Schools and college qualifications and curriculum",
  description: nil,
  document_type: "placeholder_policy",
  content_purpose_document_supertype: nil,
  content_purpose_subgroup: nil,
  content_purpose_supergroup: nil,
  email_document_supertype: nil,
  government_document_supertype: nil,
  navigation_document_supertype: nil,
  search_user_need_document_supertype: nil,
  user_journey_document_supertype: nil,
  schema_name: "placeholder_policy",
  locale: "en",
  first_published_at: nil,
  public_updated_at: "2015-04-21 11:26:49.154000000 +0100",
  publishing_scheduled_at: nil,
  details: {},
  publishing_app: "policy-publisher",
  rendering_app: "finder-frontend",
  routes: [{"path" => "/government/policies/schools-and-college-qualifications-and-curriculum", "type" => "exact"}],
  redirects: [],
  expanded_links: nil,
  access_limited: nil,
  auth_bypass_ids: nil,
  phase: "live",
  analytics_identifier: nil,
  payload_version: 0,
  withdrawn_notice: nil,
  publishing_request_id: nil,
  created_at: nil,
  updated_at: "2015-04-21 11:26:49.242000000 +0100",
  _id: nil,
  scheduled_publishing_delay_seconds: nil>]
```